### PR TITLE
Added two more textboxes for extra information in RelationshipMatrix

### DIFF
--- a/RelationshipMatrix/ViewModels/MatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/MatrixViewModel.cs
@@ -950,8 +950,6 @@ namespace CDP4RelationshipMatrix.ViewModels
             }
         }
 
-
-
         /// <summary>
         /// Sets the info detail properties
         /// </summary>

--- a/RelationshipMatrix/Views/RelationshipMatrix.xaml
+++ b/RelationshipMatrix/Views/RelationshipMatrix.xaml
@@ -214,7 +214,7 @@
                                                                    EventArgsConverter="{converters:PreviewMouseDownArgsConverter}"
                                                                    EventName="PreviewMouseDown" ModifierKeys=""
                                                                    PassEventArgsToCommand="True" />
-                                    
+
                                     <behaviour:TableViewMenuBehavior Command="{Binding Matrix.ToggleColumnHighlightCommand}"/>
                                 </dxmvvm:Interaction.Behaviors>
                                 <dxg:TableView.RowCellMenuCustomizations>
@@ -286,10 +286,27 @@
                                       HorizontalAlignment="Stretch"
                                       VerticalAlignment="Stretch"
                                       GroupBoxDisplayMode="Normal">
-                        <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedItemDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                        <dxlc:LayoutItem Label="Row:" LabelPosition="Top">
+                            <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedRowDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
                                       VerticalScrollBarVisibility="Auto"
                                       TextWrapping="Wrap"
-                                      IsReadOnly="True" />
+                                      IsReadOnly="True"
+                                      MaxHeight="300"/>
+                        </dxlc:LayoutItem>
+                        <dxlc:LayoutItem Label="Relations:" LabelPosition="Top">
+                        <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedCellDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                      VerticalScrollBarVisibility="Auto"
+                                      TextWrapping="Wrap"
+                                      IsReadOnly="True" 
+                                      MaxHeight="300" />
+                        </dxlc:LayoutItem>
+                        <dxlc:LayoutItem Label="Column:" LabelPosition="Top">
+                        <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedColumnDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                      VerticalScrollBarVisibility="Auto"
+                                      TextWrapping="Wrap"
+                                      IsReadOnly="True" 
+                                      MaxHeight="300" />
+                        </dxlc:LayoutItem>
                     </dxlc:LayoutGroup>
                 </Grid>
 


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
**Added two more textboxes for extra information in RelationshipMatrix.**
There is information for 
- Row
- Relationships
- Column

**Refactoring of triggers that fill the information textboxes in RelationshipMatrix.** 
This used to be triggered by a mouse click.
Now a change of the selected cell also triggers "calculating" the data in the information textboxes.