### PR TITLE
Refactoring the visualization of deprecated things

### DIFF
--- a/CDP4Composition/Mvvm/IRowViewModelBase.cs
+++ b/CDP4Composition/Mvvm/IRowViewModelBase.cs
@@ -95,6 +95,11 @@ namespace CDP4Composition.Mvvm
         bool IsExpanded { get; set; }
 
         /// <summary>
+        /// Sets a value indicating that the row is hidden
+        /// </summary>
+        bool IsHidden { get; }
+
+        /// <summary>
         /// Expands the current row and all contained rows along the containment hierarchy
         /// </summary>
         void ExpandAllRows();

--- a/CDP4Composition/Mvvm/RowViewModelBase.cs
+++ b/CDP4Composition/Mvvm/RowViewModelBase.cs
@@ -72,7 +72,7 @@ namespace CDP4Composition.Mvvm
         private bool shouldBeDisplayed = true;
 
         /// <summary>
-        /// Backing field for the <see cref="isExpanded"/> property
+        /// Backing field for <see cref="IsExpanded"/>
         /// </summary>
         private bool isExpanded;
 
@@ -86,6 +86,9 @@ namespace CDP4Composition.Mvvm
         /// </summary>
         private ThingStatus thingStatus;
 
+        /// <summary>
+        /// Backing field for <see cref="IsHidden"/>
+        /// </summary>
         private ObservableAsPropertyHelper<bool> isHidden;
 
         /// <summary>

--- a/CDP4Composition/Services/FilterStringService.cs
+++ b/CDP4Composition/Services/FilterStringService.cs
@@ -20,7 +20,7 @@ namespace CDP4Composition.Services
         /// <summary>
         /// The string to filter rows of things that are deprecated.
         /// </summary>
-        private const string DeprecatedFilterString = "[IsDeprecated]=False";
+        private const string DeprecatedFilterString = "[IsHidden]=False";
 
         /// <summary>
         /// Object used to make this singleton threadsafe

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RequirementContainerRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RequirementContainerRowViewModel.cs
@@ -32,7 +32,7 @@ namespace CDP4Requirements.ViewModels
     /// <typeparam name="T">
     /// A type of <see cref="RequirementsContainer"/>
     /// </typeparam>
-    public abstract class RequirementContainerRowViewModel<T> : RequirementsContainerRowViewModel<T> where T : RequirementsContainer
+    public abstract class RequirementContainerRowViewModel<T> : RequirementsContainerRowViewModel<T>, IDeprecatableThing where T : RequirementsContainer
     {
         /// <summary>
         /// The <see cref="IComparer{T}"/>
@@ -77,6 +77,7 @@ namespace CDP4Requirements.ViewModels
             this.simpleParameters = new CDP4Composition.FolderRowViewModel("Simple Parameter Values", "Simple Parameter Values", this.Session, this);
             this.ContainedRows.Add(this.simpleParameters);
             this.TopParentRow = topNode ?? this as RequirementsSpecificationRowViewModel;
+            this.SetSubscriptions();
         }
 
         /// <summary>
@@ -243,6 +244,17 @@ namespace CDP4Requirements.ViewModels
         }
 
         /// <summary>
+        /// Add the necessary subscriptions 
+        /// </summary>
+        private void SetSubscriptions()
+        {
+            this.Disposables.Add(
+                this
+                    .WhenAnyValue(x => x.IsDeprecated)
+                    .Subscribe(x => this.UpdateIsDeprecated()));
+        }
+
+        /// <summary>
         /// Update the values of this row
         /// </summary>
         protected virtual void UpdateProperties()
@@ -254,7 +266,18 @@ namespace CDP4Requirements.ViewModels
             this.CategoryList = new List<Category>(this.Thing.Category);
             this.UpdateValues();
         }
-        
+
+        /// <summary>
+        /// Update deprecated for <see cref="simpleParameters"/>
+        /// </summary>
+        private void UpdateIsDeprecated()
+        {
+            if (this.simpleParameters != null)
+            {
+                this.simpleParameters.IsDeprecated = this.IsDeprecated;
+            }
+        }
+
         /// <summary>
         /// Handle the drag-over of a <see cref="Category"/>
         /// </summary>

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RequirementRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RequirementRowViewModel.cs
@@ -29,7 +29,7 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// the row-view-model representing a <see cref="Requirement"/>
     /// </summary>
-    public class RequirementRowViewModel : CDP4CommonView.RequirementRowViewModel, IDropTarget
+    public class RequirementRowViewModel : CDP4CommonView.RequirementRowViewModel, IDropTarget, IDeprecatableThing
     {
         /// <summary>
         /// The folder row containing the <see cref="SimpleParameterValue"/>

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsGroupRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsGroupRowViewModel.cs
@@ -25,7 +25,7 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// The row-view-model that represents a <see cref="RequirementsGroup"/>
     /// </summary>
-    public class RequirementsGroupRowViewModel : RequirementContainerRowViewModel<RequirementsGroup>, IDropTarget
+    public class RequirementsGroupRowViewModel : RequirementContainerRowViewModel<RequirementsGroup>, IDropTarget, IDeprecatableThing
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequirementsGroupRowViewModel"/> class


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The default way of hiding/filtering out deprecated things did not always work for treeview controls, like the requirements browser.
In the Requirements browser the list of items that is used to populate the treeview control is a (reactive)List of IRowViewModelBase<T>.
This interface doesn't define the IsDeprecated property, so based on that, the TreeView cannot create the necessary filter for this property, even if the class that implements the interface does implement an IsDeprecated property. In that case the IsDeprecated property surely is there, but it is not "connected" to the interface
For this reason the IsHidden property is added to IRowViewModelBase<T>, so the filter can use that property instead of an IsDeprecated property.
The default value of IsHidden is false, but when a RowViewModelBase<T>, or subclass is created, the RowViewModelBase checks if it implements the IDeprecatableThing interface, or if it's Thing class implements the IDeprecatableThing interface.
If it does, it sets up the lionk between IsDeprecated en IsHidden.

The treeview doesn't hide child nodes based on the fact that a parent node is Deprecated by default. 
Newer versions of DevExpress have more features for this, but, for now, some childnodes need to be hidden "manually" (RequirementsSpecificationRowViewModel).