### PR TITLE
Various UI fixes

### DIFF
--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -92,7 +92,7 @@ namespace CDP4EngineeringModel.ViewModels
         public ElementDefinitionsBrowserViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
             : base(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
         {
-            this.Caption = "Element definitions";
+            this.Caption = "Element Definitions";
             this.ToolTip = string.Format("{0}\n{1}\n{2}", ((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
 
             this.ElementDefinitionRowViewModels = new ReactiveList<IRowViewModelBase<Thing>>();

--- a/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
+++ b/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
@@ -221,7 +221,7 @@
             <views:BrowserHeader Grid.Row="1" />
 
             <dxg:TreeListControl Grid.Row="2"
-                                 MaxHeight="1080"
+                                 
                                  ItemsSource="{Binding ElementDefinitionRowViewModels}"
                                  SelectedItem="{Binding SelectedThing}"
                                  CurrentItem="{Binding FocusedRow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -236,7 +236,6 @@
                 </dxmvvm:Interaction.Behaviors>
                 <dxg:TreeListControl.View>
                     <dxg:TreeListView Name="View"
-                                      MaxHeight="1080"
                                       AllowEditing="False"
                                       AutoWidth="False"
                                       EditorShowMode="MouseUpFocused"

--- a/ProductTree/ViewModels/ProductTreeViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeViewModel.cs
@@ -89,7 +89,7 @@ namespace CDP4ProductTree.ViewModels
         /// <summary>
         /// The Panel Caption
         /// </summary>
-        private const string PanelCaption = "Product tree";
+        private const string PanelCaption = "Product Tree";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProductTreeViewModel"/> class

--- a/RelationshipMatrix/ViewModels/MatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/MatrixViewModel.cs
@@ -970,7 +970,7 @@ namespace CDP4RelationshipMatrix.ViewModels
 
                 var matrixAddress = new MatrixAddress
                 {
-                    Column = thing?.Name ?? string.Empty,
+                    Column = thing?.ShortName ?? string.Empty,
                     Row = this.Records.IndexOf(selectedRow)
                 };
 
@@ -1021,6 +1021,12 @@ namespace CDP4RelationshipMatrix.ViewModels
                                               .Value?
                                               .Tooltip ??
                                           string.Empty;
+            }
+            else
+            {
+                // column only selected
+                this.SelectedRowDetails = string.Empty;
+                this.SelectedCellDetails = string.Empty;
             }
         }
 

--- a/RelationshipMatrix/Views/RelationshipMatrix.xaml
+++ b/RelationshipMatrix/Views/RelationshipMatrix.xaml
@@ -284,28 +284,37 @@
                                       View="GroupBox"
                                       IsCollapsible="True"
                                       HorizontalAlignment="Stretch"
-                                      VerticalAlignment="Stretch"
                                       GroupBoxDisplayMode="Normal">
-                        <dxlc:LayoutItem Label="Row:" LabelPosition="Top">
+                        <dxlc:LayoutItem VerticalAlignment="Stretch"
+                                         
+                                         Label="Row:"
+                                         LabelPosition="Top">        
                             <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedRowDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
                                       VerticalScrollBarVisibility="Auto"
+                                      VerticalContentAlignment="Top"
+                                      TextWrapping="Wrap"
+                                      Height="200"
+                                      IsReadOnly="True"
+                                      />
+                        </dxlc:LayoutItem>
+                        <dxlc:LayoutItem VerticalAlignment="Stretch"
+                                         Label="Relations:"
+                                         LabelPosition="Top">
+                            <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedCellDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                      VerticalScrollBarVisibility="Auto"
+                                      VerticalContentAlignment="Top"
+                                      TextWrapping="Wrap"
+                                      IsReadOnly="True" />
+                        </dxlc:LayoutItem>
+                        <dxlc:LayoutItem VerticalAlignment="Stretch"
+                                         Label="Column:"
+                                         LabelPosition="Top">
+                            <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedColumnDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                      VerticalScrollBarVisibility="Auto"
+                                      VerticalContentAlignment="Top"
                                       TextWrapping="Wrap"
                                       IsReadOnly="True"
-                                      MaxHeight="300"/>
-                        </dxlc:LayoutItem>
-                        <dxlc:LayoutItem Label="Relations:" LabelPosition="Top">
-                        <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedCellDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
-                                      VerticalScrollBarVisibility="Auto"
-                                      TextWrapping="Wrap"
-                                      IsReadOnly="True" 
-                                      MaxHeight="300" />
-                        </dxlc:LayoutItem>
-                        <dxlc:LayoutItem Label="Column:" LabelPosition="Top">
-                        <dxe:TextEdit EditValue="{Binding Path=Matrix.SelectedColumnDetails, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
-                                      VerticalScrollBarVisibility="Auto"
-                                      TextWrapping="Wrap"
-                                      IsReadOnly="True" 
-                                      MaxHeight="300" />
+                                      />
                         </dxlc:LayoutItem>
                     </dxlc:LayoutGroup>
                 </Grid>

--- a/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
@@ -569,7 +569,7 @@ namespace CDP4Requirements.ViewModels
 
                 if (binaryRelationships.Any())
                 {
-                    var relationshipMenu = new ContextMenuItemViewModel("Requirement satisfaction", "", null, MenuItemKind.None);
+                    var relationshipMenu = new ContextMenuItemViewModel("Requirement Verification Relationship", "", null, MenuItemKind.None);
 
                     foreach (var relationship in binaryRelationships)
                     {

--- a/Requirements/Views/Dialogs/RequirementDialog.xaml
+++ b/Requirements/Views/Dialogs/RequirementDialog.xaml
@@ -211,7 +211,7 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-                            <dxg:GridColumn Binding="{Binding StringTopExpression}" Header="Expression" />
+                            <dxg:GridColumn Binding="{Binding TopExpression.StringValue}" Header="Expression" />
                         </dxg:GridControl.Columns>
                     </dxg:GridControl>
                 </lc:LayoutItem>


### PR DESCRIPTION
- ED Browser now works with 4K screens
- Matrix info text boxes populated correctly based on selection and are fixed height now. #159

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to CDP4-IME! -->

