### PR TITLE
Fixes #230: Visual issues in ParametricConstraints Dialog

### DIFF
--- a/CDP4IME.Tests/ViewModels/SessionViewModelTestFixture.cs
+++ b/CDP4IME.Tests/ViewModels/SessionViewModelTestFixture.cs
@@ -62,7 +62,14 @@ namespace CDP4IME.Tests.ViewModels
             this.cache = new List<Thing>();
             this.dalOutputs = new List<CDP4Common.DTO.Thing>();
             var sitedirectory = new CDP4Common.DTO.SiteDirectory(Guid.NewGuid(), 22);
+            var person = new CDP4Common.DTO.Person(Guid.NewGuid(), 22)
+            {
+                ShortName = "John"
+            };
+
+            sitedirectory.Person.Add(person.Iid);
             this.dalOutputs.Add(sitedirectory);
+            this.dalOutputs.Add(person);
             this.tokenSource = new CancellationTokenSource();
             CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(SiteDirectory)).Subscribe(x => this.OnEvent(x.ChangedThing));
 
@@ -105,7 +112,7 @@ namespace CDP4IME.Tests.ViewModels
         [Test]
         public async Task VerifyThatRefreshUpdatesTheLastUpdateDatetimeAndSynchronizeData()
         {
-            var updatedSiteDir = new CDP4Common.DTO.SiteDirectory(this.dalOutputs.Single().Iid, 30);
+            var updatedSiteDir = new CDP4Common.DTO.SiteDirectory(this.dalOutputs.Single(x => x.ClassKind == ClassKind.SiteDirectory).Iid, 30);
 
             var openTaskCompletionSource = new TaskCompletionSource<IEnumerable<CDP4Common.DTO.Thing>>();
             openTaskCompletionSource.SetResult(this.GetTestDtos());
@@ -129,7 +136,7 @@ namespace CDP4IME.Tests.ViewModels
         [Test]
         public async Task VerifyThatReloadUpdatesTheLastUpdateDatetime()
         {
-            var updatedSiteDir = new CDP4Common.DTO.SiteDirectory(this.dalOutputs.Single().Iid, 30);
+            var updatedSiteDir = new CDP4Common.DTO.SiteDirectory(this.dalOutputs.Single(x => x.ClassKind == ClassKind.SiteDirectory).Iid, 30);
 
             var openTaskCompletionSource = new TaskCompletionSource<IEnumerable<CDP4Common.DTO.Thing>>();
             openTaskCompletionSource.SetResult(this.GetTestDtos());

--- a/Requirements.Tests/Dialogs/ParametricConstraintDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/ParametricConstraintDialogViewModelTestFixture.cs
@@ -122,6 +122,7 @@ namespace CDP4Requirements.Tests.Dialogs
                                  };
             this.requirement = new Requirement(Guid.NewGuid(), this.cache, this.uri);
             this.relationalExpression = new RelationalExpression(Guid.NewGuid(), this.cache, this.uri);
+            this.relationalExpression.ParameterType = new BooleanParameterType();
             this.andExpression = new AndExpression(Guid.NewGuid(), this.cache, this.uri);
             this.orExpression = new OrExpression(Guid.NewGuid(), this.cache, this.uri);
             this.exclusiveOrExpression = new ExclusiveOrExpression(Guid.NewGuid(), this.cache, this.uri);

--- a/Requirements/ExtensionMethods/BooleanExpressionMethods.cs
+++ b/Requirements/ExtensionMethods/BooleanExpressionMethods.cs
@@ -138,7 +138,7 @@ namespace CDP4Requirements.ExtensionMethods
         /// Gets the expressions that are toplevel for this list of <see cref="BooleanExpression"/>
         /// </summary>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing top level <see cref="BooleanExpression"/>s</returns>
-        public static IReadOnlyList<BooleanExpression> GetTopLevelExpressions(this ContainerList<BooleanExpression> expressionList)
+        public static IReadOnlyList<BooleanExpression> GetTopLevelExpressions(this IList<BooleanExpression> expressionList)
         {
             var notInTerms = new List<BooleanExpression>();
 
@@ -181,7 +181,7 @@ namespace CDP4Requirements.ExtensionMethods
         /// <param name="expressionList">List that contains all known <see cref="BooleanExpression"/>s</param>
         /// <param name="myself">The <see cref="BooleanExpression"/> for which its direct children must be returned</param>
         /// <returns><see cref="IReadOnlyList{BooleanExpression}"/> containing <see cref="BooleanExpression"/>s that are direct children of the class in the <see cref="myself"/> parameter or that are not set as a child for another <see cref="BooleanExpression"/></returns>
-        public static IReadOnlyList<BooleanExpression> GetMyAndFreeExpressions(this ContainerList<BooleanExpression> expressionList, BooleanExpression myself)
+        public static IReadOnlyList<BooleanExpression> GetMyAndFreeExpressions(this IList<BooleanExpression> expressionList, BooleanExpression myself)
         {
             var myExpressions = new List<BooleanExpression>();
 

--- a/Requirements/ViewModels/Dialogs/ParametricConstraintDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/ParametricConstraintDialogViewModel.cs
@@ -24,6 +24,8 @@ namespace CDP4Requirements.ViewModels
     using CDP4Dal;
     using CDP4Dal.Operations;
 
+    using CDP4Requirements.ExtensionMethods;
+
     using ReactiveUI;
 
     /// <summary>
@@ -176,13 +178,8 @@ namespace CDP4Requirements.ViewModels
         {
             this.Expression.Clear();
 
-            foreach (var booleanExpression in this.BooleanExpression.OrderBy(e => e.ClassKind))
+            foreach (var booleanExpression in this.BooleanExpression.GetTopLevelExpressions().OrderBy(e => e.ClassKind))
             {
-                if (this.GetDisplayedExpressionsIids().Contains(booleanExpression.Iid))
-                {
-                    continue;
-                }
-
                 switch (booleanExpression.ClassKind)
                 {
                     case ClassKind.NotExpression:
@@ -216,39 +213,6 @@ namespace CDP4Requirements.ViewModels
             if (this.Expression.Count == 1)
             {
                 this.SelectedTopExpression = this.Expression.Single().Thing;
-            }
-        }
-
-        /// <summary>
-        /// Gets all the <see cref="BooleanExpression"/>s that are already in the tree 
-        /// </summary>
-        private IEnumerable<Guid> GetDisplayedExpressionsIids()
-        {
-            var booleanExpressions = new List<BooleanExpression>();
-
-            foreach (var containedExpressionRow in this.Expression)
-            {
-                this.AddContainedExpression(containedExpressionRow, booleanExpressions);
-            }
-
-            return booleanExpressions.Select(e => e.Iid);
-        }
-
-        /// <summary>
-        /// Adds the <see cref="BooleanExpression"/>s contained in this <see cref="IRowViewModelBase<BooleanExpression>"/> to the list of <see cref="BooleanExpression"/s>
-        /// </summary>
-        private void AddContainedExpression(IRowViewModelBase<BooleanExpression> containedExpressionRow, ICollection<BooleanExpression> booleanExpressions)
-        {
-            booleanExpressions.Add(containedExpressionRow.Thing);
-
-            if (!containedExpressionRow.ContainedRows.Any())
-            {
-                return;
-            }
-
-            foreach (var containedRow in containedExpressionRow.ContainedRows.OfType<IRowViewModelBase<BooleanExpression>>())
-            {
-                this.AddContainedExpression(containedRow, booleanExpressions);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [X] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [X] I have provided test coverage for my change (where applicable)

### Description
- Fixed bugs where wrong data was shown when adding a non-RelationalExpression BooleanExpression to an existing tree of BooleanExpressions
- Fixed missing data in Session related unittests (credits for Alex)
- Fixed unit tests for ParametricConstraints
