### PR TITLE
Sorting and display property selection in Relationship Matrix is now done separately - #180

### DIFF
--- a/RelationshipMatrix/Settings/SourceConfiguration.cs
+++ b/RelationshipMatrix/Settings/SourceConfiguration.cs
@@ -36,6 +36,7 @@ namespace CDP4RelationshipMatrix.Settings
             this.SelectedBooleanOperatorKind = source.SelectedBooleanOperatorKind;
             this.SelectedClassKind = source.SelectedClassKind;
             this.SelectedDisplayKind = source.SelectedDisplayKind;
+            this.SelectedSortKind = source.SelectedSortKind;
             this.SortOrder = SortOrder.Ascending;
 
             this.SelectedCategories.AddRange(source.SelectedCategories.Select(x => x.Iid));
@@ -52,6 +53,12 @@ namespace CDP4RelationshipMatrix.Settings
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
         public DisplayKind SelectedDisplayKind { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="DisplayKind"/> for order
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public DisplayKind SelectedSortKind { get; set; }
 
         /// <summary>
         /// Gets or sets the selected categories

--- a/RelationshipMatrix/ViewModels/MatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/MatrixViewModel.cs
@@ -680,7 +680,7 @@ namespace CDP4RelationshipMatrix.ViewModels
 
             if (sourceConfigurationViewModel.SelectedSortOrder == SortOrder.Ascending)
             {
-                if (sourceConfigurationViewModel.SelectedDisplayKind == DisplayKind.Name)
+                if (sourceConfigurationViewModel.SelectedSortKind == DisplayKind.Name)
                 {
                     sourceXCatThing = sourceXCatThing.OrderBy(x => x.Name).ToList();
                 }
@@ -691,7 +691,7 @@ namespace CDP4RelationshipMatrix.ViewModels
             }
             else
             {
-                if (sourceConfigurationViewModel.SelectedDisplayKind == DisplayKind.Name)
+                if (sourceConfigurationViewModel.SelectedSortKind == DisplayKind.Name)
                 {
                     sourceXCatThing = sourceXCatThing.OrderByDescending(x => x.Name).ToList();
                 }

--- a/RelationshipMatrix/ViewModels/SourceConfigurationViewModel.cs
+++ b/RelationshipMatrix/ViewModels/SourceConfigurationViewModel.cs
@@ -39,9 +39,14 @@ namespace CDP4RelationshipMatrix.ViewModels
         private ClassKind? selectedClassKind;
 
         /// <summary>
-        /// Backing field for <see cref="SelectedDisplay"/> property.
+        /// Backing field for <see cref="SelectedDisplayKind"/> property.
         /// </summary>
         private DisplayKind selectedDisplayKind;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedSortKind"/> property.
+        /// </summary>
+        private DisplayKind selectedSortKind;
 
         /// <summary>
         /// Backing field for <see cref="SelectedSortOrder"/> property.
@@ -103,6 +108,11 @@ namespace CDP4RelationshipMatrix.ViewModels
                 this.OnLightUpdateAction();
             });
 
+            this.WhenAnyValue(x => x.SelectedSortKind).Skip(1).Subscribe(_ =>
+            {
+                this.OnLightUpdateAction();
+            });
+
             this.WhenAnyValue(x => x.SelectedSortOrder).Skip(1).Subscribe(_ =>
             {
                 this.OnLightUpdateAction();
@@ -141,6 +151,7 @@ namespace CDP4RelationshipMatrix.ViewModels
             this.SelectedBooleanOperatorKind = source.SelectedBooleanOperatorKind;
             this.SelectedClassKind = source.SelectedClassKind;
             this.SelectedDisplayKind = source.SelectedDisplayKind;
+            this.SelectedSortKind = source.SelectedSortKind;
             this.selectedSortOrder = source.SortOrder;
 
             this.OnLightUpdateAction = onLightUpdateAction;
@@ -181,6 +192,15 @@ namespace CDP4RelationshipMatrix.ViewModels
         {
             get { return this.selectedDisplayKind; }
             set { this.RaiseAndSetIfChanged(ref this.selectedDisplayKind, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="DisplayKind"/> for sorting
+        /// </summary>
+        public DisplayKind SelectedSortKind
+        {
+            get { return this.selectedSortKind; }
+            set { this.RaiseAndSetIfChanged(ref this.selectedSortKind, value); }
         }
 
         /// <summary>

--- a/RelationshipMatrix/Views/RelationshipMatrix.xaml
+++ b/RelationshipMatrix/Views/RelationshipMatrix.xaml
@@ -363,6 +363,11 @@
                                                             EditValue="{Binding SourceXConfiguration.SelectedDisplayKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                             ItemsSource="{Binding SourceXConfiguration.PossibleDisplayKinds, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
                                                 </dxlc:LayoutItem>
+                                                <dxlc:LayoutItem Label="Sort On:">
+                                                    <dxe:ComboBoxEdit
+                                                        EditValue="{Binding SourceXConfiguration.SelectedSortKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                        ItemsSource="{Binding SourceXConfiguration.PossibleDisplayKinds, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                </dxlc:LayoutItem>
                                                 <dxlc:LayoutItem Label="Sort Order: ">
                                                     <dxe:ComboBoxEdit
                                                             IsTextEditable="False"
@@ -430,10 +435,12 @@
                                                 <dxlc:LayoutItem Label="Display: ">
                                                     <dxe:ComboBoxEdit
                                                             EditValue="{Binding SourceYConfiguration.SelectedDisplayKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                            ItemsSource="{Binding SourceYConfiguration.PossibleDisplayKinds, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                                            AutoComplete="False"
-                                                            AllowNullInput="False"
-                                                            AllowDefaultButton="True" />
+                                                            ItemsSource="{Binding SourceYConfiguration.PossibleDisplayKinds, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
+                                                </dxlc:LayoutItem>
+                                                <dxlc:LayoutItem Label="Sort On: ">
+                                                    <dxe:ComboBoxEdit
+                                                        EditValue="{Binding SourceYConfiguration.SelectedSortKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                        ItemsSource="{Binding SourceYConfiguration.PossibleDisplayKinds, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
                                                 </dxlc:LayoutItem>
                                                 <dxlc:LayoutItem Label="Sort Order: ">
                                                     <dxe:ComboBoxEdit


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description

Added option to axis definition to select sort property name, so now it is possible to order by one value and display another.
