### PR TITLE
Null checks for data shown on Team Composition Card fixes #213

### DIFF
--- a/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionCardViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/TeamComposition/TeamCompositionCardViewModel.cs
@@ -286,10 +286,10 @@ namespace CDP4SiteDirectory.ViewModels
             this.Domains = new ReactiveList<DomainOfExpertise>(this.Thing.Domain);
             this.Person = this.Thing.Person.Name;
 
-            this.Organization = this.Thing.Person.Organization != null ? this.Thing.Person.Organization.Name : string.Empty;
-            this.OrganizationalUnit = this.Thing.Person.OrganizationalUnit;
+            this.Organization = this.Thing.Person.Organization?.Name ?? string.Empty;
+            this.OrganizationalUnit = this.Thing.Person.OrganizationalUnit ?? string.Empty;
             this.ParticipantRole = this.Thing.Role.Name;
-            this.PersonRole = this.Thing.Person.Role.Name;
+            this.PersonRole = this.Thing.Person.Role?.Name ?? string.Empty;
             this.IsActive = this.Thing.IsActive;
 
             this.UpdateEmailAddress();


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Added null checks for optional data that is shown on a team composition card