### PR TITLE
Fixes #107 ShortName of SimpleParameterValue now shown in the grid in the first column. Fixed bug with creating a SimpleParameterValue in a new Requirement.

### DIFF
--- a/CDP4Composition/Services/TooltipService.cs
+++ b/CDP4Composition/Services/TooltipService.cs
@@ -32,6 +32,13 @@ namespace CDP4Composition.Services
         /// <returns></returns>
         public static string Tooltip(this Thing thing)
         {
+            if (thing.ChangeKind == ChangeKind.Create)
+            {
+                // when creating things, especially in nested creted dialogs there are multiple opportunities for various exceptions
+                // occuring. i.e. ContainmentException when calling .Owner when that property is derived. So skip the tooltips in this case.
+                return string.Empty;
+            }
+
             var sb = new StringBuilder();
 
             if (thing is IShortNamedThing shortNamedThing)

--- a/Requirements/Requirements.csproj
+++ b/Requirements/Requirements.csproj
@@ -468,7 +468,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Requirements/Views/Dialogs/RequirementDialog.xaml
+++ b/Requirements/Views/Dialogs/RequirementDialog.xaml
@@ -149,8 +149,9 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-                            <dxg:GridColumn Header="Type" FieldName="ParameterTypeName" AllowEditing="False" Width="80"/>
+                            <dxg:GridColumn Header="Type" FieldName="ParameterTypeShortName" AllowEditing="False" Width="40"/>
                             <dxg:GridColumn Header="Value" FieldName="Definition" AllowEditing="False"/>
+                            <dxg:GridColumn Header="Type Name" FieldName="ParameterTypeName" AllowEditing="False" Width="80"/>
                             <dxg:GridColumn Header="Scale" FieldName="ScaleShortName" Width="80" AllowEditing="False">
                             </dxg:GridColumn>
                         </dxg:GridControl.Columns>

--- a/Requirements/Views/Dialogs/RequirementDialog.xaml
+++ b/Requirements/Views/Dialogs/RequirementDialog.xaml
@@ -149,8 +149,8 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-                            <dxg:GridColumn Header="Value" FieldName="Definition" AllowEditing="False"/>
                             <dxg:GridColumn Header="Type" FieldName="ParameterTypeName" AllowEditing="False" Width="80"/>
+                            <dxg:GridColumn Header="Value" FieldName="Definition" AllowEditing="False"/>
                             <dxg:GridColumn Header="Scale" FieldName="ScaleShortName" Width="80" AllowEditing="False">
                             </dxg:GridColumn>
                         </dxg:GridControl.Columns>

--- a/Requirements/Views/Dialogs/SimpleParameterValueDialog.xaml
+++ b/Requirements/Views/Dialogs/SimpleParameterValueDialog.xaml
@@ -55,8 +55,9 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-                            <dxg:GridColumn Header="Type" FieldName="ParameterType.Name" Width="80" AllowEditing="False"/>
+                            <dxg:GridColumn Header="Type" FieldName="ParameterType.ShortName" Width="40" AllowEditing="False"/>
                             <dxg:GridColumn Header="Value" FieldName="Manual" AllowEditing="True" CellTemplateSelector="{StaticResource ManualValueCellTemplateSelector}"/>
+                            <dxg:GridColumn Header="Type Name" FieldName="ParameterType.Name" Width="80" AllowEditing="False"/>
                             <dxg:GridColumn Header="Scale" FieldName="Scale" Width="80" AllowEditing="True">
                                 <dxg:GridColumn.CellTemplate>
                                     <DataTemplate>

--- a/Requirements/Views/Dialogs/SimpleParameterValueDialog.xaml
+++ b/Requirements/Views/Dialogs/SimpleParameterValueDialog.xaml
@@ -55,8 +55,8 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-                            <dxg:GridColumn Header="Value" FieldName="Manual" AllowEditing="True" CellTemplateSelector="{StaticResource ManualValueCellTemplateSelector}"/>
                             <dxg:GridColumn Header="Type" FieldName="ParameterType.Name" Width="80" AllowEditing="False"/>
+                            <dxg:GridColumn Header="Value" FieldName="Manual" AllowEditing="True" CellTemplateSelector="{StaticResource ManualValueCellTemplateSelector}"/>
                             <dxg:GridColumn Header="Scale" FieldName="Scale" Width="80" AllowEditing="True">
                                 <dxg:GridColumn.CellTemplate>
                                     <DataTemplate>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Both the RequirementsDialog and the SimpleParameterValueDialog now have the ParameterType Shortname displayed in the lists.

Also fixes a bug in the tooltip services that would cause an exception and thus prevent creating SimpleParameterValues while creating the Requirement itself. The call to derived `.Owner` property in the service would throw a `ContainmentException` because, of course, the container chain has not been entirely set for the things. For now the fix is catch all as there are suspected possible other random cases where this can happen. @samatrhea please chime in if a more thorough case by case fix is wanted. 
