### PR TITLE
Persisted favorite parameter types and major deprecation filtering refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ CDP4.v12.suo
 .vs
 
 /RelationshipMatrix/Settings.StyleCop
+**l.cs.orig

--- a/BasicRdl.Tests/BasicRdlModuleTestFixture.cs
+++ b/BasicRdl.Tests/BasicRdlModuleTestFixture.cs
@@ -45,7 +45,7 @@ namespace BasicRdl.Tests
         {
             var ribbonManager = new FluentRibbonManager();
 
-            var module = new BasicRdlModule(this.regionManager.Object, ribbonManager, this.panelNavigationService.Object, null, null, null);
+            var module = new BasicRdlModule(this.regionManager.Object, ribbonManager, this.panelNavigationService.Object, null, null, null, null);
             //module.Initialize();
             Assert.AreEqual(this.regionManager.Object, module.RegionManager);            
         }

--- a/BasicRdl.Tests/OfficeRibbon/BasicRdlRibbonPartTestFixture.cs
+++ b/BasicRdl.Tests/OfficeRibbon/BasicRdlRibbonPartTestFixture.cs
@@ -77,7 +77,7 @@ namespace BasicRdl.Tests
             this.amountOfRibbonControls = 6;
             this.order = 1;
 
-            this.ribbonPart = new BasicRdlRibbonPart(this.order, this.panelNavigationService.Object, null, null, null);
+            this.ribbonPart = new BasicRdlRibbonPart(this.order, this.panelNavigationService.Object, null, null, null, null);
 
             ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
             this.serviceLocator.Setup(x => x.GetInstance<IThingDialogNavigationService>())

--- a/BasicRdl.Tests/OfficeRibbon/BasicRdlRibbonPartTestFixture.cs
+++ b/BasicRdl.Tests/OfficeRibbon/BasicRdlRibbonPartTestFixture.cs
@@ -7,6 +7,7 @@
 namespace BasicRdl.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO.Packaging;
     using System.Reactive.Concurrency;
     using System.Threading;
@@ -18,6 +19,7 @@ namespace BasicRdl.Tests
     using CDP4Composition;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services.FavoritesService;
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Permission;
@@ -41,12 +43,14 @@ namespace BasicRdl.Tests
         private int amountOfRibbonControls;
         private int order;
         private string ribbonxmlname;
-        private Mock<IServiceLocator> serviceLocator; 
+        private Mock<IServiceLocator> serviceLocator;
+
         private Mock<IPanelNavigationService> panelNavigationService;
         private Mock<IThingDialogNavigationService> dialogNavigationService;
         private Mock<IPermissionService> permittingPermissionService;
         private Mock<ISession> session;
         private Person person;
+        private Mock<IFavoritesService> favoritesService;
 
         [SetUp]
         public void SetUp()
@@ -59,7 +63,7 @@ namespace BasicRdl.Tests
             this.session = new Mock<ISession>();
             var siteDirectory = new SiteDirectory(Guid.NewGuid(), null, this.uri);
             this.person = new Person(Guid.NewGuid(), null, this.uri) { GivenName = "John", Surname = "Doe" };
-
+            this.favoritesService = new Mock<IFavoritesService>();
             this.session.Setup(x => x.DataSourceUri).Returns("test");
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(siteDirectory);
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
@@ -72,12 +76,17 @@ namespace BasicRdl.Tests
             this.permittingPermissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
             this.permittingPermissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
 
+            this.favoritesService.Setup(x => x.GetFavoriteItemsCollectionByType(It.IsAny<ISession>(), It.IsAny<Type>()))
+                .Returns(new HashSet<Guid>());
+            this.favoritesService.Setup(x =>
+                x.SubscribeToChanges(It.IsAny<ISession>(), It.IsAny<Type>(), It.IsAny<Action<HashSet<Guid>>>())).Returns(new Mock<IDisposable>().Object);
+
             this.session.Setup(x => x.PermissionService).Returns(this.permittingPermissionService.Object);
 
             this.amountOfRibbonControls = 6;
             this.order = 1;
 
-            this.ribbonPart = new BasicRdlRibbonPart(this.order, this.panelNavigationService.Object, null, null, null, null);
+            this.ribbonPart = new BasicRdlRibbonPart(this.order, this.panelNavigationService.Object, null, null, null, this.favoritesService.Object);
 
             ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
             this.serviceLocator.Setup(x => x.GetInstance<IThingDialogNavigationService>())

--- a/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
@@ -75,7 +75,7 @@ namespace BasicRdl.Tests.ViewModels
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
 
-            this.ParameterTypesBrowserViewModel = new ParameterTypesBrowserViewModel(this.session.Object, this.siteDirectory, this.dialogNavigationService.Object, this.panelNavigationService.Object, null, null);
+            this.ParameterTypesBrowserViewModel = new ParameterTypesBrowserViewModel(this.session.Object, this.siteDirectory, this.dialogNavigationService.Object, this.panelNavigationService.Object, null, null, null);
         }
 
         [TearDown]
@@ -151,7 +151,7 @@ namespace BasicRdl.Tests.ViewModels
             this.siteDirectory.Model.Add(engineeringModelSetup);
             this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new HashSet<ReferenceDataLibrary>(this.siteDirectory.SiteReferenceDataLibrary) { modelReferenceDataLibrary });     
 
-            var browser = new ParameterTypesBrowserViewModel(this.session.Object, this.siteDirectory, null, null, null, null);
+            var browser = new ParameterTypesBrowserViewModel(this.session.Object, this.siteDirectory, null, null, null, null, null);
             Assert.AreEqual(4, browser.ParameterTypes.Count);
             Assert.IsNotNull(browser.ParameterTypes.First().Thing);
 
@@ -162,7 +162,7 @@ namespace BasicRdl.Tests.ViewModels
         [Test]
         public void VerifyThatRdlShortnameIsUpdated()
         {
-            var vm = new ParameterTypesBrowserViewModel(this.session.Object, this.siteDirectory, null, null, null, null);
+            var vm = new ParameterTypesBrowserViewModel(this.session.Object, this.siteDirectory, null, null, null, null, null);
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;

--- a/BasicRdl.Tests/ViewModels/Ribbons/ParameterTypeRibbonViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Ribbons/ParameterTypeRibbonViewModelTestFixture.cs
@@ -18,6 +18,7 @@ namespace BasicRdl.Tests.ViewModels.Ribbons
     using CDP4Dal;
     using CDP4Dal.Permission;
     using BasicRdl.ViewModels;
+    using CDP4Composition.Services.FavoritesService;
     using Microsoft.Practices.ServiceLocation;
     using Moq;
     using NUnit.Framework;
@@ -35,6 +36,7 @@ namespace BasicRdl.Tests.ViewModels.Ribbons
         private Mock<IPanelNavigationService> panelNavigationService;
         private Mock<IDialogNavigationService> dialogNavigationService;
         private Mock<IPluginSettingsService> pluginSettingsService;
+        private Mock<IFavoritesService> favoritesService;
 
         private readonly Uri uri = new Uri("http://www.rheagroup.com");
         private Mock<IServiceLocator> serviceLocator;
@@ -57,6 +59,8 @@ namespace BasicRdl.Tests.ViewModels.Ribbons
             this.panelNavigationService = new Mock<IPanelNavigationService>();
             this.dialogNavigationService = new Mock<IDialogNavigationService>();
             this.pluginSettingsService = new Mock<IPluginSettingsService>();
+            this.pluginSettingsService = new Mock<IPluginSettingsService>();
+            this.favoritesService = new Mock<IFavoritesService>();
 
             this.assembler = new Assembler(this.uri);
             this.cache = this.assembler.Cache;
@@ -104,7 +108,8 @@ namespace BasicRdl.Tests.ViewModels.Ribbons
                 this.thingDialogNavigationService.Object,
                 this.panelNavigationService.Object,
                 this.dialogNavigationService.Object,
-                this.pluginSettingsService.Object);
+                this.pluginSettingsService.Object,
+                this.favoritesService.Object);
 
             Assert.IsInstanceOf<ParameterTypesBrowserViewModel>(viewmodel);
         }

--- a/BasicRdl/BasicRdlModule.cs
+++ b/BasicRdl/BasicRdlModule.cs
@@ -13,6 +13,7 @@ namespace BasicRdl
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+    using CDP4Composition.Services.FavoritesService;
     using Microsoft.Practices.Prism.Modularity;
     using Microsoft.Practices.Prism.Regions;
 
@@ -43,8 +44,9 @@ namespace BasicRdl
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
+        /// <param name="favoritesService">The <see cref="IFavoritesService"/> to be used to store and retrieve favorite things.</param>
         [ImportingConstructor]
-        public BasicRdlModule(IRegionManager regionManager, IFluentRibbonManager ribbonManager, IPanelNavigationService panelNavigationService, IThingDialogNavigationService thingDialogNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+        public BasicRdlModule(IRegionManager regionManager, IFluentRibbonManager ribbonManager, IPanelNavigationService panelNavigationService, IThingDialogNavigationService thingDialogNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService, IFavoritesService favoritesService)
         {
             this.RegionManager = regionManager;
             this.RibbonManager = ribbonManager;
@@ -52,6 +54,7 @@ namespace BasicRdl
             this.ThingDialogNavigationService = thingDialogNavigationService;
             this.DialogNavigationService = dialogNavigationService;
             this.PluginSettingsService = pluginSettingsService;
+            this.FavoritesService = favoritesService;
         }
 
         /// <summary>
@@ -85,6 +88,11 @@ namespace BasicRdl
         internal IPluginSettingsService PluginSettingsService { get; private set; }
 
         /// <summary>
+        /// Gets the <see cref="IFavoritesService"/> used to read and write lists of favorite things to user preferences.
+        /// </summary>
+        internal IFavoritesService FavoritesService { get; private set; }
+
+        /// <summary>
         /// Initialize the Module
         /// </summary>
         public void Initialize()
@@ -99,7 +107,7 @@ namespace BasicRdl
         /// </summary>
         private void RegisterRibbonParts()
         {
-            var rdlRibbonPart = new BasicRdlRibbonPart(20, this.PanelNavigationService, this.ThingDialogNavigationService, this.DialogNavigationService, this.PluginSettingsService);
+            var rdlRibbonPart = new BasicRdlRibbonPart(20, this.PanelNavigationService, this.ThingDialogNavigationService, this.DialogNavigationService, this.PluginSettingsService, this.FavoritesService);
             this.RibbonManager.RegisterRibbonPart(rdlRibbonPart);
         }
     }

--- a/BasicRdl/OfficeRibbon/BasicRdlRibbonPart.cs
+++ b/BasicRdl/OfficeRibbon/BasicRdlRibbonPart.cs
@@ -16,6 +16,7 @@ namespace BasicRdl
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+    using CDP4Composition.Services.FavoritesService;
     using CDP4Dal;
     using CDP4Dal.Events;
     using NLog;
@@ -67,16 +68,24 @@ namespace BasicRdl
         /// </param>
         /// <param name="thingDialogNavigationService">The instance of <see cref="IThingDialogNavigationService"/> that orchestrates navigation of <see cref="IThingDialogView"/></param>
         /// <param name="dialogNavigationService">The instance of <see cref="IDialogNavigationService"/> that orchestrates navigation to dialogs</param>
-        public BasicRdlRibbonPart(int order, IPanelNavigationService panelNavigationService, IThingDialogNavigationService thingDialogNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+        /// <param name="pluginSettingsService">The instance of <see cref="IPluginSettingsService"/> that reads and writes </param>
+        /// <param name="favoritesService">The instance of <see cref="IDialogNavigationService"/> that</param>
+        public BasicRdlRibbonPart(int order, IPanelNavigationService panelNavigationService, IThingDialogNavigationService thingDialogNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService, IFavoritesService favoritesService)
             : base(order, panelNavigationService, thingDialogNavigationService, dialogNavigationService, pluginSettingsService)
         {
-            CDPMessageBus.Current.Listen<SessionEvent>().Subscribe(this.SessionChangeEventHandler);            
+            CDPMessageBus.Current.Listen<SessionEvent>().Subscribe(this.SessionChangeEventHandler);
+            this.FavoritesService = favoritesService;
         }
 
         /// <summary>
         /// Gets the <see cref="ISession"/> that is active for the <see cref="RibbonPart"/>
         /// </summary>
         public ISession Session { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IFavoritesService"/> that is active for the <see cref="RibbonPart"/>
+        /// </summary>
+        public IFavoritesService FavoritesService { get; private set; }
 
         /// <summary>
         /// Gets the the current executing assembly
@@ -128,7 +137,7 @@ namespace BasicRdl
                 this.measurementScalesBrowserViewModel = new MeasurementScalesBrowserViewModel(session, siteDirectory, this.ThingDialogNavigationService, this.PanelNavigationService, this.DialogNavigationService, this.PluginSettingsService);
                 this.rulesBrowserViewModel = new RulesBrowserViewModel(session, siteDirectory, this.ThingDialogNavigationService, this.PanelNavigationService, this.DialogNavigationService, this.PluginSettingsService);
                 this.categoryBrowserViewModel = new CategoryBrowserViewModel(session, siteDirectory, this.ThingDialogNavigationService, this.PanelNavigationService, this.DialogNavigationService, this.PluginSettingsService);
-                this.parameterTypesBrowserViewModel = new ParameterTypesBrowserViewModel(session, siteDirectory, this.ThingDialogNavigationService, this.PanelNavigationService, this.DialogNavigationService, this.PluginSettingsService);
+                this.parameterTypesBrowserViewModel = new ParameterTypesBrowserViewModel(session, siteDirectory, this.ThingDialogNavigationService, this.PanelNavigationService, this.DialogNavigationService, this.PluginSettingsService, this.FavoritesService);
 
                 this.Session = session;
             }

--- a/BasicRdl/Resources/RibbonXml/rdlribbon.xml
+++ b/BasicRdl/Resources/RibbonXml/rdlribbon.xml
@@ -2,7 +2,7 @@
   <group id="basicrdl" label="Reference Data">
     <button id="ShowMeasurementUnits" size="large" label="Units" supertip="Manage Measurement Units" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
     <button id="ShowMeasurementScales" size="large" label="Scales" supertip="Manage Measurement Scales" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
-    <button id="ShowParameterTypes" size="large" label="ParameterTypes" supertip="Manage Units" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
+    <button id="ShowParameterTypes" size="large" label="ParameterTypes" supertip="Manage ParameterTypes" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
     <button id="ShowRules" size="large" label="Rules" supertip="Manage Rules" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
     <button id="ShowCategories" size="large" label="Categories" supertip="Manage Categories" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
   </group>

--- a/BasicRdl/ViewModels/CategoryBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/CategoryBrowserViewModel.cs
@@ -25,7 +25,7 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// Represents the view-model of the <see cref="CategoryBrowser"/> view
     /// </summary>
-    public class CategoryBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class CategoryBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The Panel Caption
@@ -41,7 +41,7 @@ namespace BasicRdl.ViewModels
         /// Backing field for <see cref="CanCreateRdlElement"/>
         /// </summary>
         private bool canCreateRdlElement;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CategoryBrowserViewModel"/> class
         /// </summary>
@@ -53,13 +53,17 @@ namespace BasicRdl.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public CategoryBrowserViewModel(ISession session, SiteDirectory thing, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(thing, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public CategoryBrowserViewModel(ISession session, SiteDirectory thing,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(thing, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
-            this.AddSubscriptions();            
+            this.AddSubscriptions();
         }
 
         /// <summary>
@@ -67,10 +71,7 @@ namespace BasicRdl.ViewModels
         /// </summary>
         public ReactiveList<CategoryRowViewModel> Categories
         {
-            get
-            {
-                return this.categories;
-            }
+            get { return this.categories; }
         }
 
         /// <summary>
@@ -101,7 +102,7 @@ namespace BasicRdl.ViewModels
                 category.Dispose();
             }
         }
-        
+
         /// <summary>
         /// Loads the <see cref="Thing"/>s from the cache when the browser is instantiated.
         /// </summary>
@@ -109,7 +110,8 @@ namespace BasicRdl.ViewModels
         {
             base.Initialize();
             var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
-            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
+            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
+                .Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
                 foreach (var category in referenceDataLibrary.DefinedCategory)
                 {
@@ -120,7 +122,7 @@ namespace BasicRdl.ViewModels
 
         /// <summary>
         /// Initialize the <see cref="ICommand{T}"/>s
-        /// </summary>       
+        /// </summary>
         protected override void InitializeCommands()
         {
             base.InitializeCommands();
@@ -150,8 +152,10 @@ namespace BasicRdl.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Category", "", this.CreateCommand, MenuItemKind.Create, ClassKind.Category));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Highlight", "", this.HighlightCommand, MenuItemKind.Highlight));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Category", "", this.CreateCommand,
+                MenuItemKind.Create, ClassKind.Category));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Highlight", "", this.HighlightCommand,
+                MenuItemKind.Highlight));
         }
 
         /// <summary>
@@ -161,7 +165,8 @@ namespace BasicRdl.ViewModels
         {
             var addListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(Category))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Added && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as Category)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.AddCategoryRowViewModel);
@@ -169,7 +174,8 @@ namespace BasicRdl.ViewModels
 
             var removeListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(Category))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Removed && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Removed &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as Category)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RemoveCategoryRowViewModel);
@@ -177,7 +183,8 @@ namespace BasicRdl.ViewModels
 
             var rdlUpdateListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ReferenceDataLibrary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as ReferenceDataLibrary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RefreshContainerName);
@@ -246,7 +253,8 @@ namespace BasicRdl.ViewModels
             CDPMessageBus.Current.SendMessage(new CancelHighlightEvent());
 
             // highlight the selected thing
-            CDPMessageBus.Current.SendMessage(new HighlightByCategoryEvent(this.SelectedThing.Thing as Category), this.SelectedThing.Thing);
+            CDPMessageBus.Current.SendMessage(new HighlightByCategoryEvent(this.SelectedThing.Thing as Category),
+                this.SelectedThing.Thing);
         }
     }
 }

--- a/BasicRdl/ViewModels/ConstantsBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ConstantsBrowserViewModel.cs
@@ -4,8 +4,6 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-
-
 namespace BasicRdl.ViewModels
 {
     using System;
@@ -28,7 +26,8 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// The purpose of the <see cref="ConstantsBrowserViewModel"/> is to represent the view-model for <see cref="Constant"/>s
     /// </summary>
-    public class ConstantsBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget
+    public class ConstantsBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget,
+        IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The Panel Caption
@@ -56,26 +55,27 @@ namespace BasicRdl.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public ConstantsBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public ConstantsBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
             this.constants.ChangeTrackingEnabled = true;
 
             this.AddSubscriptions();
         }
-        
+
         /// <summary>
         /// Gets the <see cref="ConstantRowViewModel"/> that are contained by this view-model
         /// </summary>
-        public ReactiveList<ConstantRowViewModel> Constants 
+        public ReactiveList<ConstantRowViewModel> Constants
         {
-            get
-            {
-                return this.constants;
-            }
+            get { return this.constants; }
         }
 
         /// <summary>
@@ -113,7 +113,8 @@ namespace BasicRdl.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Constant", "", this.CreateCommand, MenuItemKind.Create, ClassKind.Constant));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Constant", "", this.CreateCommand,
+                MenuItemKind.Create, ClassKind.Constant));
         }
 
         /// <summary>
@@ -124,7 +125,8 @@ namespace BasicRdl.ViewModels
             base.Initialize();
 
             var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
-            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
+            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
+                .Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
                 foreach (var constant in referenceDataLibrary.Constant)
                 {
@@ -155,7 +157,8 @@ namespace BasicRdl.ViewModels
         {
             var addListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(Constant))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Added && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as Constant)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.AddConstantRowViewModel);
@@ -163,7 +166,8 @@ namespace BasicRdl.ViewModels
 
             var removeListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(Constant))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Removed && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Removed &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as Constant)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RemoveConstantRowViewModel);
@@ -171,7 +175,8 @@ namespace BasicRdl.ViewModels
 
             var rdlUpdateListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ReferenceDataLibrary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as ReferenceDataLibrary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RefreshContainerName);

--- a/BasicRdl/ViewModels/FileTypeBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/FileTypeBrowserViewModel.cs
@@ -26,7 +26,8 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// The purpose of the <see cref="FileTypeBrowserViewModel"/> is to represent the view-model for <see cref="FileType"/>s
     /// </summary>
-    public class FileTypeBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget
+    public class FileTypeBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget,
+        IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The Panel Caption
@@ -49,14 +50,17 @@ namespace BasicRdl.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public FileTypeBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public FileTypeBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = $"{PanelCaption}, {this.Thing.Name}";
             this.ToolTip = $"{this.Thing.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
             this.AddSubscriptions();
         }
-        
+
         /// <summary>
         /// Gets or sets a value indicating if the current person can create, edit or delete a <see cref="FileType"/>
         /// </summary>
@@ -70,7 +74,7 @@ namespace BasicRdl.ViewModels
         /// Gets the <see cref="FileTypes"/> rows that are contained by this view-model
         /// </summary>
         public ReactiveList<FileTypeRowViewModel> FileTypes { get; private set; }
-        
+
         /// <summary>
         /// Add the necessary subscriptions for this view model.
         /// </summary>
@@ -78,7 +82,8 @@ namespace BasicRdl.ViewModels
         {
             var addListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(FileType))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Added && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as FileType)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.AddFileTypeRowViewModel);
@@ -86,7 +91,8 @@ namespace BasicRdl.ViewModels
 
             var removeListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(FileType))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Removed && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Removed &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as FileType)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RemoveFileTypeRowViewModel);
@@ -94,7 +100,8 @@ namespace BasicRdl.ViewModels
 
             var rdlUpdateListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ReferenceDataLibrary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as ReferenceDataLibrary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RefreshContainerName);
@@ -131,7 +138,7 @@ namespace BasicRdl.ViewModels
             {
                 this.FileTypes.Remove(row);
                 row.Dispose();
-            }  
+            }
         }
 
         /// <summary>
@@ -164,7 +171,8 @@ namespace BasicRdl.ViewModels
             base.Initialize();
             this.FileTypes = new ReactiveList<FileTypeRowViewModel>();
             var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
-            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
+            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
+                .Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
                 foreach (var filetype in referenceDataLibrary.FileType)
                 {
@@ -191,7 +199,8 @@ namespace BasicRdl.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a File Type", "", this.CreateCommand, MenuItemKind.Create, ClassKind.FileType));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a File Type", "", this.CreateCommand,
+                MenuItemKind.Create, ClassKind.FileType));
         }
 
         /// <summary>
@@ -216,7 +225,7 @@ namespace BasicRdl.ViewModels
         ///  Information about the drag operation.
         /// </param>
         /// <remarks>
-        /// To allow a drop at the current drag position, the <see cref="DropInfo.Effects"/> property on 
+        /// To allow a drop at the current drag position, the <see cref="DropInfo.Effects"/> property on
         /// <paramref name="dropInfo"/> should be set to a value other than <see cref="DragDropEffects.None"/>
         /// and <see cref="DropInfo.Payload"/> should be set to a non-null value.
         /// </remarks>

--- a/BasicRdl/ViewModels/GlossaryBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/GlossaryBrowserViewModel.cs
@@ -27,7 +27,8 @@ namespace BasicRdl.ViewModels
     /// The <see cref="GlossaryBrowserViewModel"/> is a View Model that is responsible for managing the data and interactions with that data for a view
     /// that shows all the <see cref="Glossary"/>s contained by a data-source following the containment tree that is modeled in 10-25 and the CDP4 extensions.
     /// </summary>
-    public class GlossaryBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget
+    public class GlossaryBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget,
+        IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The NLog logger
@@ -60,11 +61,15 @@ namespace BasicRdl.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public GlossaryBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public GlossaryBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
             this.AddSubscriptions();
         }
@@ -109,7 +114,8 @@ namespace BasicRdl.ViewModels
         {
             var addListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(Glossary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Added && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as Glossary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.AddGlossaryRowViewModel);
@@ -117,7 +123,8 @@ namespace BasicRdl.ViewModels
 
             var removeListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(Glossary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Removed && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Removed &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as Glossary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RemoveGlossaryRowViewModel);
@@ -125,7 +132,8 @@ namespace BasicRdl.ViewModels
 
             var rdlUpdateListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ReferenceDataLibrary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as ReferenceDataLibrary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RefreshContainerName);
@@ -192,7 +200,8 @@ namespace BasicRdl.ViewModels
             this.Glossaries = new ReactiveList<GlossaryRowViewModel>();
 
             var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
-            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
+            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
+                .Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
                 foreach (var glossary in referenceDataLibrary.Glossary)
                 {
@@ -208,8 +217,10 @@ namespace BasicRdl.ViewModels
         {
             base.InitializeCommands();
 
-            this.CreateTermCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateTerm));           
-            this.CreateTermCommand.Subscribe(_ => this.ExecuteCreateCommand<Term>(this.SelectedThing.Thing as Glossary ?? this.SelectedThing.Thing.GetContainerOfType<Glossary>()));
+            this.CreateTermCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateTerm));
+            this.CreateTermCommand.Subscribe(_ =>
+                this.ExecuteCreateCommand<Term>(this.SelectedThing.Thing as Glossary ??
+                                                this.SelectedThing.Thing.GetContainerOfType<Glossary>()));
 
             this.CreateGlossaryCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateGlossary));
             this.CreateGlossaryCommand.Subscribe(_ => this.ExecuteCreateCommand<Glossary>());
@@ -220,7 +231,8 @@ namespace BasicRdl.ViewModels
         /// </summary>
         protected override void ExecuteExportCommand()
         {
-            var dialogViewModel = new HtmlExportGlossarySelectionDialogViewModel(this.Glossaries.Select(grvm => grvm.Thing).ToList());
+            var dialogViewModel =
+                new HtmlExportGlossarySelectionDialogViewModel(this.Glossaries.Select(grvm => grvm.Thing).ToList());
             this.DialogNavigationService.NavigateModal(dialogViewModel);
         }
 
@@ -237,7 +249,8 @@ namespace BasicRdl.ViewModels
                 return;
             }
 
-            this.CanCreateTerm = this.PermissionService.CanWrite(ClassKind.Term, this.SelectedThing.Thing as Glossary ?? this.SelectedThing.Thing.GetContainerOfType<Glossary>());
+            this.CanCreateTerm = this.PermissionService.CanWrite(ClassKind.Term,
+                this.SelectedThing.Thing as Glossary ?? this.SelectedThing.Thing.GetContainerOfType<Glossary>());
         }
 
         /// <summary>
@@ -246,14 +259,16 @@ namespace BasicRdl.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Glossary", "", this.CreateGlossaryCommand, MenuItemKind.Create, ClassKind.Glossary));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Glossary", "", this.CreateGlossaryCommand,
+                MenuItemKind.Create, ClassKind.Glossary));
 
             if (this.SelectedThing == null)
             {
                 return;
             }
 
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Term", "", this.CreateTermCommand, MenuItemKind.Create, ClassKind.Term));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Term", "", this.CreateTermCommand,
+                MenuItemKind.Create, ClassKind.Term));
         }
 
         /// <summary>

--- a/BasicRdl/ViewModels/MeasurementScalesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/MeasurementScalesBrowserViewModel.cs
@@ -23,7 +23,8 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// The purpose of the <see cref="MeasurementScalesBrowserViewModel"/> is to represent the view-model for <see cref="MeasurementScale"/>s
     /// </summary>
-    public class MeasurementScalesBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class MeasurementScalesBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel,
+        IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The Panel Caption
@@ -38,7 +39,8 @@ namespace BasicRdl.ViewModels
         /// <summary>
         /// Backing field for the <see cref="MeasurementScales"/> property.
         /// </summary>
-        private readonly ReactiveList<MeasurementScaleRowViewModel> measurementScales = new ReactiveList<MeasurementScaleRowViewModel>();
+        private readonly ReactiveList<MeasurementScaleRowViewModel> measurementScales =
+            new ReactiveList<MeasurementScaleRowViewModel>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MeasurementScalesBrowserViewModel"/> class.
@@ -51,26 +53,27 @@ namespace BasicRdl.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public MeasurementScalesBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public MeasurementScalesBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
             this.measurementScales.ChangeTrackingEnabled = true;
 
             this.AddSubscriptions();
         }
-        
+
         /// <summary>
         /// Gets the <see cref="MeasurementScaleRowViewModel"/> that are contained by this view-model
         /// </summary>
         public ReactiveList<MeasurementScaleRowViewModel> MeasurementScales
         {
-            get
-            {
-                return this.measurementScales;
-            }
+            get { return this.measurementScales; }
         }
 
         /// <summary>
@@ -90,7 +93,7 @@ namespace BasicRdl.ViewModels
         /// <summary>
         /// Gets the <see cref="ReactiveCommand"/> used to create a <see cref="LogarithmicScale"/>
         /// </summary>
-        public ReactiveCommand<object> CreateLogarithmicScale { get; private set; }     
+        public ReactiveCommand<object> CreateLogarithmicScale { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ReactiveCommand"/> used to create a <see cref="OrdinalScale"/>
@@ -105,8 +108,8 @@ namespace BasicRdl.ViewModels
         /// <summary>
         /// Gets the <see cref="ReactiveCommand"/> used to create a <see cref="CyclicRatioScale"/>
         /// </summary>
-        public ReactiveCommand<object> CreateCyclicRatioScale { get; private set; } 
-        
+        public ReactiveCommand<object> CreateCyclicRatioScale { get; private set; }
+
         /// <summary>
         /// Add the necessary subscriptions for this view model.
         /// </summary>
@@ -114,7 +117,8 @@ namespace BasicRdl.ViewModels
         {
             var addListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(MeasurementScale))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Added && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as MeasurementScale)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.AddMeasurementScaleRowViewModel);
@@ -122,7 +126,8 @@ namespace BasicRdl.ViewModels
 
             var removeListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(MeasurementScale))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Removed && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Removed &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as MeasurementScale)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RemoveMeasurementScaleRowViewModel);
@@ -130,7 +135,8 @@ namespace BasicRdl.ViewModels
 
             var rdlUpdateListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ReferenceDataLibrary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as ReferenceDataLibrary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RefreshContainerName);
@@ -195,7 +201,8 @@ namespace BasicRdl.ViewModels
             base.Initialize();
 
             var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
-            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
+            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
+                .Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
                 foreach (var scale in referenceDataLibrary.Scale)
                 {
@@ -258,11 +265,16 @@ namespace BasicRdl.ViewModels
         {
             base.PopulateContextMenu();
 
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Cyclic Ratio Scale", "", this.CreateCyclicRatioScale, MenuItemKind.Create, ClassKind.CyclicRatioScale));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create an Interval Scale", "", this.CreateIntervalScale, MenuItemKind.Create, ClassKind.IntervalScale));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Logarithmic Scale", "", this.CreateLogarithmicScale, MenuItemKind.Create, ClassKind.LogarithmicScale));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create an Ordinal Scale", "", this.CreateOrdinalScale, MenuItemKind.Create, ClassKind.OrdinalScale));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Ratio Scale", "", this.CreateRatioScale, MenuItemKind.Create, ClassKind.RatioScale));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Cyclic Ratio Scale", "",
+                this.CreateCyclicRatioScale, MenuItemKind.Create, ClassKind.CyclicRatioScale));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create an Interval Scale", "", this.CreateIntervalScale,
+                MenuItemKind.Create, ClassKind.IntervalScale));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Logarithmic Scale", "",
+                this.CreateLogarithmicScale, MenuItemKind.Create, ClassKind.LogarithmicScale));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create an Ordinal Scale", "", this.CreateOrdinalScale,
+                MenuItemKind.Create, ClassKind.OrdinalScale));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Ratio Scale", "", this.CreateRatioScale,
+                MenuItemKind.Create, ClassKind.RatioScale));
         }
     }
 }

--- a/BasicRdl/ViewModels/MeasurementUnitsBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/MeasurementUnitsBrowserViewModel.cs
@@ -23,7 +23,8 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// The purpose of the <see cref="MeasurementUnitsBrowserViewModel"/> is to represent the view-model for <see cref="MeasurementUnit"/>s
     /// </summary>
-    public class MeasurementUnitsBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class MeasurementUnitsBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel,
+        IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The Panel Caption
@@ -33,7 +34,8 @@ namespace BasicRdl.ViewModels
         /// <summary>
         /// Backing field for the <see cref="MeasurementUnits"/> property
         /// </summary>
-        private readonly ReactiveList<MeasurementUnitRowViewModel> measurementUnits = new ReactiveList<MeasurementUnitRowViewModel>();
+        private readonly ReactiveList<MeasurementUnitRowViewModel> measurementUnits =
+            new ReactiveList<MeasurementUnitRowViewModel>();
 
         /// <summary>
         /// Backing field for <see cref="CanCreateRdlElement"/>
@@ -51,26 +53,27 @@ namespace BasicRdl.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public MeasurementUnitsBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public MeasurementUnitsBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
             this.measurementUnits.ChangeTrackingEnabled = true;
 
             this.AddSubscriptions();
         }
-        
+
         /// <summary>
         /// Gets the <see cref="MeasurementUnitRowViewModel"/> that are contained by this view-model
         /// </summary>
-        public ReactiveList<MeasurementUnitRowViewModel> MeasurementUnits 
+        public ReactiveList<MeasurementUnitRowViewModel> MeasurementUnits
         {
-            get
-            {
-                return this.measurementUnits;
-            }
+            get { return this.measurementUnits; }
         }
 
         /// <summary>
@@ -101,7 +104,7 @@ namespace BasicRdl.ViewModels
         /// Gets the <see cref="ReactiveCommand"/> used to create a <see cref="PrefixedUnit"/>
         /// </summary>
         public ReactiveCommand<object> CreatePrefixedUnit { get; private set; }
-        
+
         /// <summary>
         /// Add the necessary subscriptions for this view model.
         /// </summary>
@@ -109,7 +112,8 @@ namespace BasicRdl.ViewModels
         {
             var addListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(MeasurementUnit))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Added && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as MeasurementUnit)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.AddMeasurementUnitRowViewModel);
@@ -117,7 +121,8 @@ namespace BasicRdl.ViewModels
 
             var removeListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(MeasurementUnit))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Removed && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Removed &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as MeasurementUnit)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RemoveMeasurementUnitRowViewModel);
@@ -125,7 +130,8 @@ namespace BasicRdl.ViewModels
 
             var rdlUpdateListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ReferenceDataLibrary))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                           objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as ReferenceDataLibrary)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RefreshContainerName);
@@ -196,10 +202,14 @@ namespace BasicRdl.ViewModels
         {
             base.PopulateContextMenu();
 
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Simple Unit", "", this.CreateSimpleUnit, MenuItemKind.Create, ClassKind.SimpleUnit));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Derived Unit", "", this.CreateDerivedUnit, MenuItemKind.Create, ClassKind.DerivedUnit));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Linear Conversion Unit", "", this.CreateLinearConversionUnit, MenuItemKind.Create, ClassKind.LinearConversionUnit));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Prefixed Unit", "", this.CreatePrefixedUnit, MenuItemKind.Create, ClassKind.PrefixedUnit));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Simple Unit", "", this.CreateSimpleUnit,
+                MenuItemKind.Create, ClassKind.SimpleUnit));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Derived Unit", "", this.CreateDerivedUnit,
+                MenuItemKind.Create, ClassKind.DerivedUnit));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Linear Conversion Unit", "",
+                this.CreateLinearConversionUnit, MenuItemKind.Create, ClassKind.LinearConversionUnit));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Prefixed Unit", "", this.CreatePrefixedUnit,
+                MenuItemKind.Create, ClassKind.PrefixedUnit));
         }
 
         /// <summary>
@@ -229,7 +239,8 @@ namespace BasicRdl.ViewModels
         {
             base.Initialize();
             var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
-            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
+            foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
+                .Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
                 foreach (var measurementUnit in referenceDataLibrary.Unit)
                 {

--- a/BasicRdl/ViewModels/ParameterTypeRowViewModel.cs
+++ b/BasicRdl/ViewModels/ParameterTypeRowViewModel.cs
@@ -48,6 +48,11 @@ namespace BasicRdl.ViewModels
         /// Backing field for the is base quantity kind.
         /// </summary>
         private bool isBaseQuantityKind;
+
+        /// <summary>
+        /// Backing field for the <see cref="IsFavorite"/> property
+        /// </summary>
+        private bool isFavorite;
         
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterTypeRowViewModel"/> class.
@@ -125,6 +130,22 @@ namespace BasicRdl.ViewModels
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the item that is represented by the current row-view-model is marked as favorite
+        /// </summary>
+        public bool IsFavorite
+        {
+            get
+            {
+                return this.isFavorite;
+            }
+
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.isFavorite, value);
+            }
+        }
+
+        /// <summary>
         /// Updates the properties of the current view-model
         /// </summary>
         private void UpdateProperties()
@@ -134,6 +155,21 @@ namespace BasicRdl.ViewModels
             this.ContainerRdl = container == null ? string.Empty : container.ShortName;
             var quantityKind = this.Thing as QuantityKind;
             this.IsBaseQuantityKind = container != null && (quantityKind != null && container.BaseQuantityKind.Contains(quantityKind));
+
+            // random favorites
+            this.IsFavorite = new Random().Next(100) <= 30;
+            this.UpdateThingStatus();
+        }
+
+        /// <summary>
+        /// Update the <see cref="ThingStatus"/> property
+        /// </summary>
+        protected override void UpdateThingStatus()
+        {
+            this.ThingStatus = new ThingStatus(this.Thing)
+            {
+                IsFavorite = this.IsFavorite
+            };
         }
 
         /// <summary>
@@ -194,6 +230,8 @@ namespace BasicRdl.ViewModels
             base.ObjectChangeEventHandler(objectChange);
             this.UpdateProperties();
         }
+
+        
 
         /// <summary>
         /// Queries whether a drag can be started

--- a/BasicRdl/ViewModels/ParameterTypeRowViewModel.cs
+++ b/BasicRdl/ViewModels/ParameterTypeRowViewModel.cs
@@ -155,9 +155,17 @@ namespace BasicRdl.ViewModels
             this.ContainerRdl = container == null ? string.Empty : container.ShortName;
             var quantityKind = this.Thing as QuantityKind;
             this.IsBaseQuantityKind = container != null && (quantityKind != null && container.BaseQuantityKind.Contains(quantityKind));
+            
+            this.UpdateThingStatus();
+        }
 
-            // random favorites
-            this.IsFavorite = new Random().Next(100) <= 30;
+        /// <summary>
+        /// Set the favorite status of the row.
+        /// </summary>
+        /// <param name="status">True if should be marked as favorite.</param>
+        public void SetFavoriteStatus(bool status)
+        {
+            this.IsFavorite = status;
             this.UpdateThingStatus();
         }
 
@@ -230,9 +238,7 @@ namespace BasicRdl.ViewModels
             base.ObjectChangeEventHandler(objectChange);
             this.UpdateProperties();
         }
-
         
-
         /// <summary>
         /// Queries whether a drag can be started
         /// </summary>
@@ -245,8 +251,7 @@ namespace BasicRdl.ViewModels
         /// </remarks>
         public override void StartDrag(IDragInfo dragInfo)
         {
-            var quantityKind = this.Thing as QuantityKind;
-            var scale = quantityKind != null ? quantityKind.DefaultScale : null;
+            var scale = this.Thing is QuantityKind quantityKind ? quantityKind.DefaultScale : null;
 
             var payload = new Tuple<ParameterType, MeasurementScale>(this.Thing, scale);
             dragInfo.Payload = payload;
@@ -283,8 +288,7 @@ namespace BasicRdl.ViewModels
         /// </param>
         public async Task Drop(IDropInfo dropInfo)
         {
-            var category = dropInfo.Payload as Category;
-            if (category != null)
+            if (dropInfo.Payload is Category category)
             {
                 await this.Drop(category);
                 return;

--- a/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
@@ -139,7 +139,12 @@ namespace BasicRdl.ViewModels
         /// Gets the <see cref="ReactiveCommand"/> used to create a <see cref="ArrayParameterType"/>
         /// </summary>
         public ReactiveCommand<object> CreateArrayParameterType { get; private set; }
-        
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> used to toggle the state of <see cref="IsFavorite"/> for a perticulat row.
+        /// </summary>
+        public ReactiveCommand<object> ToggleFavoriteCommand { get; private set; }
+
         /// <summary>
         /// Add the necessary subscriptions for this view model.
         /// </summary>
@@ -209,6 +214,9 @@ namespace BasicRdl.ViewModels
 
             this.CreateArrayParameterType = ReactiveCommand.Create(this.WhenAnyValue(vm => vm.CanCreateParameterType));
             this.CreateArrayParameterType.Subscribe(_ => this.ExecuteCreateCommand<ArrayParameterType>());
+
+            this.ToggleFavoriteCommand = ReactiveCommand.Create();
+            this.ToggleFavoriteCommand.Subscribe(_ => this.ExecuteToggleFavoriteCommand());
         }
 
         /// <summary>
@@ -227,6 +235,11 @@ namespace BasicRdl.ViewModels
         {
             base.PopulateContextMenu();
 
+            if (this.SelectedThing is ParameterTypeRowViewModel selectedParameterTypeRow)
+            {
+                this.ContextMenu.Add(new ContextMenuItemViewModel(!selectedParameterTypeRow.IsFavorite ? "Add to Favorites" : "Remove from Favorites", "", this.ToggleFavoriteCommand, MenuItemKind.Favorite));
+            }
+
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create an Array Parameter Type", "", this.CreateArrayParameterType, MenuItemKind.Create, ClassKind.ArrayParameterType));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Boolean Parameter Type", "", this.CreateBooleanParameterType, MenuItemKind.Create, ClassKind.BooleanParameterType));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Compound Parameter Type", "", this.CreateCompoundParameterType, MenuItemKind.Create, ClassKind.CompoundParameterType));
@@ -238,6 +251,19 @@ namespace BasicRdl.ViewModels
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Specialized Quantity Kind", "", this.CreateSpecializedQuantityKind, MenuItemKind.Create, ClassKind.SpecializedQuantityKind));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Text Parameter Type", "", this.CreateTextParameterType, MenuItemKind.Create, ClassKind.TextParameterType));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Time of Day Parameter Type", "", this.CreateTimeOfDayParameterType, MenuItemKind.Create, ClassKind.TimeOfDayParameterType));
+        }
+
+        /// <summary>
+        /// Execute the <see cref="ToggleFavoriteCommand"/>
+        /// </summary>
+        private void ExecuteToggleFavoriteCommand()
+        {
+            if (this.SelectedThing == null)
+            {
+                return;
+            }
+
+            //this.ExecuteDeleteCommand(this.SelectedThing.Thing);
         }
 
         /// <summary>

--- a/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
@@ -87,8 +87,6 @@ namespace BasicRdl.ViewModels
             this.RefreshFavorites(
                 this.favoritesService.GetFavoriteItemsCollectionByType(this.Session, typeof(ParameterType)));
 
-            this.WhenAnyValue(vm => vm.ShowOnlyFavorites).Subscribe(_ => this.ExecuteToggleShowFavoriteCommand());
-
             this.AddSubscriptions();
         }
 
@@ -188,6 +186,9 @@ namespace BasicRdl.ViewModels
         /// </summary>
         private void AddSubscriptions()
         {
+            var favoritesToggleListener = this.WhenAnyValue(vm => vm.ShowOnlyFavorites).Subscribe(_ => this.ExecuteToggleShowFavoriteCommand());
+            this.Disposables.Add(favoritesToggleListener);
+
             var addListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ParameterType))
                     .Where(objectChange => objectChange.EventKind == EventKind.Added &&

--- a/BasicRdl/ViewModels/ReferenceSourceBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ReferenceSourceBrowserViewModel.cs
@@ -27,7 +27,7 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// The purpose of the <see cref="ReferenceSourceBrowserViewModel"/> is to represent the view-model for <see cref="ReferenceSource"/>s
     /// </summary>
-    public class ReferenceSourceBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget
+    public class ReferenceSourceBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDropTarget, IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The NLog logger
@@ -236,7 +236,7 @@ namespace BasicRdl.ViewModels
         ///  Information about the drag operation.
         /// </param>
         /// <remarks>
-        /// To allow a drop at the current drag position, the <see cref="DropInfo.Effects"/> property on 
+        /// To allow a drop at the current drag position, the <see cref="DropInfo.Effects"/> property on
         /// <paramref name="dropInfo"/> should be set to a value other than <see cref="DragDropEffects.None"/>
         /// and <see cref="DropInfo.Payload"/> should be set to a non-null value.
         /// </remarks>

--- a/BasicRdl/ViewModels/Ribbons/ParameterTypeRibbonViewModel.cs
+++ b/BasicRdl/ViewModels/Ribbons/ParameterTypeRibbonViewModel.cs
@@ -12,13 +12,15 @@ namespace BasicRdl.ViewModels
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+    using CDP4Composition.Services.FavoritesService;
     using CDP4Dal;
     using NLog;
+    using Views;
 
     /// <summary>
     /// The view-model for the <see cref="ParameterTypeRibbon"/> view
     /// </summary>
-    public class ParameterTypeRibbonViewModel : RibbonButtonSessionDependentViewModel
+    public class ParameterTypeRibbonViewModel : RibbonButtonSessionFavoritesDependentViewModel
     {
         /// <summary>
         /// The logger for the current class
@@ -40,11 +42,13 @@ namespace BasicRdl.ViewModels
         /// <param name="thingDialogNavigationService">The <see cref="IThingDialogNavigationService"/></param>
         /// <param name="panelNavigationService">The <see cref="IPanelNavigationService"/></param>
         /// <param name="dialogNavigationService">The <see cref="IDialogNavigationService"/></param>
+        /// <param name="pluginSettingsService">The <see cref="IPluginSettingsService"/></param>
+        /// <param name="favoritesService">The <see cref="IFavoritesService"/></param>
         /// <returns>An instance of the <see cref="ParameterTypesBrowserViewModel"/> class</returns>
-        public static IPanelViewModel InstantiatePanelViewModel(ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+        public static IPanelViewModel InstantiatePanelViewModel(ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService, IFavoritesService favoritesService)
         {
             var stopWatch = Stopwatch.StartNew();
-            var viewModel = new ParameterTypesBrowserViewModel(session, session.RetrieveSiteDirectory(), thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var viewModel = new ParameterTypesBrowserViewModel(session, session.RetrieveSiteDirectory(), thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService, favoritesService);
             stopWatch.Stop();
             Logger.Info("The ParameterTypesBrowserViewModel opened in {0} [ms]", stopWatch.Elapsed);
             return viewModel;

--- a/BasicRdl/ViewModels/RulesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/RulesBrowserViewModel.cs
@@ -23,7 +23,7 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// The purpose of the <see cref="RulesBrowserViewModel"/> is to represent the view-model for <see cref="Rule"/>s
     /// </summary>
-    public class RulesBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class RulesBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The Panel Caption
@@ -106,7 +106,7 @@ namespace BasicRdl.ViewModels
         /// Gets the <see cref="ReactiveCommand"/> used to create a <see cref="ReferencerRule"/>
         /// </summary>
         public ReactiveCommand<object> CreateReferencerRule { get; private set; }
-        
+
         /// <summary>
         /// Add the necessary subscriptions for this view model.
         /// </summary>

--- a/BasicRdl/ViewModels/UnitPrefixBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/UnitPrefixBrowserViewModel.cs
@@ -23,7 +23,7 @@ namespace BasicRdl.ViewModels
     /// <summary>
     /// The purpose of the <see cref="UnitPrefixBrowserViewModel"/> is to represent the view-model for <see cref="UnitPrefix"/>es
     /// </summary>
-    public class UnitPrefixBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class UnitPrefixBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The Panel Caption

--- a/BasicRdl/Views/CategoryBrowser.xaml
+++ b/BasicRdl/Views/CategoryBrowser.xaml
@@ -57,6 +57,7 @@
                                HorizontalAlignment="Stretch"
                                VerticalAlignment="Stretch"
                                AllowColumnMoving="True"
+                               RowStyle="{StaticResource RowStyleDeprecatedHighlighted}"
                                AllowEditing="False"
                                AllowGrouping="True"
                                ShowFilterPanelMode="Never"
@@ -69,11 +70,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
@@ -93,7 +89,7 @@
                         </ControlTemplate>
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
-                <dxg:GridColumn FieldName="Name" Header="Name" />
+                <dxg:GridColumn FieldName="Name" Header="Name" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn FieldName="SuperCategories" Header="Super Categories" />
                 <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />

--- a/BasicRdl/Views/CategoryBrowser.xaml.cs
+++ b/BasicRdl/Views/CategoryBrowser.xaml.cs
@@ -8,15 +8,15 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
-    using CDP4Composition.Services;
-
+    using CDP4Composition.Navigation.Interfaces;
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for <see cref="CategoryBrowser"/>
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class CategoryBrowser : IPanelView
+    public partial class CategoryBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -47,8 +47,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.CategoriesGridControl);
+                this.Control = this.CategoriesGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/CategoryBrowser.xaml.cs
+++ b/BasicRdl/Views/CategoryBrowser.xaml.cs
@@ -47,13 +47,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.CategoriesGridControl;
+                this.FilterableControl = this.CategoriesGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/ConstantsBrowser.xaml
+++ b/BasicRdl/Views/ConstantsBrowser.xaml
@@ -62,6 +62,7 @@
                                AllowEditing="False"
                                AllowGrouping="True"
                                AutoWidth="true"
+                               RowStyle="{StaticResource RowStyleDeprecated}"
                                IsDetailButtonVisibleBinding="{x:Null}"
                                ShowGroupPanel="False">
                     <dxg:TableView.FocusedRow>
@@ -70,11 +71,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
@@ -93,7 +89,7 @@
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
 
-                <dxg:GridColumn FieldName="Name" Header="Name" />
+                <dxg:GridColumn FieldName="Name" Header="Name" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn FieldName="Value" Header="Value" />
                 <dxg:GridColumn Binding="{Binding SelectedScale.ShortName}" Header="Scale" />

--- a/BasicRdl/Views/ConstantsBrowser.xaml.cs
+++ b/BasicRdl/Views/ConstantsBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for ConstantsBrowser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class ConstantsBrowser : IPanelView
+    public partial class ConstantsBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.ConstantsGridControl);
+                this.Control = this.ConstantsGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/ConstantsBrowser.xaml.cs
+++ b/BasicRdl/Views/ConstantsBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.ConstantsGridControl;
+                this.FilterableControl = this.ConstantsGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/FileTypeBrowser.xaml
+++ b/BasicRdl/Views/FileTypeBrowser.xaml
@@ -61,6 +61,7 @@
                                AllowEditing="False"
                                ShowFilterPanelMode="Never"
                                AllowGrouping="True"
+                               RowStyle="{StaticResource RowStyleDeprecated}"
                                AutoWidth="true"
                                IsDetailButtonVisibleBinding="{x:Null}"
                                ShowGroupPanel="False">
@@ -70,11 +71,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
@@ -92,7 +88,7 @@
                         </ControlTemplate>
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
-                <dxg:GridColumn FieldName="Name" />
+                <dxg:GridColumn FieldName="Name" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn FieldName="Extension" />
                 <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />

--- a/BasicRdl/Views/FileTypeBrowser.xaml.cs
+++ b/BasicRdl/Views/FileTypeBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.FileTypeGridControl;
+                this.FilterableControl = this.FileTypeGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/FileTypeBrowser.xaml.cs
+++ b/BasicRdl/Views/FileTypeBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for FileTypeBrowser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class FileTypeBrowser : IPanelView
+    public partial class FileTypeBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.FileTypeGridControl);
+                this.Control = this.FileTypeGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/GlossaryBrowser.xaml
+++ b/BasicRdl/Views/GlossaryBrowser.xaml
@@ -99,7 +99,7 @@
                     <cdp4Composition:ContextMenuBehavior />
                 </dxmvvm:Interaction.Behaviors>
                 <dxg:TreeListControl.Columns>
-                    <dxg:TreeListColumn FieldName="Name" />
+                    <dxg:TreeListColumn FieldName="Name" SortIndex="0" />
                     <dxg:TreeListColumn FieldName="ShortName" />
                     <dxg:TreeListColumn FieldName="ContainerRdlShortName" Header="Reference Data Library" />
                     <dxg:TreeListColumn FieldName="DefinitionValue" Header="Value" />
@@ -116,17 +116,14 @@
                                   ShowIndicator="False"
                                   ShowNodeImages="False"
                                   ShowVerticalLines="False"
+                                  RowStyle="{StaticResource RowStyleDeprecated}"
                                   TreeDerivationMode="HierarchicalDataTemplate"
                                   TreeLineStyle="Solid"
                                   VerticalScrollbarVisibility="Auto">
                         <dxg:TreeListView.ContextMenu>
                             <ContextMenu Name="RowContextMenu" />
                         </dxg:TreeListView.ContextMenu>
-                        <dxg:TreeListView.RowStyle>
-                            <Style TargetType="{x:Type dxg:RowControl}">
-                                <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                            </Style>
-                        </dxg:TreeListView.RowStyle>
+                        
                     </dxg:TreeListView>
                 </dxg:TreeListControl.View>
 

--- a/BasicRdl/Views/GlossaryBrowser.xaml.cs
+++ b/BasicRdl/Views/GlossaryBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for GlossaryBrowser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class GlossaryBrowser : IPanelView
+    public partial class GlossaryBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddTreeListControl(this.GlossaryTreeListControl);
+                this.Control = this.GlossaryTreeListControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/GlossaryBrowser.xaml.cs
+++ b/BasicRdl/Views/GlossaryBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.GlossaryTreeListControl;
+                this.FilterableControl = this.GlossaryTreeListControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/MeasurementScalesBrowser.xaml
+++ b/BasicRdl/Views/MeasurementScalesBrowser.xaml
@@ -60,7 +60,7 @@
                                AllowColumnMoving="True"
                                ShowFilterPanelMode="Never"
                                AllowEditing="False"
-                               ShowSearchPanelMode="Always"
+                               ShowSearchPanelMode="Default"
                                AllowGrouping="True"
                                AutoWidth="true"
                                IsDetailButtonVisibleBinding="{x:Null}"
@@ -107,10 +107,10 @@
 
                 <dxg:GridColumn FieldName="Name" SortMode="Value" SortIndex="0" Header="Name" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
-                <dxg:GridColumn FieldName="ClassKind" GroupIndex="1" Header="Type" />
+                <dxg:GridColumn FieldName="ClassKind" Header="Type" />
                 <dxg:GridColumn FieldName="NumberSet" Header="Number Set" />
                 <dxg:GridColumn FieldName="MeasurementUnit" Header="Unit" />
-                <dxg:GridColumn FieldName="ContainerRdl" GroupIndex="0" Header="Container RDL" />
+                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />
             </dxg:GridControl.Columns>
             <dxg:GridControl.InputBindings>
                 <KeyBinding Gesture="CTRL+I" Command="{Binding Path=InspectCommand}"></KeyBinding>

--- a/BasicRdl/Views/MeasurementScalesBrowser.xaml
+++ b/BasicRdl/Views/MeasurementScalesBrowser.xaml
@@ -38,6 +38,7 @@
         <dxg:GridControl Grid.Row="2"
                          AllowLiveDataShaping="False"
                          Name="MeasurementScalesGridControl"
+                         AutoExpandAllGroups="True"
                          ItemsSource="{Binding MeasurementScales}"
                          SelectedItem="{Binding SelectedThing,
                                                 Mode=TwoWay,
@@ -59,6 +60,7 @@
                                AllowColumnMoving="True"
                                ShowFilterPanelMode="Never"
                                AllowEditing="False"
+                               ShowSearchPanelMode="Always"
                                AllowGrouping="True"
                                AutoWidth="true"
                                IsDetailButtonVisibleBinding="{x:Null}"
@@ -103,12 +105,12 @@
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
 
-                <dxg:GridColumn FieldName="Name" Header="Name" />
+                <dxg:GridColumn FieldName="Name" SortMode="Value" SortIndex="0" Header="Name" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
-                <dxg:GridColumn FieldName="ClassKind" Header="Type" />
+                <dxg:GridColumn FieldName="ClassKind" GroupIndex="1" Header="Type" />
                 <dxg:GridColumn FieldName="NumberSet" Header="Number Set" />
                 <dxg:GridColumn FieldName="MeasurementUnit" Header="Unit" />
-                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />
+                <dxg:GridColumn FieldName="ContainerRdl" GroupIndex="0" Header="Container RDL" />
             </dxg:GridControl.Columns>
             <dxg:GridControl.InputBindings>
                 <KeyBinding Gesture="CTRL+I" Command="{Binding Path=InspectCommand}"></KeyBinding>

--- a/BasicRdl/Views/MeasurementScalesBrowser.xaml.cs
+++ b/BasicRdl/Views/MeasurementScalesBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for MeasurementScalesBrowser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class MeasurementScalesBrowser : IPanelView
+    public partial class MeasurementScalesBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.MeasurementScalesGridControl);
+                this.Control = this.MeasurementScalesGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/MeasurementScalesBrowser.xaml.cs
+++ b/BasicRdl/Views/MeasurementScalesBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.MeasurementScalesGridControl;
+                this.FilterableControl = this.MeasurementScalesGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/MeasurementUnitsBrowser.xaml
+++ b/BasicRdl/Views/MeasurementUnitsBrowser.xaml
@@ -62,7 +62,7 @@
                                ShowFilterPanelMode="Never"
                                AllowGrouping="True"
                                AutoWidth="true"
-                               ShowSearchPanelMode="Always"
+                               ShowSearchPanelMode="Default"
                                IsDetailButtonVisibleBinding="{x:Null}"
                                ShowGroupPanel="False">
                     <dxg:TableView.FocusedRow>
@@ -107,8 +107,8 @@
 
                 <dxg:GridColumn FieldName="Name" SortMode="Value" SortIndex="1" Header="Name" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
-                <dxg:GridColumn FieldName="ClassKind" Header="Type" GroupIndex="1" />
-                <dxg:GridColumn FieldName="ContainerRdl" GroupIndex="0" Header="Container RDL" />
+                <dxg:GridColumn FieldName="ClassKind" Header="Type" />
+                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />
             </dxg:GridControl.Columns>
 
             <dxg:GridControl.InputBindings>

--- a/BasicRdl/Views/MeasurementUnitsBrowser.xaml
+++ b/BasicRdl/Views/MeasurementUnitsBrowser.xaml
@@ -37,6 +37,7 @@
 
         <dxg:GridControl Grid.Row="2"
                          AllowLiveDataShaping="False"
+                         AutoExpandAllGroups="True"
                          Name="MeasurementUnitGridControl"
                          ItemsSource="{Binding MeasurementUnits}"
                          SelectedItem="{Binding SelectedThing,
@@ -61,6 +62,7 @@
                                ShowFilterPanelMode="Never"
                                AllowGrouping="True"
                                AutoWidth="true"
+                               ShowSearchPanelMode="Always"
                                IsDetailButtonVisibleBinding="{x:Null}"
                                ShowGroupPanel="False">
                     <dxg:TableView.FocusedRow>
@@ -103,10 +105,10 @@
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
 
-                <dxg:GridColumn FieldName="Name" Header="Name" />
+                <dxg:GridColumn FieldName="Name" SortMode="Value" SortIndex="1" Header="Name" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
-                <dxg:GridColumn FieldName="ClassKind" Header="Type" />
-                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />
+                <dxg:GridColumn FieldName="ClassKind" Header="Type" GroupIndex="1" />
+                <dxg:GridColumn FieldName="ContainerRdl" GroupIndex="0" Header="Container RDL" />
             </dxg:GridControl.Columns>
 
             <dxg:GridControl.InputBindings>

--- a/BasicRdl/Views/MeasurementUnitsBrowser.xaml.cs
+++ b/BasicRdl/Views/MeasurementUnitsBrowser.xaml.cs
@@ -48,13 +48,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.MeasurementUnitGridControl;
+                this.FilterableControl = this.MeasurementUnitGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/MeasurementUnitsBrowser.xaml.cs
+++ b/BasicRdl/Views/MeasurementUnitsBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for <see cref="MeasurementUnitsBrowser"/>
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class MeasurementUnitsBrowser : IPanelView
+    public partial class MeasurementUnitsBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -47,8 +48,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.MeasurementUnitGridControl);
+                this.Control = this.MeasurementUnitGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/ParameterTypesBrowser.xaml
+++ b/BasicRdl/Views/ParameterTypesBrowser.xaml
@@ -31,7 +31,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <views:CommonThingControl GridView="{Binding ElementName=View}" IsFavoriteToggleEnabled="True" />
+        <views:CommonThingControl GridView="{Binding ElementName=View}" IsFavoriteToggleVisible="True" />
 
         <views:SessionHeader Grid.Row="1" />
 

--- a/BasicRdl/Views/ParameterTypesBrowser.xaml
+++ b/BasicRdl/Views/ParameterTypesBrowser.xaml
@@ -31,7 +31,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <views:CommonThingControl GridView="{Binding ElementName=View}" />
+        <views:CommonThingControl GridView="{Binding ElementName=View}" IsFavoriteToggleEnabled="True" />
 
         <views:SessionHeader Grid.Row="1" />
 
@@ -64,6 +64,7 @@
                                AllowGrouping="True"
                                AutoWidth="true"
                                ShowFilterPanelMode="Never"
+                               RowStyle="{StaticResource RowStyleDeprecatedHighlightedBaseQuantityKind}"
                                IsDetailButtonVisibleBinding="{x:Null}"
                                ShowGroupPanel="False"
                                ShowSearchPanelMode="Always">
@@ -73,23 +74,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding Path=Row.IsBaseQuantityKind}" Value="True">
-                                    <Setter Property="FontWeight" Value="Bold" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Path=Row.IsDeprecated}" Value="True">
-                                    <Setter Property="Background" Value="LightGray" />
-                                    <Setter Property="Opacity" Value="0.5" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Path=Row.IsHighlighted}" Value="True">
-                                    <Setter Property="Background" Value="Yellow" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
@@ -114,9 +98,9 @@
                 <dxg:GridColumn FieldName="Name" Header="Name" SortMode="Value" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn FieldName="Symbol" Header="Symbol" />
-                <dxg:GridColumn FieldName="Type" Header="Type" GroupIndex="1" />
-                <dxg:GridColumn FieldName="DefaultScale" Header="Default Scale" />
-                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" GroupIndex="0" />
+                <dxg:GridColumn FieldName="DefaultScale" Header="Default Scale"/>
+                <dxg:GridColumn FieldName="Type" Header="Type" />
+                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL"/>
             </dxg:GridControl.Columns>
 
             <dxg:GridControl.InputBindings>

--- a/BasicRdl/Views/ParameterTypesBrowser.xaml
+++ b/BasicRdl/Views/ParameterTypesBrowser.xaml
@@ -20,7 +20,7 @@
         <ResourceDictionary>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
@@ -43,6 +43,7 @@
                          SelectedItem="{Binding SelectedThing,
                                                 Mode=TwoWay,
                                                 UpdateSourceTrigger=PropertyChanged}"
+
                          SelectionMode="Row"
                          services:GridUpdateService.UpdateStarted="{Binding HasUpdateStarted,
                                                                             Mode=OneWay,
@@ -65,7 +66,7 @@
                                ShowFilterPanelMode="Never"
                                IsDetailButtonVisibleBinding="{x:Null}"
                                ShowGroupPanel="False"
-                               ShowSearchPanelMode="Default">
+                               ShowSearchPanelMode="Always">
                     <dxg:TableView.FocusedRow>
                         <dynamic:ExpandoObject />
                     </dxg:TableView.FocusedRow>
@@ -79,11 +80,11 @@
                                     <Setter Property="FontWeight" Value="Bold" />
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding Path=Row.IsDeprecated}" Value="True">
-                                    <Setter Property="Background" Value="LightGray"/>
-                                    <Setter Property="Opacity" Value="0.5"/>
+                                    <Setter Property="Background" Value="LightGray" />
+                                    <Setter Property="Opacity" Value="0.5" />
                                 </DataTrigger>
                                 <DataTrigger Binding="{Binding Path=Row.IsHighlighted}" Value="True">
-                                    <Setter Property="Background" Value="Yellow"/>
+                                    <Setter Property="Background" Value="Yellow" />
                                 </DataTrigger>
                             </Style.Triggers>
                             <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
@@ -92,7 +93,6 @@
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
-
                 <dxg:GridColumn Width="18"
                                 MinWidth="18"
                                 Fixed="Left"
@@ -102,7 +102,8 @@
                             <Image Width="16" Height="16">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
+                                        <Binding Path="DataContext.Row.ThingStatus"
+                                                 RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
                                     </MultiBinding>
                                 </Image.Source>
                             </Image>
@@ -110,17 +111,17 @@
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
 
-                <dxg:GridColumn FieldName="Name" Header="Name" />
+                <dxg:GridColumn FieldName="Name" Header="Name" SortMode="Value" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn FieldName="Symbol" Header="Symbol" />
-                <dxg:GridColumn FieldName="Type" Header="Type" />
-                <dxg:GridColumn FieldName="DefaultScale" Header="Default scale" />
-                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />
+                <dxg:GridColumn FieldName="Type" Header="Type" GroupIndex="1" />
+                <dxg:GridColumn FieldName="DefaultScale" Header="Default Scale" />
+                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" GroupIndex="0" />
             </dxg:GridControl.Columns>
 
             <dxg:GridControl.InputBindings>
-                <KeyBinding Gesture="CTRL+I" Command="{Binding Path=InspectCommand}"></KeyBinding>
-                <KeyBinding Gesture="CTRL+E" Command="{Binding Path=UpdateCommand}"></KeyBinding>
+                <KeyBinding Gesture="CTRL+I" Command="{Binding Path=InspectCommand}" />
+                <KeyBinding Gesture="CTRL+E" Command="{Binding Path=UpdateCommand}" />
             </dxg:GridControl.InputBindings>
         </dxg:GridControl>
     </Grid>

--- a/BasicRdl/Views/ParameterTypesBrowser.xaml.cs
+++ b/BasicRdl/Views/ParameterTypesBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.ParameterTypesGridControl;
+                this.FilterableControl = this.ParameterTypesGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/ParameterTypesBrowser.xaml.cs
+++ b/BasicRdl/Views/ParameterTypesBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for Parameter types browser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class ParameterTypesBrowser : IPanelView
+    public partial class ParameterTypesBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.ParameterTypesGridControl);
+                this.Control = this.ParameterTypesGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/ReferenceSourceBrowser.xaml
+++ b/BasicRdl/Views/ReferenceSourceBrowser.xaml
@@ -59,6 +59,7 @@
                                VerticalAlignment="Stretch"
                                AllowColumnMoving="True"
                                ShowFilterPanelMode="Never"
+                               RowStyle="{StaticResource RowStyleDeprecated}"
                                AllowEditing="False"
                                AllowGrouping="True"
                                AutoWidth="true"
@@ -70,11 +71,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
@@ -92,7 +88,7 @@
                         </ControlTemplate>
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
-                <dxg:GridColumn FieldName="Name" />
+                <dxg:GridColumn FieldName="Name" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn FieldName="Publisher.ShortName" Header="Publisher" />
                 <dxg:GridColumn FieldName="VersionIdentifier" Header="Version" />

--- a/BasicRdl/Views/ReferenceSourceBrowser.xaml.cs
+++ b/BasicRdl/Views/ReferenceSourceBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for ReferenceSourceBrowser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class ReferenceSourceBrowser : IPanelView
+    public partial class ReferenceSourceBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.ReferenceSourceGridControl);
+                this.Control = this.ReferenceSourceGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/ReferenceSourceBrowser.xaml.cs
+++ b/BasicRdl/Views/ReferenceSourceBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.ReferenceSourceGridControl;
+                this.FilterableControl = this.ReferenceSourceGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/Ribbons/BasicRdlRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/BasicRdlRibbon.xaml
@@ -31,3 +31,4 @@
     </dxr:RibbonPageGroup>
 
 </ribbon:ExtendedRibbonPage>
+    

--- a/BasicRdl/Views/Ribbons/BasicRdlRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/BasicRdlRibbon.xaml
@@ -5,22 +5,29 @@
                            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                            xmlns:ribbon="clr-namespace:CDP4Composition.Ribbon;assembly=CDP4Composition"
                            xmlns:views="clr-namespace:BasicRdl.Views"
+                           xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
                            Name="BasicRdlRibbonPage"
                            Caption="Reference Data"
                            IsInDefaultPageCategory="True"
                            mc:Ignorable="d"
                            MergeOrder="2000">
 
-    <views:SiteRdlSelectionRibbon/>
-    <views:MeasurementScalesRibbon/>
-    <views:MeasurementUnitsRibbon/>
-    <views:UnitPrefixRibbon/>
-    <views:CategoryRibbon/>
-    <views:ParameterTypeRibbon/>
-    <views:RulesRibbon/>
-    <views:ConstantBrowserRibbon/>
-    <views:GlossaryBrowserRibbon/>
-    <views:FileTypeBrowserRibbon/>
-    <views:ReferenceSourceRibbon/>
-    
+    <views:SiteRdlSelectionRibbon />
+    <dxr:RibbonPageGroup Caption="Parameter Types">
+        <views:ParameterTypeRibbon />
+        <views:MeasurementScalesRibbon />
+        <views:MeasurementUnitsRibbon />
+    </dxr:RibbonPageGroup>
+    <dxr:RibbonPageGroup Caption="Categorization">
+        <views:CategoryRibbon />
+        <views:RulesRibbon />
+    </dxr:RibbonPageGroup>
+    <dxr:RibbonPageGroup Caption="References">
+        <views:UnitPrefixRibbon />
+        <views:ConstantBrowserRibbon />
+        <views:GlossaryBrowserRibbon />
+        <views:FileTypeBrowserRibbon />
+        <views:ReferenceSourceRibbon />
+    </dxr:RibbonPageGroup>
+
 </ribbon:ExtendedRibbonPage>

--- a/BasicRdl/Views/Ribbons/CategoryRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/CategoryRibbon.xaml
@@ -1,33 +1,31 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.CategoryRibbon"
-                                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                                xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                                ShowCaptionButton="False"
-                                mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowCategories"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Categories"
-                            Glyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/category_32x32.png"
-                            Hint="Manage Categories"
-                            LargeGlyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/category_32x32.png"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.CategoryRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        Name="ShowCategories"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Categories"
+                        Glyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/category_32x32.png"
+                        Hint="Manage Categories"
+                        LargeGlyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/category_32x32.png"
+                        RibbonStyle="Large"
+                        mc:Ignorable="d">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/CategoryRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/CategoryRibbon.xaml.cs
@@ -8,13 +8,14 @@ namespace BasicRdl.Views
 {
     using System.ComponentModel.Composition;
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for CategoryRibbon.xaml
     /// </summary>
     [Export(typeof(CategoryRibbon))]
-    public partial class CategoryRibbon : IView
+    public partial class CategoryRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CategoryRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/ConstantBrowserRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/ConstantBrowserRibbon.xaml
@@ -1,34 +1,32 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.ConstantBrowserRibbon"
-                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                    xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                    ShowCaptionButton="False"
-                    mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowConstantsButton"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Constants"
-                            Glyph="{dx:DXImage Image=RecentlyUse_16x16.png}"
-                            Hint="Manage Constants"
-                            LargeGlyph="{dx:DXImage Image=RecentlyUse_32x32.png}"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.ConstantBrowserRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        Name="ShowConstantsButton"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Constants"
+                        Glyph="{dx:DXImage Image=RecentlyUse_16x16.png}"
+                        Hint="Manage Constants"
+                        LargeGlyph="{dx:DXImage Image=RecentlyUse_32x32.png}"
+                        RibbonStyle="Large"
+                        mc:Ignorable="d">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/ConstantBrowserRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/ConstantBrowserRibbon.xaml.cs
@@ -7,12 +7,13 @@
 namespace BasicRdl.Views
 {
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for ConstantBrowserRibbon.xaml
     /// </summary>
-    public partial class ConstantBrowserRibbon : IView
+    public partial class ConstantBrowserRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstantBrowserRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/FileTypeBrowserRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/FileTypeBrowserRibbon.xaml
@@ -1,33 +1,31 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.FileTypeBrowserRibbon"
-                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                    xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                    ShowCaptionButton="False"
-                    mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-        <dxb:BarSplitButtonItem Name="ShowFileTypeButton"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="File Types"
-                            Glyph="{dx:DXImage Image=TextBox2_16x16.png}"
-                            Hint="Manage File Types"
-                            LargeGlyph="{dx:DXImage Image=TextBox2_32x32.png}"
-                            RibbonStyle="Large">
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.FileTypeBrowserRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        Name="ShowFileTypeButton"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="File Types"
+                        Glyph="{dx:DXImage Image=TextBox2_16x16.png}"
+                        Hint="Manage File Types"
+                        LargeGlyph="{dx:DXImage Image=TextBox2_32x32.png}"
+                        RibbonStyle="Large"
+                        mc:Ignorable="d">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/FileTypeBrowserRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/FileTypeBrowserRibbon.xaml.cs
@@ -7,12 +7,13 @@
 namespace BasicRdl.Views
 {
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for FileTypeBrowserRibbon.xaml
     /// </summary>
-    public partial class FileTypeBrowserRibbon : IView
+    public partial class FileTypeBrowserRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FileTypeBrowserRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/GlossaryBrowserRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/GlossaryBrowserRibbon.xaml
@@ -1,34 +1,32 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.GlossaryBrowserRibbon"
-                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                    xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                    ShowCaptionButton="False"
-                    mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowGlossariesButton"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Glossaries"
-                            Glyph="{dx:DXImage Image=Text_16x16.png}"
-                            Hint="Manage Glossaries"
-                            LargeGlyph="{dx:DXImage Image=Text_32x32.png}"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.GlossaryBrowserRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        Name="ShowGlossariesButton"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Glossaries"
+                        Glyph="{dx:DXImage Image=Text_16x16.png}"
+                        Hint="Manage Glossaries"
+                        LargeGlyph="{dx:DXImage Image=Text_32x32.png}"
+                        RibbonStyle="Large"
+                        mc:Ignorable="d">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/GlossaryBrowserRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/GlossaryBrowserRibbon.xaml.cs
@@ -7,12 +7,13 @@
 namespace BasicRdl.Views
 {
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for GlossaryBrowserRibbon.xaml
     /// </summary>
-    public partial class GlossaryBrowserRibbon : IView
+    public partial class GlossaryBrowserRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="GlossaryBrowserRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/MeasurementScalesRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/MeasurementScalesRibbon.xaml
@@ -1,34 +1,31 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.MeasurementScalesRibbon"
-                                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                                xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                                xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                                ShowCaptionButton="False"
-                                mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowMeasurementScales"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Measurement Scales"
-                            Glyph="{dx:DXImage Image=ChartYAxisSettings_16x16.png}"
-                            Hint="Manage Measurement Scales"
-                            LargeGlyph="{dx:DXImage Image=ChartYAxisSettings_32x32.png}"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.MeasurementScalesRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        mc:Ignorable="d"
+                        Name="ShowMeasurementScales"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Measurement Scales"
+                        Glyph="{dx:DXImage Image=ChartYAxisSettings_16x16.png}"
+                        Hint="Manage Measurement Scales"
+                        LargeGlyph="{dx:DXImage Image=ChartYAxisSettings_32x32.png}"
+                        RibbonStyle="Large">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/MeasurementScalesRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/MeasurementScalesRibbon.xaml.cs
@@ -8,13 +8,14 @@ namespace BasicRdl.Views
 {
     using System.ComponentModel.Composition;
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for MeaurementScalesRibbon.xaml
     /// </summary>
     [Export(typeof(MeasurementScalesRibbon))]
-    public partial class MeasurementScalesRibbon : IView
+    public partial class MeasurementScalesRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MeasurementScalesRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/MeasurementUnitsRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/MeasurementUnitsRibbon.xaml
@@ -1,33 +1,31 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.MeasurementUnitsRibbon"
-                                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                                xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                                ShowCaptionButton="False"
-                                mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowMeasurementUnits"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Measurement Units"
-                            Glyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/measurementunit_16x16.png"
-                            Hint="Manage Measurement Units"
-                            LargeGlyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/measurementunit_32x32.png"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.MeasurementUnitsRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        mc:Ignorable="d"
+                        Name="ShowMeasurementUnits"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Measurement Units"
+                        Glyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/measurementunit_16x16.png"
+                        Hint="Manage Measurement Units"
+                        LargeGlyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/measurementunit_32x32.png"
+                        RibbonStyle="Large">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/MeasurementUnitsRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/MeasurementUnitsRibbon.xaml.cs
@@ -8,13 +8,14 @@ namespace BasicRdl.Views
 {
     using System.ComponentModel.Composition;
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for MeasurementUnitsRibbon.xaml
     /// </summary>
     [Export(typeof(MeasurementUnitsRibbon))]
-    public partial class MeasurementUnitsRibbon : IView
+    public partial class MeasurementUnitsRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MeasurementUnitsRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/ParameterTypeRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/ParameterTypeRibbon.xaml
@@ -1,33 +1,32 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.ParameterTypeRibbon"
-                                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                                xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                                ShowCaptionButton="False"
-                                mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowParameterTypes"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Parameter Types"
-                            Glyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/parametertype_32x32.png"
-                            Hint="Manage Categories"
-                            LargeGlyph="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/parametertype_32x32.png"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.ParameterTypeRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        mc:Ignorable="d"
+                        Name="ShowParameterTypes"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Parameter Types"
+                        Glyph="{dx:DXImage Image=NameManager_16x16.png}"
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+                        Hint="Manage Parameter Types"
+                        LargeGlyph="{dx:DXImage Image=NameManager_32x32.png}"
+                        RibbonStyle="Large">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/ParameterTypeRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/ParameterTypeRibbon.xaml.cs
@@ -8,13 +8,14 @@ namespace BasicRdl.Views
 {
     using System.ComponentModel.Composition;
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for ParameterTypeRibbon.xaml
     /// </summary>
     [Export(typeof(ParameterTypeRibbon))]
-    public partial class ParameterTypeRibbon : IView
+    public partial class ParameterTypeRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterTypeRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/ReferenceSourceRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/ReferenceSourceRibbon.xaml
@@ -1,34 +1,32 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.ReferenceSourceRibbon"
-                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                    xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                    ShowCaptionButton="False"
-                    mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowReferenceSourceButton"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Reference Sources"
-                            Glyph="{dx:DXImage Image=Information_16x16.png}"
-                            Hint="Manage Reference Sources"
-                            LargeGlyph="{dx:DXImage Image=Information_32x32.png}"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.ReferenceSourceRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        Name="ShowReferenceSourceButton"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Reference Sources"
+                        Glyph="{dx:DXImage Image=Information_16x16.png}"
+                        Hint="Manage Reference Sources"
+                        LargeGlyph="{dx:DXImage Image=Information_32x32.png}"
+                        RibbonStyle="Large"
+                        mc:Ignorable="d">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/ReferenceSourceRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/ReferenceSourceRibbon.xaml.cs
@@ -6,13 +6,14 @@
 
 namespace BasicRdl.Views
 {
+    using DevExpress.Xpf.Bars;
     using ViewModels;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for ReferenceSourceRibbon view
     /// </summary>
-    public partial class ReferenceSourceRibbon : IView
+    public partial class ReferenceSourceRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReferenceSourceRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/RulesRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/RulesRibbon.xaml
@@ -1,34 +1,32 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.RulesRibbon"
-                                xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                                xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                                xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                                xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                                xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                                xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                                xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                                xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                                ShowCaptionButton="False"
-                                mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowRules"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            Content="Rules"
-                            Glyph="{dx:DXImage Image=WeightedPies_16x16.png}"
-                            Hint="Manage Rules"
-                            LargeGlyph="{dx:DXImage Image=WeightedPies_32x32.png}"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.RulesRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        Name="ShowRules"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        Content="Rules"
+                        Glyph="{dx:DXImage Image=WeightedPies_16x16.png}"
+                        Hint="Manage Rules"
+                        LargeGlyph="{dx:DXImage Image=WeightedPies_32x32.png}"
+                        RibbonStyle="Large"
+                        mc:Ignorable="d">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/RulesRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/RulesRibbon.xaml.cs
@@ -8,13 +8,14 @@ namespace BasicRdl.Views
 {
     using System.ComponentModel.Composition;
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for RulesRibbon.xaml
     /// </summary>
     [Export(typeof(RulesRibbon))]
-    public partial class RulesRibbon : IView
+    public partial class RulesRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RulesRibbon"/> class.

--- a/BasicRdl/Views/Ribbons/UnitPrefixRibbon.xaml
+++ b/BasicRdl/Views/Ribbons/UnitPrefixRibbon.xaml
@@ -1,34 +1,33 @@
-﻿<dxr:RibbonPageGroup x:Class="BasicRdl.Views.UnitPrefixRibbon"
-                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                    xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-                    xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
-                    xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-                    ShowCaptionButton="False"
-                    mc:Ignorable="d">
-        <dxr:RibbonPageGroup.Resources>
-            <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
-                <ContentControl>
-                    <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
-                                      Content="{Binding MenuItemContent}"
-                                      IsChecked="{Binding Path=IsChecked}" />
-                </ContentControl>
-            </DataTemplate>
-        </dxr:RibbonPageGroup.Resources>
-    <dxb:BarSplitButtonItem Name="ShowUnitPrefixButton"
-                            Command="{Binding OpenSingleBrowserCommand}"
-                            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
-                            Content="Unit Prefixes"
-                            Glyph="{dx:DXImage Image=VerticalAxisThousands_16x16.png}"
-                            Hint="Manage Unit Prefixes"
-                            LargeGlyph="{dx:DXImage Image=VerticalAxisThousands_32x32.png}"
-                            RibbonStyle="Large">
+﻿<dxb:BarSplitButtonItem x:Class="BasicRdl.Views.UnitPrefixRibbon"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                        xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
+                        xmlns:dxr="http://schemas.devexpress.com/winfx/2008/xaml/ribbon"
+                        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                        xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm;assembly=CDP4Composition"
+                        xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+                        mc:Ignorable="d"
+                        Name="ShowUnitPrefixButton"
+                        Command="{Binding OpenSingleBrowserCommand}"
+                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
+                        Content="Unit Prefixes"
+                        Glyph="{dx:DXImage Image=VerticalAxisThousands_16x16.png}"
+                        Hint="Manage Unit Prefixes"
+                        LargeGlyph="{dx:DXImage Image=VerticalAxisThousands_32x32.png}"
+                        RibbonStyle="Large">
+    <dxb:BarSplitButtonItem.Resources>
+        <DataTemplate DataType="{x:Type mvvm:RibbonMenuItemViewModelBase}">
+            <ContentControl>
+                <dxb:BarCheckItem Command="{Binding Path=ShowOrClosePanelCommand}"
+                                  Content="{Binding MenuItemContent}"
+                                  IsChecked="{Binding Path=IsChecked}" />
+            </ContentControl>
+        </DataTemplate>
+    </dxb:BarSplitButtonItem.Resources>
 
-        <dxb:BarSplitButtonItem.PopupControl>
-            <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
-        </dxb:BarSplitButtonItem.PopupControl>
-    </dxb:BarSplitButtonItem>
-</dxr:RibbonPageGroup>
+    <dxb:BarSplitButtonItem.PopupControl>
+        <dxb:PopupMenu ItemLinksSource="{Binding OpenSessions}" />
+    </dxb:BarSplitButtonItem.PopupControl>
+
+</dxb:BarSplitButtonItem>

--- a/BasicRdl/Views/Ribbons/UnitPrefixRibbon.xaml.cs
+++ b/BasicRdl/Views/Ribbons/UnitPrefixRibbon.xaml.cs
@@ -7,12 +7,13 @@
 namespace BasicRdl.Views
 {
     using BasicRdl.ViewModels;
+    using DevExpress.Xpf.Bars;
     using Microsoft.Practices.Prism.Mvvm;
 
     /// <summary>
     /// Interaction logic for UnitPrefixRibbon view
     /// </summary>
-    public partial class UnitPrefixRibbon : IView
+    public partial class UnitPrefixRibbon : IView, IBarItem
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnitPrefixRibbon"/> class.

--- a/BasicRdl/Views/RulesBrowser.xaml
+++ b/BasicRdl/Views/RulesBrowser.xaml
@@ -62,6 +62,7 @@
                                AllowColumnMoving="True"
                                AllowEditing="False"
                                AllowGrouping="True"
+                               RowStyle="{StaticResource RowStyleDeprecated}"
                                AutoWidth="true"
                                ShowFilterPanelMode="Never"
                                IsDetailButtonVisibleBinding="{x:Null}"
@@ -73,11 +74,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
@@ -99,7 +95,7 @@
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
 
-                <dxg:GridColumn FieldName="Name" Header="Name" />
+                <dxg:GridColumn FieldName="Name" Header="Name" SortIndex="0"/>
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn Binding="{Binding Path=RowData.Row.ClassKind,
                                                   Converter={StaticResource CamelCaseToSpaceConverter}}"

--- a/BasicRdl/Views/RulesBrowser.xaml.cs
+++ b/BasicRdl/Views/RulesBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for <see cref="RulesBrowser"/>
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class RulesBrowser : IPanelView
+    public partial class RulesBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.RulesGridControl);
+                this.Control = this.RulesGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/RulesBrowser.xaml.cs
+++ b/BasicRdl/Views/RulesBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.RulesGridControl;
+                this.FilterableControl = this.RulesGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/BasicRdl/Views/UnitPrefixBrowser.xaml
+++ b/BasicRdl/Views/UnitPrefixBrowser.xaml
@@ -58,6 +58,7 @@
                                VerticalAlignment="Stretch"
                                AllowColumnMoving="True"
                                ShowFilterPanelMode="Never"
+                               RowStyle="{StaticResource RowStyleDeprecated}"
                                AllowEditing="False"
                                AllowGrouping="True"
                                AutoWidth="true"
@@ -69,11 +70,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
@@ -91,7 +87,7 @@
                         </ControlTemplate>
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
-                <dxg:GridColumn FieldName="Name" />
+                <dxg:GridColumn FieldName="Name" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:GridColumn FieldName="ConversionFactor" Header="Conversion Factor" />
                 <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" />

--- a/BasicRdl/Views/UnitPrefixBrowser.xaml.cs
+++ b/BasicRdl/Views/UnitPrefixBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace BasicRdl.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for UnitPrefixBrowser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class UnitPrefixBrowser : IPanelView
+    public partial class UnitPrefixBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.UnitPrefixGridControl);
+                this.Control = this.UnitPrefixGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/BasicRdl/Views/UnitPrefixBrowser.xaml.cs
+++ b/BasicRdl/Views/UnitPrefixBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace BasicRdl.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.UnitPrefixGridControl;
+                this.FilterableControl = this.UnitPrefixGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/CDP4CommonView/Resources/CDP4Styles.xaml
+++ b/CDP4CommonView/Resources/CDP4Styles.xaml
@@ -23,7 +23,47 @@
         <Setter Property="ContextMenu" Value="{x:Null}"/>
     </Style>
 
-    <Style TargetType ="{x:Type dxg:RowControl}">
+    <Style TargetType ="{x:Type dxg:RowControl}" x:Key="RowStyleDeprecated">
+        <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Row.IsDeprecated}" Value="True">
+                <Setter Property="Background" Value="LightGray"/>
+                <Setter Property="Opacity" Value="0.5"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType="{x:Type dxg:RowControl}" x:Key="RowStyleDeprecatedHighlightedBaseQuantityKind">
+        <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=Row.IsBaseQuantityKind}" Value="True">
+                <Setter Property="FontWeight" Value="Bold" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=Row.IsDeprecated}" Value="True">
+                <Setter Property="Background" Value="LightGray" />
+                <Setter Property="Opacity" Value="0.5" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Path=Row.IsHighlighted}" Value="True">
+                <Setter Property="Background" Value="Yellow" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType ="{x:Type dxg:RowControl}" x:Key="RowStyleDeprecatedHighlighted">
+        <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Row.IsDeprecated}" Value="True">
+                <Setter Property="Background" Value="LightGray"/>
+                <Setter Property="Opacity" Value="0.5"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding Row.IsHighlighted}" Value="True">
+                <Setter Property="Background" Value="Yellow"/>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style TargetType ="{x:Type dxg:RowControl}" x:Key="RowStyleDeprecatedHighlightedDirty">
+        <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding Row.IsDeprecated}" Value="True">
                 <Setter Property="Background" Value="LightGray"/>

--- a/CDP4CommonView/Resources/CDP4Styles.xaml
+++ b/CDP4CommonView/Resources/CDP4Styles.xaml
@@ -13,6 +13,7 @@
     <Image x:Key="CopyIcon" x:Shared="False" Source="{dx:DXImage Image=Copy_16x16.png}" Height="16" Width="16"/>
     <Image x:Key="SaveIcon" x:Shared="False" Source="{dx:DXImage Image=Save_16x16.png}" Height="16" Width="16"/>
     <Image x:Key="NavigateIcon" x:Shared="False" Source="{dx:DXImage Image=Redo_16x16.png}" Height="16" Width="16"/>
+    <Image x:Key="FavoriteIcon" x:Shared="False" Source="{dx:DXImage Image=NewContact_16x16.png}" Height="16" Width="16"/>
 
     <Style TargetType="ScrollBar">
         <!-- 
@@ -80,6 +81,9 @@
                         </DataTrigger>
                         <DataTrigger Binding="{Binding MenuItemKind}" Value="{x:Static mvvm:MenuItemKind.Navigate}">
                             <Setter Property="Icon" Value="{StaticResource NavigateIcon}"/>
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding MenuItemKind}" Value="{x:Static mvvm:MenuItemKind.Favorite}">
+                            <Setter Property="Icon" Value="{StaticResource FavoriteIcon}"/>
                         </DataTrigger>
                     </Style.Triggers>
                 </Style>

--- a/CDP4Composition.Tests/CDP4Composition.Tests.csproj
+++ b/CDP4Composition.Tests/CDP4Composition.Tests.csproj
@@ -225,6 +225,7 @@
     <Compile Include="PluginSettingService\TestModule.cs" />
     <Compile Include="PluginSettingService\TestSettings.cs" />
     <Compile Include="RuleVerification\RuleVerificationServiceTestFixture.cs" />
+    <Compile Include="Services\FilterStringServiceTestFixture.cs" />
     <Compile Include="Services\TooltipServiceTestFixture.cs" />
     <Compile Include="SpellingChecker\DictionaryServiceTestFixture.cs" />
     <Compile Include="StaticPanelViewModelTestFixture.cs" />

--- a/CDP4Composition.Tests/Services/FilterStringServiceTestFixture.cs
+++ b/CDP4Composition.Tests/Services/FilterStringServiceTestFixture.cs
@@ -1,0 +1,67 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FilterStringServiceTestFixture.cs" company="RHEA System S.A.">
+//   Copyright (c) 2015-2019 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Tests.Services
+{
+    using NUnit.Framework;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
+    using Moq;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="FilterStringServiceTestFixture"/> class
+    /// </summary>
+    [TestFixture]
+    public class FilterStringServiceTestFixture
+    {
+        private Mock<IDeprecatableToggleViewModel> deprecatableToggle;
+
+        private Mock<IPanelView> goodView;
+        private Mock<IPanelFilterableDataGridView> goodViewFilterable;
+        private Mock<IPanelView> badView;
+        private Mock<IPanelViewModel> goodViewModel;
+        private Mock<IPanelViewModel> badViewModel;
+        private Mock<IDeprecatableBrowserViewModel> goodViewModelDeprecatable;
+        private Mock<IFavoritesBrowserViewModel> goodViewModelFavorable;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.deprecatableToggle = new Mock<IDeprecatableToggleViewModel>();
+            this.goodView = new Mock<IPanelView>();
+            this.badView = new Mock<IPanelView>();
+
+            this.goodViewFilterable = this.goodView.As<IPanelFilterableDataGridView>();
+            this.goodViewModel = new Mock<IPanelViewModel>();
+            this.goodViewModelDeprecatable = this.goodViewModel.As<IDeprecatableBrowserViewModel>();
+            this.goodViewModelFavorable = this.goodViewModel.As<IFavoritesBrowserViewModel>();
+
+            this.badViewModel = new Mock<IPanelViewModel>();
+        }
+
+        [Test]
+        public void Verif_that_Deprecatable_Toggle_IsSet()
+        {
+            Assert.IsNull(FilterStringService.FilterString.DeprecatableToggleViewModel);
+
+            FilterStringService.FilterString.RegisterDeprecatableToggleViewModel(this.deprecatableToggle.Object);
+
+            Assert.IsNotNull(FilterStringService.FilterString.DeprecatableToggleViewModel);
+        }
+
+        [Test]
+        public void Verify_that_registering_bad_view_does_not_work()
+        {
+            Assert.AreEqual(0, FilterStringService.FilterString.OpenDeprecatedControls.Count);
+            Assert.AreEqual(0, FilterStringService.FilterString.OpenFavoriteControls.Count);
+
+            FilterStringService.FilterString.RegisterForService(this.badView.Object, this.badViewModel.Object);
+
+            Assert.AreEqual(0, FilterStringService.FilterString.OpenDeprecatedControls.Count);
+            Assert.AreEqual(0, FilterStringService.FilterString.OpenFavoriteControls.Count);
+        }
+    }
+}

--- a/CDP4Composition/Adapters/TabbedGroupAdapter.cs
+++ b/CDP4Composition/Adapters/TabbedGroupAdapter.cs
@@ -6,10 +6,21 @@
 
 namespace CDP4Composition.Adapters
 {
+    using System;
+    using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.ComponentModel.Composition;
+    using System.Linq;
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Data;
+    using Attributes;
     using DevExpress.Xpf.Docking;
+    using DevExpress.Xpf.Docking.Base;
     using Microsoft.Practices.Prism.Regions;
+    using Microsoft.Practices.ServiceLocation;
+    using Navigation;
+    using ViewModels;
 
     /// <summary>
     /// A region adaptor for the <see cref="TabbedGroup"/>
@@ -18,15 +29,28 @@ namespace CDP4Composition.Adapters
     public class TabbedGroupAdapter : RegionAdapterBase<TabbedGroup>
     {
         /// <summary>
+        /// Associates a view to a documentPanel
+        /// </summary>
+        private Dictionary<IPanelView, LayoutPanel> viewPanelPair;
+
+        /// <summary>
+        /// The MEF injected <see cref="IDialogNavigationService"/>
+        /// </summary>
+        private IDialogNavigationService dialogNavigationService;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TabbedGroupAdapter"/> class.
         /// </summary>
         /// <param name="behaviorFactory">
         /// The behavior factory.
         /// </param>
+        /// <param name="dialogNavigationService">
+        /// The MEF injected <see cref="IDialogNavigationService"/>
+        /// </param>
         [ImportingConstructor]
-        public TabbedGroupAdapter(IRegionBehaviorFactory behaviorFactory) :
-            base(behaviorFactory)
+        public TabbedGroupAdapter(IRegionBehaviorFactory behaviorFactory) : base(behaviorFactory)
         {
+            this.viewPanelPair = new Dictionary<IPanelView, LayoutPanel>();
         }
 
         /// <summary>
@@ -41,7 +65,7 @@ namespace CDP4Composition.Adapters
         }
 
         /// <summary>
-        /// Adapts the <see cref="TabbedGroup"/> in the association <see cref="IRegion"/>
+        /// Adapts the <see cref="LayoutGroup"/> in the association <see cref="IRegion"/>
         /// </summary>
         /// <param name="region">
         /// The associated <see cref="IRegion"/>
@@ -51,23 +75,175 @@ namespace CDP4Composition.Adapters
         /// </param>
         protected override void Adapt(IRegion region, TabbedGroup regionTarget)
         {
-            region.Views.CollectionChanged += (s, e) =>
-            {
-                OnViewsCollectionChanged(region, regionTarget, s, e);
-            };
+            region.Views.CollectionChanged += (s, e) => this.OnViewsCollectionChanged(region, regionTarget, s, e);
+            regionTarget.GetDockLayoutManager().DockItemClosed += (s, e) => this.OnPanelClosed(region, regionTarget, s, e);
+            regionTarget.GetDockLayoutManager().DockItemClosing += (s, e) => this.OnPanelClosing(region, regionTarget, s, e);
         }
 
-        void OnViewsCollectionChanged(IRegion region, TabbedGroup regionTarget, object sender, NotifyCollectionChangedEventArgs e)
+        /// <summary>
+        /// Handles the region.Views.CollectionChanged event
+        /// </summary>
+        /// <param name="region">the region</param>
+        /// <param name="regionTarget">the region target</param>
+        /// <param name="sender">the sender</param>
+        /// <param name="e">the NotifyCollectionChangedEventArgs</param>
+        private void OnViewsCollectionChanged(IRegion region, LayoutGroup regionTarget, object sender, NotifyCollectionChangedEventArgs e)
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
-                foreach (object view in e.NewItems)
+                this.OnAdd(region, regionTarget, sender, e);
+            }
+
+            if (e.Action == NotifyCollectionChangedAction.Remove)
+            {
+                this.OnRemove(region, regionTarget, sender, e);
+            }
+        }
+
+        /// <summary>
+        /// Handles the region.Views.CollectionChanged event when elements have been added
+        /// </summary>
+        /// <param name="region">the region</param>
+        /// <param name="regionTarget">the region target</param>
+        /// <param name="s">the sender</param>
+        /// <param name="e">the NotifyCollectionChangedEventArgs</param>
+        private void OnAdd(IRegion region, LayoutGroup regionTarget, object s, NotifyCollectionChangedEventArgs e)
+        {
+            foreach (var view in e.NewItems)
+            {
+                var panel = new LayoutPanel { Content = view };
+                var panelview = view as IPanelView;
+                if (panelview == null)
                 {
-                    LayoutPanel panel = new LayoutPanel();
-                    panel.Content = view;
-                    panel.Caption = "new Page";
-                    regionTarget.Items.Add(panel);
-                    regionTarget.SelectedTabIndex = regionTarget.Items.Count - 1;
+                    throw new ArgumentException(string.Format("The added view does not respect the interface IPanelView: {0}", view));
+                }
+
+                var viewModel = panelview.DataContext as IPanelViewModel;
+                if (viewModel == null)
+                {
+                    throw new ArgumentException(string.Format("The added view-model does not respect the interface IPanelViewModel: {0}", view));
+                }
+
+                var captionProperty = new Binding();
+                captionProperty.Source = viewModel;
+                captionProperty.Path = new PropertyPath("Caption");
+                captionProperty.Mode = BindingMode.OneWay;
+                captionProperty.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
+                BindingOperations.SetBinding(panel, LayoutPanel.CaptionProperty, captionProperty);
+
+                var tooltipProperty = new Binding();
+                tooltipProperty.Source = viewModel;
+                tooltipProperty.Path = new PropertyPath("ToolTip");
+                tooltipProperty.Mode = BindingMode.OneWay;
+                tooltipProperty.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
+                BindingOperations.SetBinding(panel, LayoutPanel.ToolTipProperty, tooltipProperty);
+
+                regionTarget.Items.Add(panel);
+                this.viewPanelPair.Add(panelview, panel);
+
+                regionTarget.SelectedTabIndex = regionTarget.Items.Count - 1;
+            }
+        }
+
+        /// <summary>
+        /// Handles the region.Views.CollectionChanged event when elements have been removed
+        /// </summary>
+        /// <param name="region">the region</param>
+        /// <param name="regionTarget">the region target</param>
+        /// <param name="s">the sender</param>
+        /// <param name="e">the NotifyCollectionChangedEventArgs</param>
+        private void OnRemove(IRegion region, LayoutGroup regionTarget, object s, NotifyCollectionChangedEventArgs e)
+        {
+            foreach (var view in e.OldItems)
+            {
+                var panelView = view as IPanelView;
+                if (panelView != null)
+                {
+                    LayoutPanel layoutPanel;
+                    if (this.viewPanelPair.TryGetValue(panelView, out layoutPanel))
+                    {
+                        this.viewPanelPair.Remove(panelView);
+                        regionTarget.GetDockLayoutManager().DockController.RemovePanel(layoutPanel);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles the Dock Panel closing event 
+        /// </summary>
+        /// <param name="region">The region</param>
+        /// <param name="regionTarget">The region target</param>
+        /// <param name="s">The sender</param>
+        /// <param name="e">The <see cref="ItemCancelEventArgs"/></param>
+        private void OnPanelClosing(IRegion region, LayoutGroup regionTarget, object s, ItemCancelEventArgs e)
+        {
+            if (!e.Item.Parent.Equals(regionTarget))
+            {
+                return;
+            }
+
+            var docPanel = e.Item as LayoutPanel;
+            if (docPanel == null)
+            {
+                return;
+            }
+
+            var view = (UserControl)docPanel.Content;
+            var panelViewModel = (IPanelViewModel)view.DataContext;
+            if (panelViewModel == null)
+            {
+                return;
+            }
+
+            if (!panelViewModel.IsDirty)
+            {
+                return;
+            }
+
+            if (this.dialogNavigationService == null)
+            {
+                this.dialogNavigationService = ServiceLocator.Current.GetInstance<IDialogNavigationService>();
+            }
+
+            var confirmation = new GenericConfirmationDialogViewModel("Warning", MessageHelper.ClosingPanelConfirmation);
+            var result = this.dialogNavigationService.NavigateModal(confirmation);
+            if (result != null && result.Result.HasValue && result.Result.Value)
+            {
+                return;
+            }
+
+            e.Cancel = true;
+        }
+
+        /// <summary>
+        /// Handles the Dock Panel close event 
+        /// </summary>
+        /// <param name="region">the region</param>
+        /// <param name="regionTarget">the region target</param>
+        /// <param name="s">the sender</param>
+        /// <param name="e">the NotifyCollectionChangedEventArgs</param>
+        private void OnPanelClosed(IRegion region, LayoutGroup regionTarget, object s, DockItemClosedEventArgs e)
+        {
+            foreach (var panel in e.AffectedItems)
+            {
+                var docPanel = panel as LayoutPanel;
+                if (docPanel == null)
+                {
+                    continue;
+                }
+
+                var view = this.viewPanelPair.SingleOrDefault(x => x.Value == docPanel).Key;
+                if (view == null)
+                {
+                    continue;
+                }
+
+                var regionAttribute = view.GetType().GetCustomAttributes(typeof(PanelViewExportAttribute), true).SingleOrDefault() as PanelViewExportAttribute;
+                if (regionAttribute != null && regionAttribute.Region == region.Name)
+                {
+                    this.viewPanelPair.Remove(view);
+                    region.Remove(view);
                 }
             }
         }

--- a/CDP4Composition/Adapters/TabbedGroupAdapter.cs
+++ b/CDP4Composition/Adapters/TabbedGroupAdapter.cs
@@ -44,9 +44,6 @@ namespace CDP4Composition.Adapters
         /// <param name="behaviorFactory">
         /// The behavior factory.
         /// </param>
-        /// <param name="dialogNavigationService">
-        /// The MEF injected <see cref="IDialogNavigationService"/>
-        /// </param>
         [ImportingConstructor]
         public TabbedGroupAdapter(IRegionBehaviorFactory behaviorFactory) : base(behaviorFactory)
         {
@@ -65,7 +62,7 @@ namespace CDP4Composition.Adapters
         }
 
         /// <summary>
-        /// Adapts the <see cref="LayoutGroup"/> in the association <see cref="IRegion"/>
+        /// Adapts the <see cref="TabbedGroup"/> in the association <see cref="IRegion"/>
         /// </summary>
         /// <param name="region">
         /// The associated <see cref="IRegion"/>
@@ -76,8 +73,10 @@ namespace CDP4Composition.Adapters
         protected override void Adapt(IRegion region, TabbedGroup regionTarget)
         {
             region.Views.CollectionChanged += (s, e) => this.OnViewsCollectionChanged(region, regionTarget, s, e);
-            regionTarget.GetDockLayoutManager().DockItemClosed += (s, e) => this.OnPanelClosed(region, regionTarget, s, e);
-            regionTarget.GetDockLayoutManager().DockItemClosing += (s, e) => this.OnPanelClosing(region, regionTarget, s, e);
+            regionTarget.GetDockLayoutManager().DockItemClosed +=
+                (s, e) => this.OnPanelClosed(region, regionTarget, s, e);
+            regionTarget.GetDockLayoutManager().DockItemClosing +=
+                (s, e) => this.OnPanelClosing(region, regionTarget, s, e);
         }
 
         /// <summary>
@@ -87,7 +86,8 @@ namespace CDP4Composition.Adapters
         /// <param name="regionTarget">the region target</param>
         /// <param name="sender">the sender</param>
         /// <param name="e">the NotifyCollectionChangedEventArgs</param>
-        private void OnViewsCollectionChanged(IRegion region, LayoutGroup regionTarget, object sender, NotifyCollectionChangedEventArgs e)
+        private void OnViewsCollectionChanged(IRegion region, TabbedGroup regionTarget, object sender,
+            NotifyCollectionChangedEventArgs e)
         {
             if (e.Action == NotifyCollectionChangedAction.Add)
             {
@@ -107,21 +107,24 @@ namespace CDP4Composition.Adapters
         /// <param name="regionTarget">the region target</param>
         /// <param name="s">the sender</param>
         /// <param name="e">the NotifyCollectionChangedEventArgs</param>
-        private void OnAdd(IRegion region, LayoutGroup regionTarget, object s, NotifyCollectionChangedEventArgs e)
+        private void OnAdd(IRegion region, TabbedGroup regionTarget, object s, NotifyCollectionChangedEventArgs e)
         {
             foreach (var view in e.NewItems)
             {
-                var panel = new LayoutPanel { Content = view };
+                var panel = new LayoutPanel {Content = view};
                 var panelview = view as IPanelView;
                 if (panelview == null)
                 {
-                    throw new ArgumentException(string.Format("The added view does not respect the interface IPanelView: {0}", view));
+                    throw new ArgumentException(
+                        string.Format("The added view does not respect the interface IPanelView: {0}", view));
                 }
 
                 var viewModel = panelview.DataContext as IPanelViewModel;
                 if (viewModel == null)
                 {
-                    throw new ArgumentException(string.Format("The added view-model does not respect the interface IPanelViewModel: {0}", view));
+                    throw new ArgumentException(
+                        string.Format("The added view-model does not respect the interface IPanelViewModel: {0}",
+                            view));
                 }
 
                 var captionProperty = new Binding();
@@ -152,7 +155,7 @@ namespace CDP4Composition.Adapters
         /// <param name="regionTarget">the region target</param>
         /// <param name="s">the sender</param>
         /// <param name="e">the NotifyCollectionChangedEventArgs</param>
-        private void OnRemove(IRegion region, LayoutGroup regionTarget, object s, NotifyCollectionChangedEventArgs e)
+        private void OnRemove(IRegion region, TabbedGroup regionTarget, object s, NotifyCollectionChangedEventArgs e)
         {
             foreach (var view in e.OldItems)
             {
@@ -170,13 +173,13 @@ namespace CDP4Composition.Adapters
         }
 
         /// <summary>
-        /// Handles the Dock Panel closing event 
+        /// Handles the Dock Panel closing event
         /// </summary>
         /// <param name="region">The region</param>
         /// <param name="regionTarget">The region target</param>
         /// <param name="s">The sender</param>
         /// <param name="e">The <see cref="ItemCancelEventArgs"/></param>
-        private void OnPanelClosing(IRegion region, LayoutGroup regionTarget, object s, ItemCancelEventArgs e)
+        private void OnPanelClosing(IRegion region, TabbedGroup regionTarget, object s, ItemCancelEventArgs e)
         {
             if (!e.Item.Parent.Equals(regionTarget))
             {
@@ -189,8 +192,8 @@ namespace CDP4Composition.Adapters
                 return;
             }
 
-            var view = (UserControl)docPanel.Content;
-            var panelViewModel = (IPanelViewModel)view.DataContext;
+            var view = (UserControl) docPanel.Content;
+            var panelViewModel = (IPanelViewModel) view.DataContext;
             if (panelViewModel == null)
             {
                 return;
@@ -206,7 +209,8 @@ namespace CDP4Composition.Adapters
                 this.dialogNavigationService = ServiceLocator.Current.GetInstance<IDialogNavigationService>();
             }
 
-            var confirmation = new GenericConfirmationDialogViewModel("Warning", MessageHelper.ClosingPanelConfirmation);
+            var confirmation =
+                new GenericConfirmationDialogViewModel("Warning", MessageHelper.ClosingPanelConfirmation);
             var result = this.dialogNavigationService.NavigateModal(confirmation);
             if (result != null && result.Result.HasValue && result.Result.Value)
             {
@@ -217,13 +221,13 @@ namespace CDP4Composition.Adapters
         }
 
         /// <summary>
-        /// Handles the Dock Panel close event 
+        /// Handles the Dock Panel close event
         /// </summary>
         /// <param name="region">the region</param>
         /// <param name="regionTarget">the region target</param>
         /// <param name="s">the sender</param>
         /// <param name="e">the NotifyCollectionChangedEventArgs</param>
-        private void OnPanelClosed(IRegion region, LayoutGroup regionTarget, object s, DockItemClosedEventArgs e)
+        private void OnPanelClosed(IRegion region, TabbedGroup regionTarget, object s, DockItemClosedEventArgs e)
         {
             foreach (var panel in e.AffectedItems)
             {
@@ -239,7 +243,9 @@ namespace CDP4Composition.Adapters
                     continue;
                 }
 
-                var regionAttribute = view.GetType().GetCustomAttributes(typeof(PanelViewExportAttribute), true).SingleOrDefault() as PanelViewExportAttribute;
+                var regionAttribute =
+                    view.GetType().GetCustomAttributes(typeof(PanelViewExportAttribute), true).SingleOrDefault() as
+                        PanelViewExportAttribute;
                 if (regionAttribute != null && regionAttribute.Region == region.Name)
                 {
                     this.viewPanelPair.Remove(view);

--- a/CDP4Composition/CDP4Composition.csproj
+++ b/CDP4Composition/CDP4Composition.csproj
@@ -238,6 +238,14 @@
     <Compile Include="FolderRowViewModel.cs" />
     <Compile Include="Mvvm\Behaviours\ContextMenuBehavior.cs" />
     <Compile Include="Mvvm\Behaviours\ExtendedDiagramOrgChartBehavior.cs" />
+    <Compile Include="Mvvm\MenuItems\RibbonButtonSessionFavoritesDependentViewModel.cs" />
+    <Compile Include="Mvvm\MenuItems\RibbonMenuItemSessionFavoritesDependentViewModel.cs" />
+    <Compile Include="Navigation\Interfaces\IDeprecatableToggleViewModel.cs" />
+    <Compile Include="Navigation\Interfaces\IDeprecatableBrowserViewModel.cs" />
+    <Compile Include="Navigation\Interfaces\IFavoritesBrowserViewModel.cs" />
+    <Compile Include="Navigation\Interfaces\IPanelFilterableDataGridView.cs" />
+    <Compile Include="Services\FavoritesService\FavoritesService.cs" />
+    <Compile Include="Services\FavoritesService\IFavoritesService.cs" />
     <Compile Include="Services\FilterStringService.cs" />
     <Compile Include="Mvvm\Behaviours\IExtendedDiagramOrgChartBehavior.cs" />
     <Compile Include="Mvvm\Behaviours\ItemsSourceHelper.cs" />

--- a/CDP4Composition/Converters/ThingToIconUriConverter.cs
+++ b/CDP4Composition/Converters/ThingToIconUriConverter.cs
@@ -94,6 +94,11 @@ namespace CDP4Composition
                 return this.QueryIIconCacheService().QueryOverlayBitmapSource(uri, IconUtilities.RelationshipOverlayUri, OverlayPositionKind.TopRight);
             }
 
+            if (thingStatus.IsFavorite)
+            {
+                return this.QueryIIconCacheService().QueryOverlayBitmapSource(uri, IconUtilities.FavoriteOverlayUri, OverlayPositionKind.BottomLeft);
+            }
+
             return this.QueryIIconCacheService().QueryBitmapImage(uri);
         }
 

--- a/CDP4Composition/DragDrop/FrameworkElementDragBehavior.cs
+++ b/CDP4Composition/DragDrop/FrameworkElementDragBehavior.cs
@@ -94,9 +94,10 @@ namespace CDP4Composition.DragDrop
         {
             if (e.LeftButton != MouseButtonState.Pressed)
             {
+                this.dragInfo = null;
                 return;
             }
-
+            
             if (this.dragInfo != null && !this.dragInProgress)
             {
                 var dragStart = this.dragInfo.DragStartPosition;

--- a/CDP4Composition/Mvvm/BrowserViewModelBase.cs
+++ b/CDP4Composition/Mvvm/BrowserViewModelBase.cs
@@ -869,6 +869,7 @@ namespace CDP4Composition.Mvvm
                 this.ContextMenu.Add(categoriesMenu);
             }
 
+            // TODO: This is really only applicable to expandable things, and certainly does not even need to be in grids.
             this.ContextMenu.Add(this.SelectedThing.IsExpanded ?
                     new ContextMenuItemViewModel("Collapse Rows","", this.CollpaseRowsCommand, MenuItemKind.None, ClassKind.NotThing) :
                      new ContextMenuItemViewModel("Expand Rows", "", this.ExpandRowsCommand, MenuItemKind.None, ClassKind.NotThing));

--- a/CDP4Composition/Mvvm/IRowViewModelBase.cs
+++ b/CDP4Composition/Mvvm/IRowViewModelBase.cs
@@ -95,11 +95,6 @@ namespace CDP4Composition.Mvvm
         bool IsExpanded { get; set; }
 
         /// <summary>
-        /// Sets a value indicating that the row is hidden
-        /// </summary>
-        bool IsHidden { get; }
-
-        /// <summary>
         /// Expands the current row and all contained rows along the containment hierarchy
         /// </summary>
         void ExpandAllRows();

--- a/CDP4Composition/Mvvm/MenuItems/MenuItemKind.cs
+++ b/CDP4Composition/Mvvm/MenuItems/MenuItemKind.cs
@@ -77,6 +77,11 @@ namespace CDP4Composition.Mvvm
         /// <summary>
         /// Assertion that the associated menu item is used to navigate to a Thing
         /// </summary>
-        Navigate = 12
+        Navigate = 12,
+
+        /// <summary>
+        /// Assertion that the associated menu item is used to save a Thing to favorites
+        /// </summary>
+        Favorite = 13
     }
 }

--- a/CDP4Composition/Mvvm/MenuItems/RibbonButtonSessionFavoritesDependentViewModel.cs
+++ b/CDP4Composition/Mvvm/MenuItems/RibbonButtonSessionFavoritesDependentViewModel.cs
@@ -1,0 +1,124 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RibbonButtonSessionFavoritesDependentViewModel.cs" company="RHEA System S.A.">
+//   Copyright (c) 2019 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm
+{
+    using System;
+    using System.Linq;
+    using System.Reactive.Linq;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.PluginSettingService;
+    using CDP4Dal;
+    using CDP4Dal.Events;
+    using ReactiveUI;
+    using Services.FavoritesService;
+
+    /// <summary>
+    /// The base class representing Ribbon button that depends on <see cref="ISession"/> to open a <see cref="IPanelView"/>, with Favoriting functionality.
+    /// </summary>
+    public abstract class RibbonButtonSessionFavoritesDependentViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// The Function returning an instance of <see cref="IPanelViewModel"/>
+        /// </summary>
+        protected readonly Func<ISession, IThingDialogNavigationService, IPanelNavigationService, IDialogNavigationService, IPluginSettingsService, IFavoritesService, IPanelViewModel> InstantiatePanelViewModelFunction;
+
+        /// <summary>
+        /// Backing field for <see cref="HasSession"/>
+        /// </summary>
+        private ObservableAsPropertyHelper<bool> hasSession;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RibbonButtonSessionFavoritesDependentViewModel"/> class
+        /// </summary>
+
+        protected RibbonButtonSessionFavoritesDependentViewModel(Func<ISession, IThingDialogNavigationService, IPanelNavigationService, IDialogNavigationService, IPluginSettingsService, IFavoritesService, IPanelViewModel> instantiatePanelViewModel)
+        {
+            this.InstantiatePanelViewModelFunction = instantiatePanelViewModel;
+            this.OpenSessions = new ReactiveList<RibbonMenuItemViewModelBase>();
+            this.OpenSessions.ChangeTrackingEnabled = true;
+
+            this.OpenSessions.CountChanged.Select(x => x != 0).ToProperty(this, x => x.HasSession, out this.hasSession);
+
+            this.OpenSingleBrowserCommand = ReactiveCommand.Create();
+            this.OpenSingleBrowserCommand.Subscribe(_ => this.ExecuteOpenSingleBrowser());
+
+            CDPMessageBus.Current.Listen<SessionEvent>().Subscribe(this.SessionChangeEventHandler);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether there are open sessions
+        /// </summary>
+        public bool HasSession
+        {
+            get { return this.hasSession.Value; }
+        }
+
+        /// <summary>
+        /// Gets the open or close the browser
+        /// </summary>
+        public ReactiveCommand<object> OpenSingleBrowserCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the list of open sessions
+        /// </summary>
+        public ReactiveList<RibbonMenuItemViewModelBase> OpenSessions { get; private set; }
+
+        /// <summary>
+        /// Removes the <see cref="RibbonMenuItemViewModelBase"/> associated with the closed <see cref="ISession"/>
+        /// </summary>
+        /// <param name="session">The closed <see cref="ISession"/></param>
+        protected void RemoveOpenSession(ISession session)
+        {
+            var currentSession = this.OpenSessions.Single(x => x.Session == session);
+            currentSession.IsChecked = false;
+            currentSession.ShowOrClosePanelCommand.Execute(null);
+
+            var sessionToRemove = this.OpenSessions.SingleOrDefault(x => x.Session == session);
+            if (sessionToRemove != null)
+            {
+                this.OpenSessions.Remove(sessionToRemove);
+            }
+        }
+
+        /// <summary>
+        /// Executes the <see cref="OpenSingleBrowserCommand"/> command
+        /// </summary>
+        private void ExecuteOpenSingleBrowser()
+        {
+            if (this.OpenSessions.Count != 1)
+            {
+                return;
+            }
+
+            var status = this.OpenSessions.Single().IsChecked;
+            this.OpenSessions.Single().IsChecked = !status;
+
+            this.OpenSessions.Single().ShowOrClosePanelCommand.Execute(null);
+        }
+
+        /// <summary>
+        /// The event-handler that is invoked by the subscription that listens for updates
+        /// on the <see cref="ISession"/> that is being represented by the view-model
+        /// </summary>
+        /// <param name="sessionChange">
+        /// The payload of the event that is being handled
+        /// </param>
+        protected virtual void SessionChangeEventHandler(SessionEvent sessionChange)
+        {
+            if (sessionChange.Status == SessionStatus.Open)
+            {
+                this.OpenSessions.Add(
+                    new RibbonMenuItemSessionFavoritesDependentViewModel(sessionChange.Session.Name, sessionChange.Session, this.InstantiatePanelViewModelFunction));
+            }
+            else if (sessionChange.Status == SessionStatus.Closed)
+            {
+                this.RemoveOpenSession(sessionChange.Session);
+            }
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/MenuItems/RibbonMenuItemSessionFavoritesDependentViewModel.cs
+++ b/CDP4Composition/Mvvm/MenuItems/RibbonMenuItemSessionFavoritesDependentViewModel.cs
@@ -1,0 +1,54 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="RibbonMenuItemSessionFavoritesDependentViewModel.cs" company="RHEA System S.A.">
+//   Copyright (c) 2019 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm
+{
+    using System;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.PluginSettingService;
+    using CDP4Dal;
+    using Microsoft.Practices.ServiceLocation;
+    using Services.FavoritesService;
+
+    /// <summary>
+    /// The Ribbon menu-item view-model for <see cref="ISession"/> dependency controls with favoriting functionality
+    /// </summary>
+    public class RibbonMenuItemSessionFavoritesDependentViewModel : RibbonMenuItemViewModelBase
+    {
+        /// <summary>
+        /// The <see cref="IFavoritesService"/> used to read and write favorite things to user preferences.
+        /// </summary>
+        protected readonly IFavoritesService FavoritesService;
+
+        /// <summary>
+        /// The Function returning an instance of a <see cref="IPanelViewModel"/>
+        /// </summary>
+        private readonly Func<ISession, IThingDialogNavigationService, IPanelNavigationService, IDialogNavigationService, IPluginSettingsService, IFavoritesService, IPanelViewModel> InstantiatePanelViewModelFunction;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RibbonMenuItemSessionDependentViewModel"/> class
+        /// </summary>
+        /// <param name="menuItemContent">the content string to be displayed in the user-interface for this menu-item</param>
+        /// <param name="session">The associated <see cref="ISession"/></param>
+        /// <param name="instantiatePanelViewModelFunction">The function that creates an instance of the <see cref="IPanelViewModel"/> for this menu-item</param>
+        public RibbonMenuItemSessionFavoritesDependentViewModel(string menuItemContent, ISession session, Func<ISession, IThingDialogNavigationService, IPanelNavigationService, IDialogNavigationService, IPluginSettingsService, IFavoritesService, IPanelViewModel> instantiatePanelViewModelFunction)
+            : base(menuItemContent, session)
+        {
+            this.InstantiatePanelViewModelFunction = instantiatePanelViewModelFunction;
+            this.FavoritesService = ServiceLocator.Current.GetInstance<IFavoritesService>();
+        }
+
+        /// <summary>
+        /// Returns an instance of a <see cref="IPanelViewModel"/>
+        /// </summary>
+        /// <returns>An instance of a <see cref="IPanelViewModel"/></returns>
+        protected override IPanelViewModel InstantiatePanelViewModel()
+        {
+            return this.InstantiatePanelViewModelFunction(this.Session, this.ThingDialogNavigationService, this.PanelNavigationServive, this.DialogNavigationService, this.PluginSettingsService, this.FavoritesService);
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/ThingStatus.cs
+++ b/CDP4Composition/Mvvm/ThingStatus.cs
@@ -39,5 +39,10 @@ namespace CDP4Composition.Mvvm
         /// Gets a value indicating whether the thing has associated relationships
         /// </summary>
         public bool HasRelationship { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the thing is marked as a user's favorite
+        /// </summary>
+        public bool IsFavorite { get; set; } = false;
     }
 }

--- a/CDP4Composition/Mvvm/Types/ReactiveListExtension.cs
+++ b/CDP4Composition/Mvvm/Types/ReactiveListExtension.cs
@@ -14,7 +14,7 @@ namespace CDP4Composition.Mvvm
     /// <summary>
     /// An Extension for the ReactiveList to order the contained rows
     /// </summary>
-    public static class ReactiveListExtension 
+    public static class ReactiveListExtension
     {
         /// <summary>
         /// Insert a <see cref="IRowViewModelBase{Thing}"/> into the list given a <see cref="IComparer{T}"/>
@@ -22,7 +22,8 @@ namespace CDP4Composition.Mvvm
         /// <param name="list">The <see cref="ReactiveList{T}"/></param>
         /// <param name="row">The <see cref="IRowViewModelBase{Thing}"/> to add</param>
         /// <param name="comparer">The <see cref="IComparer{T}"/> used to perform the sorting</param>
-        public static void SortedInsert(this ReactiveList<IRowViewModelBase<Thing>> list, IRowViewModelBase<Thing> row, IComparer<IRowViewModelBase<Thing>> comparer)
+        public static void SortedInsert<T>(this ReactiveList<T> list, T row,
+            IComparer<T> comparer)
         {
             if (row == null)
             {
@@ -33,7 +34,7 @@ namespace CDP4Composition.Mvvm
             {
                 throw new ArgumentNullException(nameof(comparer), $"The {nameof(comparer)} may not be null");
             }
-            
+
             // item is found using the comparer : returns the index of the item found
             // item not found : returns a negative number that is the bitwise complement 
             // of the index of the next element that is larger or count if none

--- a/CDP4Composition/Navigation/Interfaces/IDeprecatableBrowserViewModel.cs
+++ b/CDP4Composition/Navigation/Interfaces/IDeprecatableBrowserViewModel.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IDeprecatableBrowserViewModel.cs" company="RHEA System S.A.">
+//   Copyright (c) 2019 RHEA System S.A.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition
+{
+    using System;
+
+    /// <summary>
+    /// Interface definition for view models that are intended to house deprecatable items
+    /// </summary>
+    public interface IDeprecatableBrowserViewModel
+    {
+
+    }
+}

--- a/CDP4Composition/Navigation/Interfaces/IDeprecatableToggleViewModel.cs
+++ b/CDP4Composition/Navigation/Interfaces/IDeprecatableToggleViewModel.cs
@@ -1,0 +1,21 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IDeprecatableToggleViewModel.cs" company="RHEA System S.A.">
+//   Copyright (c) 2019 RHEA System S.A.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition
+{
+    using System;
+
+    /// <summary>
+    /// Interface definition for view models that are intended to have control over deprecatable thing visibility
+    /// </summary>
+    public interface IDeprecatableToggleViewModel
+    {
+        /// <summary>
+        /// Gets the a value indicating whether to display deprecatable things.
+        /// </summary>
+        bool ShowDeprecatedThings { get; set; }
+    }
+}

--- a/CDP4Composition/Navigation/Interfaces/IFavoritesBrowserViewModel.cs
+++ b/CDP4Composition/Navigation/Interfaces/IFavoritesBrowserViewModel.cs
@@ -1,0 +1,21 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IFavoritesBrowserViewModel.cs" company="RHEA System S.A.">
+//   Copyright (c) 2019 RHEA System S.A.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition
+{
+    using System;
+
+    /// <summary>
+    /// Interface definition for view models that are intended to house favoritable items
+    /// </summary>
+    public interface IFavoritesBrowserViewModel
+    {
+        /// <summary>
+        /// Gets the a value indicating whether to display favorites.
+        /// </summary>
+        bool ShowOnlyFavorites { get; set; }
+    }
+}

--- a/CDP4Composition/Navigation/Interfaces/IPanelFilterableDataGridView.cs
+++ b/CDP4Composition/Navigation/Interfaces/IPanelFilterableDataGridView.cs
@@ -16,6 +16,6 @@ namespace CDP4Composition.Navigation.Interfaces
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        DataControlBase Control { get; }
+        DataControlBase FilterableControl { get; }
     }
 }

--- a/CDP4Composition/Navigation/Interfaces/IPanelFilterableDataGridView.cs
+++ b/CDP4Composition/Navigation/Interfaces/IPanelFilterableDataGridView.cs
@@ -1,0 +1,21 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IPanelFilterableDataGridView.cs" company="RHEA System S.A.">
+//   Copyright (c) 2019 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Navigation.Interfaces
+{
+    using DevExpress.Xpf.Grid;
+
+    /// <summary>
+    /// An inteface for a panel with filterable data grid.
+    /// </summary>
+    public interface IPanelFilterableDataGridView
+    {
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        DataControlBase Control { get; }
+    }
+}

--- a/CDP4Composition/Services/FavoritesService/FavoritesService.cs
+++ b/CDP4Composition/Services/FavoritesService/FavoritesService.cs
@@ -28,6 +28,11 @@ namespace CDP4Composition.Services.FavoritesService
     public class FavoritesService : IFavoritesService
     {
         /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
         /// Type map for shortnames of UserPreferences holding favorite types.
         /// </summary>
         private readonly IReadOnlyDictionary<Type, string> favoritesTypeMap = new Dictionary<Type, string>()
@@ -143,7 +148,7 @@ namespace CDP4Composition.Services.FavoritesService
             }
             catch (Exception ex)
             {
-                LogManager.GetLogger(typeof(FavoritesService).FullName).Error("The inline update operation failed: {0}", ex.Message);
+                logger.Error("The inline update operation failed: {0}", ex.Message);
             }
         }
 

--- a/CDP4Composition/Services/FavoritesService/FavoritesService.cs
+++ b/CDP4Composition/Services/FavoritesService/FavoritesService.cs
@@ -1,0 +1,216 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FavoritesService.cs" company="RHEA System S.A.">
+//   Copyright (c) 2018 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Services.FavoritesService
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel.Composition;
+    using System.Linq;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Dal;
+    using CDP4Dal.Events;
+    using CDP4Dal.Operations;
+    using NLog;
+    using ReactiveUI;
+
+    /// <summary>
+    /// Definition of the <see cref="IFavoritesService"/> used to load user favorite preferences from the active user.
+    /// </summary>
+    [Export(typeof(IFavoritesService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class FavoritesService : IFavoritesService
+    {
+        /// <summary>
+        /// Type map for shortnames of UserPreferences holding favorite types.
+        /// </summary>
+        private readonly IReadOnlyDictionary<Type, string> favoritesTypeMap = new Dictionary<Type, string>()
+        {
+            { typeof(ParameterType), "FrequentlyUsedParameterTypes" }
+        };
+
+        /// <summary>
+        /// Gets a collection of <see cref="Guid"/> of things in UserPreferences of the active person
+        /// </summary>
+        /// <param name="type">The type of the thing to register for.</param>
+        /// <param name="session">The session for which to get the favorites for.</param>
+        /// <returns>List of Guids of favorite things of the requested type.</returns>
+        public HashSet<Guid> GetFavoriteItemsCollectionByType(ISession session, Type type)
+        {
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session), $"The {nameof(session)} may not be null");
+            }
+
+            var shortName = this.GetPreferenceShortname(type);
+
+            if (string.IsNullOrWhiteSpace(shortName))
+            {
+                return new HashSet<Guid>();
+            }
+
+            var favoritePreference = this.GetFavoritePreference(session, shortName);
+
+            return this.GetIidsFromUserPreference(favoritePreference);
+        }
+
+        /// <summary>
+        /// Creates a subscription to a <see cref="UserPreference"/> change and returns a disposable to keep in the VM collection.
+        /// </summary>
+        /// <param name="session">The session this is attached to.</param>
+        /// <param name="type">The type of favorite thing to listen to.</param>
+        /// <param name="subscriberAction">The <see cref="Action"/>to subscribe to.</param>
+        /// <returns>A <see cref="IDisposable"/> of the created observable.</returns>
+        public IDisposable SubscribeToChanges(ISession session, Type type, Action<HashSet<Guid>> subscriberAction)
+        {
+            return
+                CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(UserPreference))
+                    .Where(objectChange =>
+                    {
+                        var userPreference = (UserPreference)objectChange.ChangedThing;
+                        return userPreference.Container == session.ActivePerson &&
+                               userPreference.ShortName == this.GetPreferenceShortname(type);
+                    })
+                    .Select(o => this.GetIidsFromUserPreference((UserPreference)o.ChangedThing))
+                    .ObserveOn(RxApp.MainThreadScheduler)
+                    .Subscribe(subscriberAction);
+        }
+
+        /// <summary>
+        /// Toggles the favorite status of a thing.
+        /// </summary>
+        /// <typeparam name="T">The type on which to base the save.</typeparam>
+        /// <param name="thing">The thing to persist/remove from persistence</param>
+        /// <param name="session">The session in which to persist.</param>
+        /// <returns>The empty task.</returns>
+        public async Task ToggleFavorite<T>(ISession session, T thing) where T: Thing
+        {
+            var transaction = new ThingTransaction(TransactionContextResolver.ResolveContext(session.ActivePerson));
+            
+            var preferenceShortname = this.GetPreferenceShortname(typeof(T));
+            var preference = this.GetFavoritePreference(session, preferenceShortname);
+
+            var userClone = session.ActivePerson.Clone(false);
+
+            HashSet<Guid> valueSet;
+
+            if (preference == null)
+            {
+                // if property not there, create it and add
+                valueSet = new HashSet<Guid>
+                {
+                    thing.Iid
+                };
+
+                preference = new UserPreference(Guid.NewGuid(), null, null)
+                {
+                    ShortName = preferenceShortname
+                };
+
+                userClone.UserPreference.Add(preference);
+                transaction.CreateOrUpdate(userClone);
+            }
+            else
+            {
+                // if property is there, see if thing is in the array, true => remove, false => append
+                valueSet = this.GetIidsFromUserPreference(preference);
+
+                if (valueSet.Contains(thing.Iid))
+                {
+                    valueSet.Remove(thing.Iid);
+                }
+                else
+                {
+                    valueSet.Add(thing.Iid);
+                }
+
+                preference = preference.Clone(false);
+            }
+
+            preference.Value = string.Join(",", valueSet);
+            transaction.CreateOrUpdate(preference);
+
+            try
+            {
+                var operationContainer = transaction.FinalizeTransaction();
+                await session.Write(operationContainer);
+            }
+            catch (Exception ex)
+            {
+                LogManager.GetLogger(typeof(FavoritesService).FullName).Error("The inline update operation failed: {0}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Get the <see cref="UserPreference"/> by shortname. Null if it does not exist.
+        /// </summary>
+        /// <param name="session">The session.</param>
+        /// <param name="shortName">The shortName by which to get the preference.</param>
+        /// <returns>The <see cref="UserPreference"/> or null if it does not exist in the current user.</returns>
+        private UserPreference GetFavoritePreference(ISession session, string shortName)
+        {
+            var favoritePreference =
+                session.ActivePerson.UserPreference.FirstOrDefault(userPreference => userPreference.ShortName == shortName);
+            return favoritePreference;
+        }
+
+        /// <summary>
+        /// Converts value array of <see cref="UserPreference"/> value into list of <see cref="Guid"/>.
+        /// </summary>
+        /// <param name="userPreference">
+        /// A <see cref="UserPreference"/> with a comma seperated list of string Guids.
+        /// </param>
+        /// <returns>
+        /// HashSet of <see cref="Guid"/>s that were stored in the Value property of <see cref="UserPreference"/>.
+        /// </returns>
+        private HashSet<Guid> GetIidsFromUserPreference(UserPreference userPreference)
+        {
+            var result = new HashSet<Guid>();
+
+            if (userPreference == null)
+            {
+                return result;
+            }
+
+            var userPreferenceValue = userPreference.Value;
+
+            if (string.IsNullOrWhiteSpace(userPreferenceValue))
+            {
+                return result;
+            }
+
+            var values = userPreferenceValue.Split(',');
+
+            foreach (var iidString in values)
+            {
+                if (Guid.TryParse(iidString.Trim(), out var iid))
+                {
+                    result.Add(iid);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the shortname of the user preference based on <see cref="Type"/>.
+        /// </summary>
+        /// <param name="type">The type to use for retrieving the shortname from the map.</param>
+        /// <returns>The shortname of the setting.</returns>
+        private string GetPreferenceShortname(Type type)
+        {
+            if (this.favoritesTypeMap.TryGetValue(type, out var result))
+            {
+                return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/CDP4Composition/Services/FavoritesService/IFavoritesService.cs
+++ b/CDP4Composition/Services/FavoritesService/IFavoritesService.cs
@@ -1,0 +1,47 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="IFavoritesService.cs" company="RHEA System S.A.">
+//   Copyright (c) 2019 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Services.FavoritesService
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Dal;
+
+    /// <summary>
+    /// Definition of the <see cref="IFavoritesService"/> used to load user favorite preferences from the active user.
+    /// </summary>
+    public interface IFavoritesService
+    {
+        /// <summary>
+        /// Gets a collection of <see cref="Guid"/> of things in UserPreferences of the active person
+        /// </summary>
+        /// <param name="session">The session this is attached to.</param>
+        /// <param name="type">The type of the thing to register for.</param>
+        /// <returns>List of Guids of favorite things of the requested type.</returns>
+        HashSet<Guid> GetFavoriteItemsCollectionByType(ISession session, Type type);
+
+        /// <summary>
+        /// Creates a subscription to a <see cref="UserPreference"/> change and returns a disposable to keep in the VM collection.
+        /// </summary>
+        /// <param name="session">The session this is attached to.</param>
+        /// <param name="type">The type of favorite thing to listen to.</param>
+        /// <param name="subscriberAction">The <see cref="Action"/>to subscribe to.</param>
+        /// <returns>A <see cref="IDisposable"/> of the created observable.</returns>
+        IDisposable SubscribeToChanges(ISession session, Type type, Action<HashSet<Guid>> subscriberAction);
+
+        /// <summary>
+        /// Toggles the favorite status of a thing.
+        /// </summary>
+        /// <typeparam name="T">The type on which to base the save.</typeparam>
+        /// <param name="thing">The thing to persist/remove from persistence</param>
+        /// <param name="session">The session in which to persist.</param>
+        /// <returns>The empty task.</returns>
+        Task ToggleFavorite<T>(ISession session, T thing) where T : Thing;
+    }
+}

--- a/CDP4Composition/Services/FilterStringService.cs
+++ b/CDP4Composition/Services/FilterStringService.cs
@@ -145,7 +145,7 @@ namespace CDP4Composition.Services
             this.OpenDeprecatedControls.Add(view, viewModel);
             this.RefreshControl(view);
 
-            logger.Debug("{0} Added deprecatable to the FilterStringService", view.Control.Name);
+            logger.Debug("{0} Added deprecatable to the FilterStringService", view.FilterableControl.Name);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace CDP4Composition.Services
             this.OpenFavoriteControls.Add(view, viewModel);
             this.RefreshControl(view);
 
-            logger.Debug("{0} Added to the Favorites FilterStringService", view.Control.Name);
+            logger.Debug("{0} Added to the Favorites FilterStringService", view.FilterableControl.Name);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace CDP4Composition.Services
         /// <param name="view">The view to refresh.</param>
         private void RefreshControl(IPanelFilterableDataGridView view)
         {
-            var control = view.Control;
+            var control = view.FilterableControl;
             control.FilterString = string.Empty;
 
             // filters are always reenabled in case they were manually turned off.

--- a/CDP4Composition/Services/FilterStringService.cs
+++ b/CDP4Composition/Services/FilterStringService.cs
@@ -7,9 +7,8 @@
 namespace CDP4Composition.Services
 {
     using System.Collections.Generic;
-
-    using DevExpress.Xpf.Grid;
-
+    using System.Linq;
+    using Navigation.Interfaces;
     using NLog;
 
     /// <summary>
@@ -20,7 +19,18 @@ namespace CDP4Composition.Services
         /// <summary>
         /// The string to filter rows of things that are deprecated.
         /// </summary>
-        private const string DeprecatedFilterString = "[IsHidden]=False";
+        private static readonly string DeprecatedFilterString = "[IsDeprecated]=False";
+
+        /// <summary>
+        /// The string to filter rows of things that not favorite.
+        /// </summary>
+        private static readonly string FavoriteFilterString = "[IsFavorite]=True";
+
+        /// <summary>
+        /// The string to filter rows of things that not favorite and deprected.
+        /// </summary>
+        private static readonly string FavoriteAndHideDeprecatedFilterString =
+            $"{FavoriteFilterString} AND {DeprecatedFilterString}";
 
         /// <summary>
         /// Object used to make this singleton threadsafe
@@ -33,9 +43,16 @@ namespace CDP4Composition.Services
         private static Logger logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
-        /// The DataControlBase controls of the open <see cref="DataControlBase"/>s
+        /// The view and viewmodel of deprecatable browsers.
         /// </summary>
-        public readonly Dictionary<string, DataControlBase> OpenControls = new Dictionary<string, DataControlBase>();
+        public readonly Dictionary<IPanelFilterableDataGridView, IDeprecatableBrowserViewModel> OpenDeprecatedControls =
+            new Dictionary<IPanelFilterableDataGridView, IDeprecatableBrowserViewModel>();
+
+        /// <summary>
+        /// The view and viewmodel of favoritable browsers.
+        /// </summary>
+        public readonly Dictionary<IPanelFilterableDataGridView, IFavoritesBrowserViewModel> OpenFavoriteControls =
+            new Dictionary<IPanelFilterableDataGridView, IFavoritesBrowserViewModel>();
 
         /// <summary>
         /// Field backing the <see cref="FilterString"/> property
@@ -50,7 +67,7 @@ namespace CDP4Composition.Services
         }
 
         /// <summary>
-        /// Gets the deprecated filter.
+        /// Gets the grid filter string service.
         /// </summary>
         public static FilterStringService FilterString
         {
@@ -69,74 +86,174 @@ namespace CDP4Composition.Services
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the deprecated filter is enabled.
+        /// Gets the viewmodel in charge of toggling the state of deprecatable visibility.
         /// </summary>
-        public bool IsFilterActive { get; private set; } = true;
+        public IDeprecatableToggleViewModel DeprecatableToggleViewModel { get; private set; }
 
         /// <summary>
-        /// Toggles the <see cref="IsFilterActive"/> property and refreshes all linked controls in the <see cref="OpenControls"/> property.
+        /// Registers a filterable panel view and viewmodel combo to this service.
         /// </summary>
-        public void ToggleIsFilterActive()
+        /// <param name="view">The view.</param>
+        /// <param name="viewModel">The viewmodel.</param>
+        public void RegisterForService(IPanelView view, IPanelViewModel viewModel)
         {
-            this.IsFilterActive = !this.IsFilterActive;
-            this.RefreshAll();
+            if (!(view is IPanelFilterableDataGridView filterableView))
+            {
+                // if not filterable view, do not bother registration
+                return;
+            }
+
+            if (viewModel is IDeprecatableBrowserViewModel deprecatableViewModel)
+            {
+                // deprecatable viewmodel
+                this.AddDeprecatedControl(filterableView, deprecatableViewModel);
+            }
+
+            if (viewModel is IFavoritesBrowserViewModel favoritableViewModel)
+            {
+                // favoritable viewmodel
+                this.AddFavoritesControl(filterableView, favoritableViewModel);
+            }
         }
 
         /// <summary>
-        /// Typesafely, add a grid control to the list of open controls <see cref="OpenControls"/>.
+        /// Unregisters a panel view from all relevant collections.
         /// </summary>
-        /// <param name="gridControl">
-        /// The grid Control.
-        /// </param>
-        public void AddGridControl(GridControl gridControl) => this.AddControl(gridControl);
-
-        /// <summary>
-        /// Typesafely, add a tree list control to the list of open controls <see cref="OpenControls"/>.
-        /// </summary>
-        /// <param name="treeListControl">
-        /// The grid control.
-        /// </param>
-        public void AddTreeListControl(TreeListControl treeListControl) => this.AddControl(treeListControl);
-
-        /// <summary>
-        /// The add a control derived from DataControlBase to the list of open controls <see cref="OpenControls"/>.
-        /// </summary>
-        /// <param name="control">
-        /// The tree list control.
-        /// </param>
-        private void AddControl(DataControlBase control)
+        /// <param name="view">The view to unregister.</param>
+        public void UnregisterFromService(IPanelView view)
         {
-            if (control == null)
+            if (!(view is IPanelFilterableDataGridView filterableView))
             {
                 return;
             }
 
-            control.FilterString = DeprecatedFilterString;
-            this.OpenControls[control.Name] = control;
-            this.RefreshControl(control);
-
-            logger.Debug("{0} Added to the FilterStringService", control.Name);
+            this.RemoveView(filterableView);
         }
 
         /// <summary>
-        /// The refresh all <see cref="OpenControls"/>.
+        /// Add the deprecatable browser view and viewmodel to the list of open controls <see cref="OpenDeprecatedControls"/>.
         /// </summary>
-        private void RefreshAll()
+        /// <param name="view">The view.</param>
+        /// <param name="viewModel">The view model.</param>
+        private void AddDeprecatedControl(IPanelFilterableDataGridView view, IDeprecatableBrowserViewModel viewModel)
         {
-            foreach (var grid in this.OpenControls.Values)
+            if (view == null || viewModel == null)
+            {
+                return;
+            }
+
+            this.OpenDeprecatedControls.Add(view, viewModel);
+            this.RefreshControl(view);
+
+            logger.Debug("{0} Added deprecatable to the FilterStringService", view.Control.Name);
+        }
+
+        /// <summary>
+        /// Add the favoratable browser view and viewmodel to the list of open controls <see cref="OpenFavoriteControls"/>.
+        /// </summary>
+        /// <param name="view">The view.</param>
+        /// <param name="viewModel">The view model.</param>
+        private void AddFavoritesControl(IPanelFilterableDataGridView view, IFavoritesBrowserViewModel viewModel)
+        {
+            if (view == null || viewModel == null)
+            {
+                return;
+            }
+
+            this.OpenFavoriteControls.Add(view, viewModel);
+            this.RefreshControl(view);
+
+            logger.Debug("{0} Added to the Favorites FilterStringService", view.Control.Name);
+        }
+
+        /// <summary>
+        /// Refresh all <see cref="OpenDeprecatedControls"/>.
+        /// </summary>
+        public void RefreshDeprecatableFilterAll()
+        {
+            foreach (var grid in this.OpenDeprecatedControls.Keys)
             {
                 this.RefreshControl(grid);
             }
         }
 
         /// <summary>
-        /// Handles the refreshing of the control when needed (initially and 
+        /// Refresh a favoratable grid or tree control.
         /// </summary>
-        /// <param name="control"></param>
-        private void RefreshControl(DataControlBase control)
+        /// <param name="vm">The ViewModel of type <see cref="IFavoritesBrowserViewModel"/> to refresh</param>
+        public void RefreshFavoriteBrowser(IFavoritesBrowserViewModel vm)
         {
-            control.IsFilterEnabled = this.IsFilterActive;
+            var registeredView = this.OpenFavoriteControls
+                .FirstOrDefault(c => c.Value == vm).Key;
+
+            if (registeredView != null)
+            {
+                this.RefreshControl(registeredView);
+            }
+        }
+
+        /// <summary>
+        /// Remove the view from all registered disctionaries.
+        /// </summary>
+        /// <param name="view">The view to remove.</param>
+        private void RemoveView(IPanelFilterableDataGridView view)
+        {
+            this.OpenDeprecatedControls.Remove(view);
+            this.OpenFavoriteControls.Remove(view);
+        }
+
+        /// <summary>
+        /// Handles the refreshing of the control when needed
+        /// </summary>
+        /// <param name="view">The view to refresh.</param>
+        private void RefreshControl(IPanelFilterableDataGridView view)
+        {
+            var control = view.Control;
+            control.FilterString = string.Empty;
+
+            // filters are always reenabled in case they were manually turned off.
+            control.IsFilterEnabled = true;
+
+            // deprecation state can be told no matter if the browser has the favorites vm assigned or not
+            if (!this.DeprecatableToggleViewModel.ShowDeprecatedThings)
+            {
+                control.FilterString = DeprecatedFilterString;
+            }
+
+            // if the control is favoratable
+            if (this.OpenFavoriteControls.TryGetValue(view, out var viewModel))
+            {
+                if (!this.DeprecatableToggleViewModel.ShowDeprecatedThings && viewModel.ShowOnlyFavorites)
+                {
+                    control.FilterString = FavoriteAndHideDeprecatedFilterString;
+                }
+                else if (this.DeprecatableToggleViewModel.ShowDeprecatedThings && viewModel.ShowOnlyFavorites)
+                {
+                    control.FilterString = FavoriteFilterString;
+                }
+                else if (!this.DeprecatableToggleViewModel.ShowDeprecatedThings && !viewModel.ShowOnlyFavorites)
+                {
+                    control.FilterString = DeprecatedFilterString;
+                }
+                else
+                {
+                    control.FilterString = string.Empty;
+                }
+
+                return;
+            }
+
             control.RefreshData();
+        }
+
+        /// <summary>
+        /// Register the viewmodel rsponsible for holding the state of the visibility of deprecatable things.
+        /// </summary>
+        /// <param name="showDeprecatedBrowserRibbonViewModel">The <see cref="IDeprecatableToggleViewModel"/> representing the vm.</param>
+        public void RegisterDeprecatableToggleViewModel(
+            IDeprecatableToggleViewModel showDeprecatedBrowserRibbonViewModel)
+        {
+            this.DeprecatableToggleViewModel = showDeprecatedBrowserRibbonViewModel;
         }
     }
 }

--- a/CDP4Composition/Utilities/IconUtilities.cs
+++ b/CDP4Composition/Utilities/IconUtilities.cs
@@ -39,6 +39,11 @@ namespace CDP4Common.Helpers
         /// </summary>
         public static readonly Uri RelationshipOverlayUri = new Uri("pack://application:,,,/CDP4Composition;component/Resources/Images/Log/linkgreen_16x16.png");
 
+        /// <summary>
+        /// The <see cref="Uri"/> to the favorite image overlay.
+        /// </summary>
+        public static readonly Uri FavoriteOverlayUri = (new DXImageConverter().ConvertFrom("NewContact_16x16.png") as DXImageInfo)?.MakeUri();
+
         public static ImageSource ToImageSource(this Icon icon)
         {
             var imageSource = Imaging.CreateBitmapSourceFromHIcon(
@@ -463,9 +468,10 @@ namespace CDP4Common.Helpers
                 case ClassKind.TimeOfDayParameterType:
                 case ClassKind.ParameterTypeComponent:
                 case ClassKind.ParameterType:
-                    imagename = "parametertype";
+                    imagename = "NameManager";
+                    imageInfo = new DXImageConverter().ConvertFrom($"{imagename}{imagesize}{imageextension}") as DXImageInfo;
 
-                    return $"{compositionroot}{imagename}{imagesize}{imageextension}";
+                    return imageInfo.MakeUri().ToString();
                 case ClassKind.Definition:
                     imagename = "SendBehindText";
                     imageInfo = new DXImageConverter().ConvertFrom($"{imagename}{imagesize}{imageextension}") as DXImageInfo;

--- a/CDP4Composition/Views/CommonThingControl.xaml
+++ b/CDP4Composition/Views/CommonThingControl.xaml
@@ -71,7 +71,7 @@
 
         <dxb:BarCheckItem 
                           IsChecked="{Binding ShowOnlyFavorites}"
-                          IsVisible="{Binding IsFavoriteToggleEnabled, ElementName=Toolbar}"
+                          IsVisible="{Binding IsFavoriteToggleVisible, ElementName=Toolbar}"
                           Content="Filter on Favorite Things"
                           Description="Toggle filtering on favorite items."
                           Glyph="{dx:DXImage Image=NewContact_16x16.png}"

--- a/CDP4Composition/Views/CommonThingControl.xaml
+++ b/CDP4Composition/Views/CommonThingControl.xaml
@@ -6,6 +6,7 @@
              xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:mvvm="clr-namespace:CDP4Composition.Mvvm"
+             Name="Toolbar"
              d:DesignHeight="300"
              d:DesignWidth="300"
              mc:Ignorable="d">
@@ -24,7 +25,7 @@
 
     <dxb:ToolBarControl Height="30">
         <dxb:BarSplitButtonItem Glyph="{dx:DXImage Image=Add_16x16.png}" 
-                                Hint="Create an item."
+                                Hint="Create an Item."
                                 IsEnabled="{Binding IsAddButtonEnabled, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
             <dxb:BarSplitButtonItem.PopupControl>
                 <dxb:PopupMenu ItemLinksSource="{Binding Path=CreateContextMenu, Mode=OneWay}" />
@@ -67,5 +68,16 @@
         <dxb:BarButtonItem ItemClick="ButtonBase_OnClick"
                            Glyph="{dx:DXImage Image=Zoom_16x16.png}"
                            Hint="Show Search Panel" />
+
+        <dxb:BarCheckItem 
+                          IsChecked="{Binding ShowOnlyFavorites}"
+                          IsVisible="{Binding IsFavoriteToggleEnabled, ElementName=Toolbar}"
+                          Content="Filter on Favorite Things"
+                          Description="Toggle filtering on favorite items."
+                          Glyph="{dx:DXImage Image=NewContact_16x16.png}"
+                          Hint="Toggle filtering on favorite items."
+                          IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"/>
+
+        <dxb:BarSplitButtonItem />
     </dxb:ToolBarControl>
 </UserControl>

--- a/CDP4Composition/Views/CommonThingControl.xaml.cs
+++ b/CDP4Composition/Views/CommonThingControl.xaml.cs
@@ -26,11 +26,17 @@ namespace CDP4Composition.Views
         private readonly static DependencyProperty GridViewProperty = DependencyProperty.Register("GridView", typeof(GridDataViewBase), typeof(CommonThingControl));
 
         /// <summary>
+        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="IsFavoriteToggleEnabled"/> setter method.
+        /// </summary>
+        private readonly static DependencyProperty IsFavoriteToggleEnabledProperty = DependencyProperty.Register("IsFavoriteToggleEnabled", typeof(bool), typeof(CommonThingControl));
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CommonThingControl"/> class.
         /// </summary>
         public CommonThingControl()
         {
             this.InitializeComponent();
+            this.IsFavoriteToggleEnabled = false;
         }
 
         /// <summary>
@@ -38,8 +44,17 @@ namespace CDP4Composition.Views
         /// </summary>
         public GridDataViewBase GridView
         {
-            get { return GetValue(GridViewProperty) as GridDataViewBase; }
-            set { SetValue(GridViewProperty, value); }
+            get { return this.GetValue(GridViewProperty) as GridDataViewBase; }
+            set { this.SetValue(GridViewProperty, value); }
+        }
+
+        /// <summary>
+        /// The boolean that enables or disables the visibility of the favorites toggle buttons.
+        /// </summary>
+        public bool IsFavoriteToggleEnabled
+        {
+            get { return this.GetValue(IsFavoriteToggleEnabledProperty) is bool ? (bool) this.GetValue(IsFavoriteToggleEnabledProperty) : false; }
+            set { this.SetValue(IsFavoriteToggleEnabledProperty, value); }
         }
 
         /// <summary>

--- a/CDP4Composition/Views/CommonThingControl.xaml.cs
+++ b/CDP4Composition/Views/CommonThingControl.xaml.cs
@@ -26,9 +26,9 @@ namespace CDP4Composition.Views
         private readonly static DependencyProperty GridViewProperty = DependencyProperty.Register("GridView", typeof(GridDataViewBase), typeof(CommonThingControl));
 
         /// <summary>
-        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="IsFavoriteToggleEnabled"/> setter method.
+        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="IsFavoriteToggleVisible"/> setter method.
         /// </summary>
-        private readonly static DependencyProperty IsFavoriteToggleEnabledProperty = DependencyProperty.Register("IsFavoriteToggleEnabled", typeof(bool), typeof(CommonThingControl));
+        private readonly static DependencyProperty IsFavoriteToggleVisibleProperty = DependencyProperty.Register("IsFavoriteToggleVisible", typeof(bool), typeof(CommonThingControl));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommonThingControl"/> class.
@@ -36,7 +36,7 @@ namespace CDP4Composition.Views
         public CommonThingControl()
         {
             this.InitializeComponent();
-            this.IsFavoriteToggleEnabled = false;
+            this.IsFavoriteToggleVisible = false;
         }
 
         /// <summary>
@@ -51,10 +51,10 @@ namespace CDP4Composition.Views
         /// <summary>
         /// The boolean that enables or disables the visibility of the favorites toggle buttons.
         /// </summary>
-        public bool IsFavoriteToggleEnabled
+        public bool IsFavoriteToggleVisible
         {
-            get { return this.GetValue(IsFavoriteToggleEnabledProperty) is bool ? (bool) this.GetValue(IsFavoriteToggleEnabledProperty) : false; }
-            set { this.SetValue(IsFavoriteToggleEnabledProperty, value); }
+            get { return this.GetValue(IsFavoriteToggleVisibleProperty) is bool ? (bool) this.GetValue(IsFavoriteToggleVisibleProperty) : false; }
+            set { this.SetValue(IsFavoriteToggleVisibleProperty, value); }
         }
 
         /// <summary>

--- a/CDP4IME/CDP4IMEBootstrapper.cs
+++ b/CDP4IME/CDP4IMEBootstrapper.cs
@@ -125,7 +125,7 @@ namespace CDP4IME
         {
             this.UpdateBootstrapperState("Configuring Region Mappings");
 
-            RegionAdapterMappings mappings = base.ConfigureRegionAdapterMappings();
+            var mappings = base.ConfigureRegionAdapterMappings();
 
             mappings.RegisterMapping(typeof(LayoutPanel), this.Container.GetExportedValue<LayoutPanelAdapter>());
             mappings.RegisterMapping(typeof(LayoutGroup), this.Container.GetExportedValue<LayoutGroupAdapter>());

--- a/CDP4IME/Shell.xaml
+++ b/CDP4IME/Shell.xaml
@@ -284,7 +284,7 @@
             <dxdo:LayoutGroup DestroyOnClosingChildren="False" Orientation="Horizontal">
 
                 <dxdo:LayoutGroup ItemHeight="0.7*" Orientation="Horizontal">
-                    <dxdo:LayoutGroup Name="LeftGroup"
+                    <dxdo:TabbedGroup Name="LeftGroup"
                                       DestroyOnClosingChildren="False"
                                       ItemWidth="0.2*"
                                       regions:RegionManager.RegionName="{x:Static cdp4Composition:RegionNames.LeftPanel}" />
@@ -292,7 +292,7 @@
                                         DestroyOnClosingChildren="False"
                                         ItemWidth="0.6*"
                                         regions:RegionManager.RegionName="{x:Static cdp4Composition:RegionNames.EditorPanel}" />
-                    <dxdo:LayoutGroup Name="rightGroup"
+                    <dxdo:TabbedGroup Name="rightGroup"
                                       DestroyOnClosingChildren="False"
                                       ItemWidth="0.2*"
                                       regions:RegionManager.RegionName="{x:Static cdp4Composition:RegionNames.RightPanel}" />

--- a/CDP4SiteDirectory.Tests/ShowDeprecatedRibbonViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/ShowDeprecatedRibbonViewModelTestFixture.cs
@@ -30,14 +30,6 @@ namespace CDP4SiteDirectory.Tests
         }
 
         [Test]
-        public void VerifyShowHideDeprecatedThingsCommandDoesNotThrowError()
-        {
-            var viewmodel = new ShowDeprecatedBrowserRibbonViewModel();
-            Assert.IsTrue(viewmodel.ShowHideDeprecatedThingsCommand.CanExecute(null));
-            viewmodel.ShowHideDeprecatedThingsCommand.Execute(null);
-        }
-
-        [Test]
         public void VerifyThatSessionArePopulated()
         {
             var viewmodel = new ShowDeprecatedBrowserRibbonViewModel();

--- a/CDP4SiteDirectory/ViewModels/DomainOfExpertiseBrowser/DomainOfExpertiseBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/DomainOfExpertiseBrowser/DomainOfExpertiseBrowserViewModel.cs
@@ -7,7 +7,7 @@
 namespace CDP4SiteDirectory.ViewModels
 {
     using System;
-    using System.Linq;   
+    using System.Linq;
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
     using CDP4CommonView;
@@ -23,9 +23,11 @@ namespace CDP4SiteDirectory.ViewModels
     /// <summary>
     /// represents a view-model for the <see cref="DomainOfExpertise"/>s in a <see cref="SiteDirectory"/>
     /// </summary>
-    public class DomainOfExpertiseBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class DomainOfExpertiseBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel,
+        IDeprecatableBrowserViewModel
     {
         #region Fields
+
         /// <summary>
         /// The row comparer
         /// </summary>
@@ -39,7 +41,7 @@ namespace CDP4SiteDirectory.ViewModels
         /// <summary>
         /// The Panel Caption
         /// </summary>
-        private const string PanelCaption = "Domains of expertise";
+        private const string PanelCaption = "Domains of Expertise";
 
         #endregion
 
@@ -58,11 +60,15 @@ namespace CDP4SiteDirectory.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public DomainOfExpertiseBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public DomainOfExpertiseBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
             this.DomainOfExpertises = new ReactiveList<DomainOfExpertiseRowViewModel>();
             this.ComputeDomains();
@@ -83,9 +89,11 @@ namespace CDP4SiteDirectory.ViewModels
         /// Gets the List of <see cref="DomainOfExpertiseRowViewModel"/>
         /// </summary>
         public ReactiveList<DomainOfExpertiseRowViewModel> DomainOfExpertises { get; private set; }
+
         #endregion
 
         #region browser base
+
         /// <summary>
         /// Initialize the <see cref="ReactiveCommand"/>s of the current view-model
         /// </summary>
@@ -137,8 +145,10 @@ namespace CDP4SiteDirectory.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Domain of Expertise", "", this.CreateCommand, MenuItemKind.Create, ClassKind.DomainOfExpertise));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Domain of Expertise", "", this.CreateCommand,
+                MenuItemKind.Create, ClassKind.DomainOfExpertise));
         }
+
         #endregion
 
         /// <summary>

--- a/CDP4SiteDirectory/ViewModels/OrganizationBrowser/OrganizationBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/OrganizationBrowser/OrganizationBrowserViewModel.cs
@@ -23,7 +23,7 @@ namespace CDP4SiteDirectory.ViewModels
     /// <summary>
     /// The view-model for the <see cref="OrganizationBrowser"/>
     /// </summary>
-    public class OrganizationBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class OrganizationBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// Backing field for <see cref="CanCreateOrganization"/>
@@ -113,7 +113,7 @@ namespace CDP4SiteDirectory.ViewModels
 
             foreach (var addedPerson in addedPersons)
             {
-                var row = new OrganizationBrowser.PersonRowViewModel(addedPerson, this.Session, this);
+                var row = new OrganizationBrowser.PersonRowViewModel(addedPerson, this.Session, organizationRow);
                 organizationRow.ContainedRows.Add(row);
             }
 

--- a/CDP4SiteDirectory/ViewModels/OrganizationBrowser/PersonRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/OrganizationBrowser/PersonRowViewModel.cs
@@ -6,11 +6,14 @@
 
 namespace CDP4SiteDirectory.ViewModels.OrganizationBrowser
 {
+    using System;
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4CommonView;
     using CDP4Composition.Mvvm;
     using CDP4Dal;
     using CDP4Dal.Events;
+    using ReactiveUI;
 
     /// <summary>
     /// Represents a <see cref="Person"/> object that is contained in a <see cref="SiteDirectory"/>
@@ -45,6 +48,22 @@ namespace CDP4SiteDirectory.ViewModels.OrganizationBrowser
         }
 
         /// <summary>
+        /// Initializes the subscriptions
+        /// </summary>
+        protected override void InitializeSubscriptions()
+        {
+            base.InitializeSubscriptions();
+
+            if (this.ContainerViewModel is OrganizationRowViewModel deprecatable)
+            {
+                var containerIsDeprecatedSubscription = deprecatable.WhenAnyValue(vm => vm.IsDeprecated)
+                    .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
+
+                this.Disposables.Add(containerIsDeprecatedSubscription);
+            }
+        }
+
+        /// <summary>
         /// Update the properties of this row
         /// </summary>
         private void UpdateProperties()
@@ -58,6 +77,19 @@ namespace CDP4SiteDirectory.ViewModels.OrganizationBrowser
             {
                 this.RoleName = string.Empty;
                 this.RoleShortName = string.Empty;
+            }
+
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
+        }
+
+        /// <summary>
+        /// Updates the IsDeprecated property based on the value of the container <see cref="OrganizationRowViewModel"/>
+        /// </summary>
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
+        {
+            if (this.ContainerViewModel is OrganizationRowViewModel deprecatable)
+            {
+                this.IsDeprecated = deprecatable.IsDeprecated;
             }
         }
     }

--- a/CDP4SiteDirectory/ViewModels/PersonBrowser/PersonBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/PersonBrowser/PersonBrowserViewModel.cs
@@ -23,7 +23,8 @@ namespace CDP4SiteDirectory.ViewModels
     /// The <see cref="PersonBrowserViewModel"/> is a View Model that is responsible for managing the data and interactions with that data for a view
     /// that shows the <see cref="Person"/>s and the related <see cref="Participant"/> contained by a <see cref="SiteDirectory"/>
     /// </summary>
-    public class PersonBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class PersonBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel,
+        IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// Backing field for <see cref="CanCreatePerson"/>
@@ -50,16 +51,20 @@ namespace CDP4SiteDirectory.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public PersonBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public PersonBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
             this.PersonRowViewModels = new ReactiveList<PersonRowViewModel>();
             this.UpdatePersonRows();
         }
-        
+
         /// <summary>
         /// Gets the <see cref="PersonRowViewModel"/> that are contained by the row-view-model
         /// </summary>
@@ -172,7 +177,6 @@ namespace CDP4SiteDirectory.ViewModels
             base.ComputePermission();
             this.CanCreatePerson = this.PermissionService.CanWrite(ClassKind.Person, this.Thing);
         }
-        
 
         /// <summary>
         /// Populate the <see cref="PersonBrowserViewModel.ContextMenu"/>
@@ -180,7 +184,8 @@ namespace CDP4SiteDirectory.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Person", "", this.CreateCommand, MenuItemKind.Create, ClassKind.Person));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Person", "", this.CreateCommand,
+                MenuItemKind.Create, ClassKind.Person));
         }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/RoleBrowser/ParticipantPermissionRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/RoleBrowser/ParticipantPermissionRowViewModel.cs
@@ -53,6 +53,8 @@ namespace CDP4SiteDirectory.ViewModels
         {
             get { return this.ObjectClass; }
         }
+
+        /// <summary>
         /// Initializes the subscriptions
         /// </summary>
         protected override void InitializeSubscriptions()
@@ -77,5 +79,6 @@ namespace CDP4SiteDirectory.ViewModels
             {
                 this.IsDeprecated = deprecatable.IsDeprecated;
             }
+        }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/RoleBrowser/PersonPermissionRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/RoleBrowser/PersonPermissionRowViewModel.cs
@@ -53,6 +53,8 @@ namespace CDP4SiteDirectory.ViewModels
         {
             get { return this.ObjectClass; }
         }
+
+        /// <summary>
         /// Initializes the subscriptions
         /// </summary>
         protected override void InitializeSubscriptions()
@@ -69,9 +71,6 @@ namespace CDP4SiteDirectory.ViewModels
         }
 
         /// <summary>
-        }
-
-        /// <summary>
         /// Updates the IsDeprecated property based on the value of the container <see cref="PersonRoleRowViewModel"/>
         /// </summary>
         private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
@@ -80,5 +79,6 @@ namespace CDP4SiteDirectory.ViewModels
             {
                 this.IsDeprecated = deprecatable.IsDeprecated;
             }
+        }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/RoleBrowser/RoleBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/RoleBrowser/RoleBrowserViewModel.cs
@@ -23,7 +23,7 @@ namespace CDP4SiteDirectory.ViewModels
     /// <summary>
     /// The purpose of the <see cref="RoleBrowserViewModel"/> is to represent the view-model for <see cref="CDP4Common.SiteDirectoryData.Rule"/>s
     /// </summary>
-    public class RoleBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class RoleBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel, IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// The <see cref="CDP4Common.SiteDirectoryData.PersonRole"/> folder row

--- a/CDP4SiteDirectory/ViewModels/SiteRdlBrowser/SiteRdlBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/SiteRdlBrowser/SiteRdlBrowserViewModel.cs
@@ -18,11 +18,12 @@ namespace CDP4SiteDirectory.ViewModels
     using CDP4Dal;
     using CDP4Dal.Events;
     using ReactiveUI;
-    
+
     /// <summary>
     /// The view-model for the <see cref="SiteRdlBrowserViewModel"/>
     /// </summary>
-    public class SiteRdlBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel
+    public class SiteRdlBrowserViewModel : BrowserViewModelBase<SiteDirectory>, IPanelViewModel,
+        IDeprecatableBrowserViewModel
     {
         /// <summary>
         /// Backing field for <see cref="CanCreateSiteRdl"/>
@@ -49,12 +50,15 @@ namespace CDP4SiteDirectory.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-
-        public SiteRdlBrowserViewModel(ISession session, SiteDirectory siteDir, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
-            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
+        public SiteRdlBrowserViewModel(ISession session, SiteDirectory siteDir,
+            IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService,
+            IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+            : base(siteDir, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService,
+                pluginSettingsService)
         {
             this.Caption = string.Format("{0}, {1}", PanelCaption, this.Thing.Name);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.ToolTip = string.Format("{0}\n{1}\n{2}", this.Thing.Name, this.Thing.IDalUri,
+                this.Session.ActivePerson.Name);
 
             this.SiteRdls = new ReactiveList<SiteRdlRowViewModel>();
             this.ComputeSiteRdlRows();
@@ -115,7 +119,8 @@ namespace CDP4SiteDirectory.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Site Rdl", "", this.CreateCommand, MenuItemKind.Create, ClassKind.SiteReferenceDataLibrary));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Site Rdl", "", this.CreateCommand,
+                MenuItemKind.Create, ClassKind.SiteReferenceDataLibrary));
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml
+++ b/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml
@@ -56,6 +56,7 @@
                                VerticalAlignment="Stretch"
                                AllowEditing="True"
                                AllowGrouping="False"
+                               RowStyle="{StaticResource RowStyleDeprecated}"
                                AutoWidth="true"
                                ShowFilterPanelMode="Never"
                                EditorShowMode="MouseUpFocused"
@@ -67,11 +68,7 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
+                    
                     <dxg:TableView.FocusedRow>
                         <dynamic:ExpandoObject />
                     </dxg:TableView.FocusedRow>
@@ -97,7 +94,7 @@
                         </ControlTemplate>
                     </dxg:GridColumn.DisplayTemplate>
                 </dxg:GridColumn>
-                <dxg:GridColumn FieldName="Name" Header="Name" />
+                <dxg:GridColumn FieldName="Name" Header="Name" SortIndex="0" />
                 <dxg:GridColumn FieldName="ShortName" Header="Short Name" />
             </dxg:GridControl.Columns>
             <dxg:GridControl.InputBindings>

--- a/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.DomainsGridControl;
+                this.FilterableControl = this.DomainsGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace CDP4SiteDirectory.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for DomainOfExpertiseBrowser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class DomainOfExpertiseBrowser : IPanelView
+    public partial class DomainOfExpertiseBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.DomainsGridControl);
+                this.Control = this.DomainsGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/CDP4SiteDirectory/Views/HighlightingRibbon.xaml
+++ b/CDP4SiteDirectory/Views/HighlightingRibbon.xaml
@@ -12,7 +12,7 @@
                                 MergeOrder="9000"
                                 mc:Ignorable="d">
     <dxb:BarButtonItem Command="{Binding ClearHighlightingCommand}"
-                       Content="Clear highlighting"
+                       Content="Clear Highlighting"
                        Description="Clear highlighting of all things in all browsers"
                        Glyph="{dx:DXImage Image=HighlightField_16x16.png}"
                        Hint="Clear highlighting of all things in all browsers"

--- a/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml
+++ b/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml
@@ -91,7 +91,7 @@
                 <dragDrop:FrameworkElementDragBehavior />
             </i:Interaction.Behaviors>
             <dxg:TreeListControl.Columns>
-                <dxg:TreeListColumn FieldName="Name" Header="Name" />
+                <dxg:TreeListColumn FieldName="Name" Header="Name" SortIndex="0"/>
                 <dxg:TreeListColumn FieldName="ShortName" Header="Short Name" />
                 <dxg:TreeListColumn FieldName="RoleName" Header="Role" />
                 <dxg:TreeListColumn FieldName="DefaultEmailAddressValue" Header="Default Email" />
@@ -106,7 +106,9 @@
                                   ShowHorizontalLines="False"
                                   ShowIndicator="False"
                                   ShowNodeImages="False"
+                                  RowStyle="{StaticResource RowStyleDeprecated}"
                                   ShowVerticalLines="False"
+                                  FilterMode="Smart"
                                   ShowFilterPanelMode="Never"
                                   TreeDerivationMode="HierarchicalDataTemplate"
                                   TreeLineStyle="Solid"
@@ -114,11 +116,7 @@
                     <dxg:TreeListView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TreeListView.ContextMenu>
-                    <dxg:TreeListView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TreeListView.RowStyle>
+                    
                 </dxg:TreeListView>
             </dxg:TreeListControl.View>
             <dxg:TreeListControl.InputBindings>

--- a/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml.cs
@@ -45,14 +45,14 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.OrganizationsTreeList;
+                this.FilterableControl = this.OrganizationsTreeList;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
 
     }
 }

--- a/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace CDP4SiteDirectory.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for OrganizationBrowser.xaml
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class OrganizationBrowser : IPanelView
+    public partial class OrganizationBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,14 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddTreeListControl(this.OrganizationsTreeList);
+                this.Control = this.OrganizationsTreeList;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
+
     }
 }

--- a/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml
+++ b/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml
@@ -123,7 +123,7 @@
                 <cdp4Composition:ContextMenuBehavior />
             </dxmvvm:Interaction.Behaviors>
             <dxg:TreeListControl.Columns>
-                <dxg:TreeListColumn FieldName="GivenName" Header="First Name" />
+                <dxg:TreeListColumn FieldName="GivenName" Header="First Name" SortIndex="0" />
                 <dxg:TreeListColumn FieldName="Surname" Header="Last Name" />
                 <dxg:TreeListColumn FieldName="Organization.ShortName" Header="Organization" />
             </dxg:TreeListControl.Columns>
@@ -137,6 +137,7 @@
                                   ShowHorizontalLines="False"
                                   ShowIndicator="False"
                                   ShowNodeImages="False"
+                                  RowStyle="{StaticResource RowStyleDeprecated}"
                                   ShowVerticalLines="False"
                                   FixedLineWidth="0"
                                   TreeDerivationMode="HierarchicalDataTemplate"
@@ -149,11 +150,7 @@
                     <dxg:TreeListView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TreeListView.ContextMenu>
-                    <dxg:TreeListView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TreeListView.RowStyle>
+                    
                 </dxg:TreeListView>
             </dxg:TreeListControl.View>
             <dxg:TreeListControl.InputBindings>

--- a/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.PersonsTreeListControl;
+                this.FilterableControl = this.PersonsTreeListControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace CDP4SiteDirectory.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for PersonBrowser
     /// </summary>
     [PanelViewExport(RegionNames.RightPanel)]
-    public partial class PersonBrowser : IPanelView
+    public partial class PersonBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddTreeListControl(this.PersonsTreeListControl);
+                this.Control = this.PersonsTreeListControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml
+++ b/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml
@@ -192,6 +192,7 @@
                                   NavigationStyle="Cell"
                                   ShowHorizontalLines="False"
                                   ShowIndicator="False"
+                                  RowStyle="{StaticResource RowStyleDeprecated}"
                                   ShowNodeImages="False"
                                   ShowVerticalLines="False"
                                   TreeDerivationMode="HierarchicalDataTemplate"
@@ -201,11 +202,6 @@
                     <dxg:TreeListView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TreeListView.ContextMenu>
-                    <dxg:TreeListView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TreeListView.RowStyle>
                 </dxg:TreeListView>
             </dxg:TreeListControl.View>
             <dxg:TreeListControl.InputBindings>

--- a/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace CDP4SiteDirectory.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for Role browser
     /// </summary>
     [PanelViewExport(RegionNames.RightPanel)]
-    public partial class RoleBrowser : IPanelView
+    public partial class RoleBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddTreeListControl(this.RolesTreeListControl);
+                this.Control = this.RolesTreeListControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.RolesTreeListControl;
+                this.FilterableControl = this.RolesTreeListControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/CDP4SiteDirectory/Views/ShowDeprecatedRibbon.xaml
+++ b/CDP4SiteDirectory/Views/ShowDeprecatedRibbon.xaml
@@ -12,11 +12,11 @@
                                 MergeOrder="9000"
                                 mc:Ignorable="d">
 
-    <dxb:BarCheckItem Command="{Binding ShowHideDeprecatedThingsCommand}"
-                       Content="Show deprecated things"
-                       Description="Show or hide deprecated things in all browsers"
+    <dxb:BarCheckItem IsChecked="{Binding ShowDeprecatedThings}"
+                       Content="Show Deprecated Things"
+                       Description="Show or hide deprecated things in all browsers."
                        Glyph="{dx:DXImage Image=Show_16x16.png}"
-                       Hint="Show or hide deprecated things in all browsers"
+                       Hint="Show or hide deprecated things in all browsers."
                        IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"
                        LargeGlyph="{dx:DXImage Image=Show_32x32.png}"
                        RibbonStyle="large" />

--- a/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml
+++ b/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml
@@ -57,6 +57,7 @@
                                VerticalAlignment="Stretch"
                                AllowColumnMoving="True"
                                AllowEditing="False"
+                               RowStyle="{StaticResource RowStyleDeprecated}"
                                AllowGrouping="True"
                                AutoWidth="true"
                                ShowFilterPanelMode="Never"
@@ -68,11 +69,6 @@
                     <dxg:TableView.ContextMenu>
                         <ContextMenu Name="RowContextMenu" />
                     </dxg:TableView.ContextMenu>
-                    <dxg:TableView.RowStyle>
-                        <Style TargetType="{x:Type dxg:RowControl}">
-                            <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                        </Style>
-                    </dxg:TableView.RowStyle>
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>

--- a/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace CDP4SiteDirectory.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for Organization Browser
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class SiteRdlBrowser : IPanelView
+    public partial class SiteRdlBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddGridControl(this.SiteRdlsGridControl);
+                this.Control = this.SiteRdlsGridControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }

--- a/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml.cs
+++ b/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace CDP4SiteDirectory.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.SiteRdlsGridControl;
+                this.FilterableControl = this.SiteRdlsGridControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterComponentValueRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterComponentValueRowViewModel.cs
@@ -147,8 +147,13 @@ namespace CDP4EngineeringModel.ViewModels
         /// </summary>
         public override void SetValues()
         {
-            var compoundParameterType = (CompoundParameterType)this.Thing.ParameterType;
             base.SetValues();
+
+            if (!(this.Thing.ParameterType is CompoundParameterType compoundParameterType))
+            {
+                throw new InvalidOperationException("This row shall only be used for CompoundParameterType.");
+            }
+
             this.Scale = compoundParameterType.Component[this.ValueIndex].Scale;
             this.ScaleShortName = this.Scale == null ? "-" : this.Scale.ShortName;
         }

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterValueBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterValueBaseRowViewModel.cs
@@ -102,7 +102,7 @@ namespace CDP4EngineeringModel.ViewModels
             this.ValueIndex = valueIndex;
             this.ParameterTypeClassKind = this.Thing.ParameterType.ClassKind;
 
-            this.SetValues();
+            this.UpdateThingStatus();
             this.SetOwnerValue();
         }
         #endregion

--- a/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml.cs
+++ b/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml.cs
@@ -12,7 +12,7 @@ namespace CDP4EngineeringModel.Views
     /// <summary>
     /// Interaction logic for ElementDefinitions view
     /// </summary>
-    [PanelViewExport(RegionNames.LeftPanel)]
+    [PanelViewExport(RegionNames.EditorPanel)]
     public partial class ElementDefinitionsBrowser : IPanelView
     {
         /// <summary>

--- a/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
@@ -10,20 +10,30 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
     using System.Linq;
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Composition;
+    using CDP4Composition.Services;
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4RelationshipMatrix.Settings;
+    using Moq;
     using NUnit.Framework;
     using ViewModels;
 
     public class RelationshipMatrixViewModelTestFixture : ViewModelTestBase
     {
+        private Mock<IDeprecatableToggleViewModel> toggle;
+
         [SetUp]
         public override void Setup()
         {
             base.Setup();
+
+            this.toggle = new Mock<IDeprecatableToggleViewModel>();
+            this.toggle.Setup(x => x.ShowDeprecatedThings).Returns(true);
+
+            FilterStringService.FilterString.RegisterDeprecatableToggleViewModel(this.toggle.Object);
         }
-        
+
         [Test]
         public void AssertViewModelWorks()
         {
@@ -46,18 +56,27 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
             Assert.AreEqual(this.settings.PossibleClassKinds.Count, vm.SourceYConfiguration.PossibleClassKinds.Count);
             Assert.AreEqual(0, vm.RelationshipConfiguration.PossibleRules.Count);
 
-            vm.SourceYConfiguration.SelectedClassKind = vm.SourceYConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
-            vm.SourceXConfiguration.SelectedClassKind = vm.SourceXConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
+            vm.SourceYConfiguration.SelectedClassKind =
+                vm.SourceYConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
+            vm.SourceXConfiguration.SelectedClassKind =
+                vm.SourceXConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
 
-            Assert.AreEqual(this.srdl.DefinedCategory.Count(x => x.PermissibleClass.Contains(ClassKind.ElementDefinition)), vm.SourceYConfiguration.PossibleCategories.Count);
-            Assert.AreEqual(this.srdl.DefinedCategory.Count(x => x.PermissibleClass.Contains(ClassKind.ElementDefinition)), vm.SourceXConfiguration.PossibleCategories.Count);
+            Assert.AreEqual(
+                this.srdl.DefinedCategory.Count(x => x.PermissibleClass.Contains(ClassKind.ElementDefinition)),
+                vm.SourceYConfiguration.PossibleCategories.Count);
+            Assert.AreEqual(
+                this.srdl.DefinedCategory.Count(x => x.PermissibleClass.Contains(ClassKind.ElementDefinition)),
+                vm.SourceXConfiguration.PossibleCategories.Count);
 
             Assert.AreEqual(this.srdl.Rule.Count, vm.RelationshipConfiguration.PossibleRules.Count);
             Assert.IsEmpty(vm.Matrix.Records);
             Assert.IsEmpty(vm.Matrix.Columns);
 
-            vm.SourceYConfiguration.SelectedCategories = new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd1.Iid || x.Iid == this.catEd2.Iid));
-            vm.SourceXConfiguration.SelectedCategories = new List<Category>(vm.SourceXConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd2.Iid));
+            vm.SourceYConfiguration.SelectedCategories = new List<Category>(
+                vm.SourceYConfiguration.PossibleCategories.Where(x =>
+                    x.Iid == this.catEd1.Iid || x.Iid == this.catEd2.Iid));
+            vm.SourceXConfiguration.SelectedCategories =
+                new List<Category>(vm.SourceXConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd2.Iid));
             vm.SourceYConfiguration.SelectedBooleanOperatorKind = CategoryBooleanOperatorKind.OR;
             vm.RelationshipConfiguration.SelectedRule = vm.RelationshipConfiguration.PossibleRules.Single();
 
@@ -67,21 +86,25 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
             Assert.AreEqual(3, vm.Matrix.Columns.Count);
 
             vm.SourceYConfiguration.IncludeSubcategories = true;
-            
+
             Assert.AreEqual(5, vm.Matrix.Records.Count);
             Assert.AreEqual(3, vm.Matrix.Columns.Count);
 
-            vm.SourceYConfiguration.SelectedCategories = new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd3.Iid));
+            vm.SourceYConfiguration.SelectedCategories =
+                new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd3.Iid));
 
             Assert.AreEqual(2, vm.Matrix.Records.Count);
             Assert.AreEqual(3, vm.Matrix.Columns.Count);
 
-            vm.SourceYConfiguration.SelectedCategories = new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd4.Iid));
+            vm.SourceYConfiguration.SelectedCategories =
+                new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd4.Iid));
 
             Assert.AreEqual(1, vm.Matrix.Records.Count);
             Assert.AreEqual(3, vm.Matrix.Columns.Count);
 
-            vm.SourceYConfiguration.SelectedCategories = new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd1.Iid || x.Iid == this.catEd2.Iid));
+            vm.SourceYConfiguration.SelectedCategories = new List<Category>(
+                vm.SourceYConfiguration.PossibleCategories.Where(x =>
+                    x.Iid == this.catEd1.Iid || x.Iid == this.catEd2.Iid));
             vm.SourceYConfiguration.SelectedBooleanOperatorKind = CategoryBooleanOperatorKind.AND;
 
             Assert.AreEqual(1, vm.Matrix.Records.Count);
@@ -108,11 +131,16 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
                 this.dialogNavigationService.Object,
                 this.pluginService.Object);
 
-            vm.SourceYConfiguration.SelectedClassKind = vm.SourceYConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
-            vm.SourceXConfiguration.SelectedClassKind = vm.SourceXConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
+            vm.SourceYConfiguration.SelectedClassKind =
+                vm.SourceYConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
+            vm.SourceXConfiguration.SelectedClassKind =
+                vm.SourceXConfiguration.PossibleClassKinds.First(x => x == ClassKind.ElementDefinition);
 
-            vm.SourceYConfiguration.SelectedCategories = new List<Category>(vm.SourceYConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd1.Iid || x.Iid == this.catEd2.Iid));
-            vm.SourceXConfiguration.SelectedCategories = new List<Category>(vm.SourceXConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd2.Iid));
+            vm.SourceYConfiguration.SelectedCategories = new List<Category>(
+                vm.SourceYConfiguration.PossibleCategories.Where(x =>
+                    x.Iid == this.catEd1.Iid || x.Iid == this.catEd2.Iid));
+            vm.SourceXConfiguration.SelectedCategories =
+                new List<Category>(vm.SourceXConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd2.Iid));
             vm.SourceYConfiguration.SelectedBooleanOperatorKind = CategoryBooleanOperatorKind.OR;
             vm.RelationshipConfiguration.SelectedRule = vm.RelationshipConfiguration.PossibleRules.Single();
 

--- a/RelationshipMatrix/ViewModels/MatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/MatrixViewModel.cs
@@ -260,7 +260,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <summary>
         /// Gets or sets a value indicating whether deprecated items are shown
         /// </summary>
-        public bool IsDeprecatedDisplayed { get; set; } = !FilterStringService.FilterString.IsFilterActive;
+        public bool IsDeprecatedDisplayed { get; set; } = !FilterStringService.FilterString.DeprecatableToggleViewModel.ShowDeprecatedThings;
 
         /// <summary>
         /// Gets or sets the records used for row construction.

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RelationshipParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RelationshipParameterValueRowViewModel.cs
@@ -128,7 +128,7 @@ namespace CDP4Requirements.ViewModels
             if (requirementRowViewModel != null)
             {
                 var containerIsDeprecatedSubscription = requirementRowViewModel.WhenAnyValue(vm => vm.IsDeprecated)
-                .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel());
+                .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
                 this.Disposables.Add(containerIsDeprecatedSubscription);
             }
         }
@@ -136,7 +136,7 @@ namespace CDP4Requirements.ViewModels
         /// <summary>
         /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
         /// </summary>
-        private void UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel()
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
         {
             var requirementRowViewModel = this.ContainerViewModel as RequirementRowViewModel;
             if (requirementRowViewModel != null)
@@ -178,7 +178,7 @@ namespace CDP4Requirements.ViewModels
                 this.ScaleShortName = this.Scale.ShortName;
             }
 
-            this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel();
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
     }
 }

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsContainerParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsContainerParameterValueRowViewModel.cs
@@ -128,7 +128,7 @@ namespace CDP4Requirements.ViewModels
             if (requirementRowViewModel != null)
             {
                 var containerIsDeprecatedSubscription = requirementRowViewModel.WhenAnyValue(vm => vm.IsDeprecated)
-                .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel());
+                .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
                 this.Disposables.Add(containerIsDeprecatedSubscription);
             }
         }
@@ -136,7 +136,7 @@ namespace CDP4Requirements.ViewModels
         /// <summary>
         /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
         /// </summary>
-        private void UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel()
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
         {
             var requirementRowViewModel = this.ContainerViewModel as RequirementRowViewModel;
             if (requirementRowViewModel != null)
@@ -178,7 +178,7 @@ namespace CDP4Requirements.ViewModels
                 this.ScaleShortName = this.Scale.ShortName;
             }
 
-            this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel();
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
     }
 }

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsGroupRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsGroupRowViewModel.cs
@@ -25,7 +25,8 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// The row-view-model that represents a <see cref="RequirementsGroup"/>
     /// </summary>
-    public class RequirementsGroupRowViewModel : RequirementContainerRowViewModel<RequirementsGroup>, IDropTarget, IDeprecatableThing
+    public class RequirementsGroupRowViewModel : RequirementContainerRowViewModel<RequirementsGroup>, IDropTarget,
+        IDeprecatableThing
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequirementsGroupRowViewModel"/> class
@@ -34,7 +35,8 @@ namespace CDP4Requirements.ViewModels
         /// <param name="session">The <see cref="ISession"/></param>
         /// <param name="containerViewModel">The container <see cref="IViewModelBase{T}"/></param>
         /// <param name="topNode">The top level node for this row</param>
-        public RequirementsGroupRowViewModel(RequirementsGroup group, ISession session, IViewModelBase<Thing> containerViewModel, RequirementsSpecificationRowViewModel topNode)
+        public RequirementsGroupRowViewModel(RequirementsGroup group, ISession session,
+            IViewModelBase<Thing> containerViewModel, RequirementsSpecificationRowViewModel topNode)
             : base(group, session, containerViewModel, topNode)
         {
             this.UpdateProperties();
@@ -50,7 +52,7 @@ namespace CDP4Requirements.ViewModels
             this.UpdateRequirementGroupRows();
             this.UpdateIsDeprecatedDerivedFromContainerRequirementsSpecification();
         }
-        
+
         /// <summary>
         /// Initializes the subscriptions
         /// </summary>
@@ -58,7 +60,8 @@ namespace CDP4Requirements.ViewModels
         {
             base.InitializeSubscriptions();
 
-            var requirementsSpecificationRowViewModel = this.ContainerViewModel as RequirementsSpecificationRowViewModel;
+            var requirementsSpecificationRowViewModel =
+                this.ContainerViewModel as RequirementsSpecificationRowViewModel;
             if (requirementsSpecificationRowViewModel != null)
             {
                 var containerIsDeprecatedSubscription =
@@ -86,17 +89,19 @@ namespace CDP4Requirements.ViewModels
         /// <summary>
         /// Recursively Update the IsDeprecated property
         /// </summary>
-        /// <param name="containedGroupRows">
-        /// 
+        /// <param name="groupRows">
+        /// The collection of rows in the group.
         /// </param>
-        /// <param name="isDeprecated"></param>
-        private void RecursivelyUpdateIsDeprecated(IEnumerable<RequirementsGroupRowViewModel> groupRows, bool isDeprecated)
+        /// <param name="isDeprecated">The deprecated state.</param>
+        private void RecursivelyUpdateIsDeprecated(IEnumerable<RequirementsGroupRowViewModel> groupRows,
+            bool isDeprecated)
         {
             foreach (var requirementsGroupRowViewModel in groupRows)
             {
                 requirementsGroupRowViewModel.IsDeprecated = isDeprecated;
 
-                var containedGroupRows = requirementsGroupRowViewModel.ContainedRows.OfType<RequirementsGroupRowViewModel>();
+                var containedGroupRows =
+                    requirementsGroupRowViewModel.ContainedRows.OfType<RequirementsGroupRowViewModel>();
                 requirementsGroupRowViewModel.RecursivelyUpdateIsDeprecated(containedGroupRows, isDeprecated);
             }
         }
@@ -110,7 +115,7 @@ namespace CDP4Requirements.ViewModels
             base.ObjectChangeEventHandler(objectChange);
             this.UpdateProperties();
         }
-        
+
         /// <summary>
         /// Queries whether a drag can be started
         /// </summary>
@@ -152,9 +157,12 @@ namespace CDP4Requirements.ViewModels
             {
                 var canDropRequirement = this.PermissionService.CanWrite(requirement);
                 var requirementSpecification = this.Thing.GetContainerOfType<RequirementsSpecification>();
-                var canModifyRequirementSpecification = (requirementSpecification == requirement.Container) || this.PermissionService.CanWrite(ClassKind.Requirement, requirementSpecification);
+                var canModifyRequirementSpecification = (requirementSpecification == requirement.Container) ||
+                                                        this.PermissionService.CanWrite(ClassKind.Requirement,
+                                                            requirementSpecification);
 
-                if (!canDropRequirement || !canModifyRequirementSpecification || requirement.IDalUri.ToString() != this.Session.DataSourceUri)
+                if (!canDropRequirement || !canModifyRequirementSpecification ||
+                    requirement.IDalUri.ToString() != this.Session.DataSourceUri)
                 {
                     dropInfo.Effects = DragDropEffects.None;
                 }
@@ -164,10 +172,10 @@ namespace CDP4Requirements.ViewModels
 
             var group = dropInfo.Payload as RequirementsGroup;
             if (group != null)
-            { 
+            {
                 var canDropRequirementGroup = this.PermissionService.CanWrite(ClassKind.RequirementsGroup, this.Thing);
                 if (!canDropRequirementGroup || group.IDalUri.ToString() != this.Session.DataSourceUri
-                    || this.CreatesCycle(this.Thing, group))
+                                             || this.CreatesCycle(this.Thing, group))
                 {
                     dropInfo.Effects = DragDropEffects.None;
                 }
@@ -223,7 +231,7 @@ namespace CDP4Requirements.ViewModels
             else
             {
                 // insert before first
-                var model = (EngineeringModel)this.Thing.TopContainer;
+                var model = (EngineeringModel) this.Thing.TopContainer;
                 var orderPt = OrderHandlerService.GetOrderParameterType(model);
 
                 if (orderPt == null)
@@ -273,7 +281,7 @@ namespace CDP4Requirements.ViewModels
             if (dropInfo.KeyStates == (DragDropKeyStates.LeftMouseButton | DragDropKeyStates.ControlKey))
             {
                 // ordered-move
-                var model = (EngineeringModel)this.Thing.TopContainer;
+                var model = (EngineeringModel) this.Thing.TopContainer;
                 var orderPt = OrderHandlerService.GetOrderParameterType(model);
 
                 if (orderPt == null)
@@ -282,7 +290,8 @@ namespace CDP4Requirements.ViewModels
                 }
 
                 var orderService = new RequirementsGroupOrderHandlerService(this.Session, orderPt);
-                var transaction = orderService.Insert(requirementGroup, this.Thing, dropInfo.IsDroppedAfter ? InsertKind.InsertAfter : InsertKind.InsertBefore);
+                var transaction = orderService.Insert(requirementGroup, this.Thing,
+                    dropInfo.IsDroppedAfter ? InsertKind.InsertAfter : InsertKind.InsertBefore);
                 await this.Session.Write(transaction.FinalizeTransaction());
             }
             else
@@ -301,7 +310,10 @@ namespace CDP4Requirements.ViewModels
                 if (previousRequirementSpec != currentRequirementSpec)
                 {
                     // Update the requirements that were inside any of the groups that have been dropped
-                    var previousRequirementSpecRow = (RequirementsSpecificationRowViewModel)((RequirementsBrowserViewModel)this.TopParentRow.ContainerViewModel).ReqSpecificationRows.Single(x => x.Thing == previousRequirementSpec);
+                    var previousRequirementSpecRow =
+                        (RequirementsSpecificationRowViewModel)
+                        ((RequirementsBrowserViewModel) this.TopParentRow.ContainerViewModel).ReqSpecificationRows
+                        .Single(x => x.Thing == previousRequirementSpec);
                     var droppedRequirementGroups = requirementGroup.ContainedGroup().ToList();
                     droppedRequirementGroups.Add(requirementGroup);
                     foreach (var keyValuePair in previousRequirementSpecRow.requirementContainerGroupCache)
@@ -338,7 +350,8 @@ namespace CDP4Requirements.ViewModels
             }
 
             parentRequirementsGroup = parentRequirementsGroup.Container as RequirementsGroup;
-            return parentRequirementsGroup != null && this.CreatesCycle(parentRequirementsGroup, draggedRequirementsGroup);
+            return parentRequirementsGroup != null &&
+                   this.CreatesCycle(parentRequirementsGroup, draggedRequirementsGroup);
         }
     }
 }

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsSpecificationRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RequirementsSpecificationRowViewModel.cs
@@ -26,7 +26,8 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// A row-view-model that represents a <see cref="RequirementsSpecification"/> in the requirement browser
     /// </summary>
-    public class RequirementsSpecificationRowViewModel : RequirementContainerRowViewModel<RequirementsSpecification>, IDropTarget
+    public class RequirementsSpecificationRowViewModel : RequirementContainerRowViewModel<RequirementsSpecification>,
+        IDropTarget
     {
         /// <summary>
         /// Cache for the <see cref="Requirement"/> currently contained
@@ -42,14 +43,15 @@ namespace CDP4Requirements.ViewModels
         /// The <see cref="Requirement"/> update listener cache
         /// </summary>
         private Dictionary<Requirement, IDisposable> listenerCache;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RequirementsSpecificationRowViewModel"/> class
         /// </summary>
         /// <param name="reqContainer">The <see cref="RequirementsSpecification"/></param>
         /// <param name="session">The <see cref="ISession"/></param>
         /// <param name="containerViewModel">The container <see cref="IViewModelBase{T}"/></param>
-        public RequirementsSpecificationRowViewModel(RequirementsSpecification reqContainer, ISession session, IViewModelBase<Thing> containerViewModel)
+        public RequirementsSpecificationRowViewModel(RequirementsSpecification reqContainer, ISession session,
+            IViewModelBase<Thing> containerViewModel)
             : base(reqContainer, session, containerViewModel)
         {
             this.requirementCache = new Dictionary<Requirement, IRowViewModelBase<Requirement>>();
@@ -63,7 +65,7 @@ namespace CDP4Requirements.ViewModels
         /// Gets the <see cref="RequirementsGroup"/> cache
         /// </summary>
         public Dictionary<RequirementsGroup, IRowViewModelBase<Thing>> GroupCache { get; private set; }
-        
+
         /// <summary>
         /// Gets the content of the first definition.
         /// </summary>
@@ -132,17 +134,20 @@ namespace CDP4Requirements.ViewModels
             }
 
             var updateListener = CDPMessageBus.Current.Listen<ObjectChangedEvent>(req)
-                .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber)
+                .Where(objectChange => objectChange.EventKind == EventKind.Updated &&
+                                       objectChange.ChangedThing.RevisionNumber > this.RevisionNumber)
                 .ObserveOn(RxApp.MainThreadScheduler)
-                .Subscribe(x => this.UpdateRequirementRow((Requirement)x.ChangedThing, false));
+                .Subscribe(x => this.UpdateRequirementRow((Requirement) x.ChangedThing, false));
 
-            var orderPt = OrderHandlerService.GetOrderParameterType((EngineeringModel)this.Thing.TopContainer);
+            var orderPt = OrderHandlerService.GetOrderParameterType((EngineeringModel) this.Thing.TopContainer);
             if (orderPt != null)
             {
                 var orderListener = CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(SimpleParameterValue))
-                    .Where(objectChange => ((SimpleParameterValue)objectChange.ChangedThing).ParameterType == orderPt && this.Thing.Requirement.Any(r => r.ParameterValue.Contains(objectChange.ChangedThing)))
+                    .Where(objectChange =>
+                        ((SimpleParameterValue) objectChange.ChangedThing).ParameterType == orderPt &&
+                        this.Thing.Requirement.Any(r => r.ParameterValue.Contains(objectChange.ChangedThing)))
                     .ObserveOn(RxApp.MainThreadScheduler)
-                    .Subscribe(x => this.UpdateRequirementRow((Requirement)x.ChangedThing.Container, true));
+                    .Subscribe(x => this.UpdateRequirementRow((Requirement) x.ChangedThing.Container, true));
 
                 this.Disposables.Add(orderListener);
             }
@@ -192,7 +197,8 @@ namespace CDP4Requirements.ViewModels
         /// <param name="newOrder">A value indicating whether the order may have changed</param>
         private void UpdateRequirementRow(Requirement req, bool newOrder)
         {
-            if (req.Container != this.Thing || !this.requirementContainerGroupCache.ContainsKey(req) || !this.requirementCache.ContainsKey(req))
+            if (req.Container != this.Thing || !this.requirementContainerGroupCache.ContainsKey(req) ||
+                !this.requirementCache.ContainsKey(req))
             {
                 return;
             }
@@ -201,13 +207,14 @@ namespace CDP4Requirements.ViewModels
 
             var reqRow = this.requirementCache[req];
             var currentContainerRow = currentGroup != null ? this.GroupCache[currentGroup] : this;
-            
+
             IRowViewModelBase<Thing> updatedContainerRow;
             if (req.Group != null)
             {
                 if (!this.GroupCache.TryGetValue(req.Group, out updatedContainerRow))
                 {
-                    logger.Error("The requirement-group {0} could not be found in the Specification {1}", req.Group.Name, this.Thing.Name);
+                    logger.Error("The requirement-group {0} could not be found in the Specification {1}",
+                        req.Group.Name, this.Thing.Name);
                     return;
                 }
             }
@@ -285,7 +292,8 @@ namespace CDP4Requirements.ViewModels
             if (group != null)
             {
                 var canDropRequirementGroup = this.PermissionService.CanWrite(ClassKind.RequirementsGroup, this.Thing);
-                if (!canDropRequirementGroup || group.IDalUri.ToString() != this.Session.DataSourceUri || this.Thing.Group.Contains(group))
+                if (!canDropRequirementGroup || group.IDalUri.ToString() != this.Session.DataSourceUri ||
+                    this.Thing.Group.Contains(group))
                 {
                     dropInfo.Effects = DragDropEffects.None;
                 }
@@ -359,7 +367,7 @@ namespace CDP4Requirements.ViewModels
             else
             {
                 // insert before first
-                var model = (EngineeringModel)this.Thing.TopContainer;
+                var model = (EngineeringModel) this.Thing.TopContainer;
                 var orderPt = OrderHandlerService.GetOrderParameterType(model);
 
                 if (orderPt == null)
@@ -422,7 +430,9 @@ namespace CDP4Requirements.ViewModels
                 if (previousRequirementSpec != this.Thing)
                 {
                     // Update the requirements that were inside any of the groups that have been dropped
-                    var previousRequirementSpecRow = (RequirementsSpecificationRowViewModel)((RequirementsBrowserViewModel)this.ContainerViewModel).ReqSpecificationRows.Single(x => x.Thing == previousRequirementSpec);
+                    var previousRequirementSpecRow =
+                        (RequirementsSpecificationRowViewModel) ((RequirementsBrowserViewModel) this.ContainerViewModel)
+                        .ReqSpecificationRows.Single(x => x.Thing == previousRequirementSpec);
                     var droppedRequirementGroups = requirementGroupPayload.ContainedGroup().ToList();
                     droppedRequirementGroups.Add(requirementGroupPayload);
                     foreach (var keyValuePair in previousRequirementSpecRow.requirementContainerGroupCache)
@@ -443,7 +453,7 @@ namespace CDP4Requirements.ViewModels
             else
             {
                 // insert before first
-                var model = (EngineeringModel)this.Thing.TopContainer;
+                var model = (EngineeringModel) this.Thing.TopContainer;
                 var orderPt = OrderHandlerService.GetOrderParameterType(model);
 
                 if (orderPt == null)
@@ -466,7 +476,7 @@ namespace CDP4Requirements.ViewModels
         /// <param name="dropinfo">The <see cref="IDropInfo"/></param>
         private async Task OnRequirementSpecificationDrop(RequirementsSpecification reqSpecPayload, IDropInfo dropinfo)
         {
-            var model = (EngineeringModel)this.Thing.TopContainer;
+            var model = (EngineeringModel) this.Thing.TopContainer;
             var orderPt = OrderHandlerService.GetOrderParameterType(model);
 
             if (orderPt == null)
@@ -475,7 +485,8 @@ namespace CDP4Requirements.ViewModels
             }
 
             var orderService = new RequirementsSpecificationOrderHandlerService(this.Session, orderPt);
-            var transaction = orderService.Insert(reqSpecPayload, this.Thing, dropinfo.IsDroppedAfter ? InsertKind.InsertAfter : InsertKind.InsertBefore);
+            var transaction = orderService.Insert(reqSpecPayload, this.Thing,
+                dropinfo.IsDroppedAfter ? InsertKind.InsertAfter : InsertKind.InsertBefore);
             await this.Session.Write(transaction.FinalizeTransaction());
         }
     }

--- a/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
@@ -128,7 +128,7 @@ namespace CDP4Requirements.ViewModels
             if (requirementRowViewModel != null)
             {
                 var containerIsDeprecatedSubscription = requirementRowViewModel.WhenAnyValue(vm => vm.IsDeprecated)
-                .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel());
+                .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
                 this.Disposables.Add(containerIsDeprecatedSubscription);
             }
         }
@@ -136,7 +136,7 @@ namespace CDP4Requirements.ViewModels
         /// <summary>
         /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
         /// </summary>
-        private void UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel()
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
         {
             var requirementRowViewModel = this.ContainerViewModel as RequirementRowViewModel;
             if (requirementRowViewModel != null)
@@ -178,7 +178,7 @@ namespace CDP4Requirements.ViewModels
                 this.ScaleShortName = this.Scale.ShortName;
             }
 
-            this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel();
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
     }
 }

--- a/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementRowViewModel.cs
@@ -11,7 +11,7 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
     using System.Linq;
     using System.Reactive;
     using System.Threading.Tasks;
-    using CDP4Common.CommonData;    
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4CommonView.EventAggregator;
     using CDP4CommonView.ViewModels;
@@ -20,7 +20,7 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
     using CDP4Dal.Events;
     using CDP4Requirements.Utils;
     using ReactiveUI;
-    
+
     /// <summary>
     /// The <see cref="RequirementRowViewModel"/> is the view-model that represents a <see cref="Requirement"/> in the <see cref="RequirementsSpecificationEditorViewModel"/>
     /// </summary>
@@ -35,7 +35,7 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
         /// Backing field for the <see cref="Categories"/> property
         /// </summary>
         private string categories;
-        
+
         /// <summary>
         /// Backing field for the <see cref="DefinitionContent"/> property
         /// </summary>
@@ -72,7 +72,8 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
         /// <param name="requirement">The <see cref="Requirement"/> associated with this row</param>
         /// <param name="session">The session</param>
         /// <param name="containerViewModel">The <see cref="IViewModelBase{Thing}"/> that is the container of this <see cref="IRowViewModelBase{Thing}"/></param>
-        public RequirementRowViewModel(Requirement requirement, ISession session, IViewModelBase<Thing> containerViewModel)
+        public RequirementRowViewModel(Requirement requirement, ISession session,
+            IViewModelBase<Thing> containerViewModel)
             : base(requirement, session, containerViewModel)
         {
             this.InitializeCommands();
@@ -80,17 +81,13 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
 
             this.WhenAnyValue(vm => vm.DefinitionContent).Subscribe(
                 _ =>
-                    {
-                        var originalDefinition = this.Thing.Definition.FirstOrDefault();
-                        var originalDefinitionText = originalDefinition == null ? String.Empty : originalDefinition.Content;
-                        this.IsDirty = this.DefinitionContent != originalDefinitionText;
-                    });
+                {
+                    var originalDefinition = this.Thing.Definition.FirstOrDefault();
+                    var originalDefinitionText = originalDefinition == null ? String.Empty : originalDefinition.Content;
+                    this.IsDirty = this.DefinitionContent != originalDefinitionText;
+                });
 
             this.UpdateProperties();
-
-            var specSubscription =
-                CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(RequirementsSpecification)).ObserveOn(RxApp.MainThreadScheduler).Subscribe(x => this.UpdateRowVisibility());
-            this.Disposables.Add(specSubscription);
         }
 
         /// <summary>
@@ -191,18 +188,8 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
             this.SetDefinitionContent();
 
             this.SetCategories();
-            
-            this.BreadCrumb = this.Thing.BreadCrumb();
-            this.UpdateRowVisibility();
-        }
 
-        /// <summary>
-        /// Update the visibility of this row
-        /// </summary>
-        protected override void UpdateRowVisibility()
-        {
-            var isDeprecated = this.IsDeprecated || ((RequirementsSpecification)this.Thing.Container).IsDeprecated;
-            this.ShouldBeDisplayed = !isDeprecated || this.IsDeprecatedDisplayed;
+            this.BreadCrumb = this.Thing.BreadCrumb();
         }
 
         /// <summary>
@@ -263,7 +250,8 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
         private void InitializeCommands()
         {
             var canSave = this.WhenAnyValue(vm => vm.IsDirty).Select(_ => this.IsDirty);
-            this.SaveCommand = ReactiveCommand.CreateAsyncTask(canSave, x => this.WriteDefinitionUpdate(), RxApp.MainThreadScheduler);
+            this.SaveCommand =
+                ReactiveCommand.CreateAsyncTask(canSave, x => this.WriteDefinitionUpdate(), RxApp.MainThreadScheduler);
 
             this.CancelCommand = ReactiveCommand.Create(canSave);
             this.CancelCommand.Subscribe(_ => this.ResetContent(true));
@@ -280,7 +268,8 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
             // give a warning. If user cancels the changes are not reset.
             if (withWarning)
             {
-                var yesNoDialog = new YesNoDialogViewModel( "Cancel Edit", "Press Yes if you want to cancel the edit. All changes will be lost");
+                var yesNoDialog = new YesNoDialogViewModel("Cancel Edit",
+                    "Press Yes if you want to cancel the edit. All changes will be lost");
                 var dialogResult = this.dialogNavigationService.NavigateModal(yesNoDialog);
                 if (dialogResult != null && dialogResult.Result != null && dialogResult.Result.Value)
                 {

--- a/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementSpecificationContentComparer.cs
+++ b/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementSpecificationContentComparer.cs
@@ -24,12 +24,12 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
         /// The Permissible Kind of child <see cref="IRowViewModelBase{T}"/>
         /// </summary>
         private static readonly List<Type> PermissibleRowTypes = new List<Type>
-                                                                     {
-                                                                         typeof(CDP4Requirements.ViewModels.RequirementsSpecificationEditor.RequirementsSpecificationRowViewModel),
-                                                                         typeof(CDP4Requirements.ViewModels.RequirementsSpecificationEditor.RequirementsGroupRowViewModel),
-                                                                         typeof(CDP4Requirements.ViewModels.RequirementsSpecificationEditor.RequirementRowViewModel),
-                                                                     };
-        
+        {
+            typeof(CDP4Requirements.ViewModels.RequirementsSpecificationEditor.RequirementsSpecificationRowViewModel),
+            typeof(CDP4Requirements.ViewModels.RequirementsSpecificationEditor.RequirementsGroupRowViewModel),
+            typeof(CDP4Requirements.ViewModels.RequirementsSpecificationEditor.RequirementRowViewModel),
+        };
+
         /// <summary>
         /// The <see cref="IComparer{IBreadCrumb}"/> used to compare rows of the <see cref="RequirementsSpecificationEditor"/>
         /// </summary>
@@ -41,8 +41,8 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
         /// <param name="x">The first <see cref="IRowViewModelBase{Thing}"/> to compare</param>
         /// <param name="y">The second <see cref="IRowViewModelBase{Thing}"/> to compare</param>
         /// <returns>
-        /// Less than zero : x is "lower" than y 
-        /// Zero: x "equals" y. 
+        /// Less than zero : x is "lower" than y
+        /// Zero: x "equals" y.
         /// Greater than zero: x is "greater" than y.
         /// </returns>
         public int Compare(IRowViewModelBase<Thing> x, IRowViewModelBase<Thing> y)
@@ -55,17 +55,19 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
             var xType = x.GetType();
             var yType = y.GetType();
 
-            if (!PermissibleRowTypes.Any(type => type.IsAssignableFrom(xType)) )
+            if (!PermissibleRowTypes.Any(type => type.IsAssignableFrom(xType)))
             {
-                throw new ArgumentException(string.Format("argument x is of type {0} which is not supported", xType.Name));
+                throw new ArgumentException(string.Format("argument x is of type {0} which is not supported",
+                    xType.Name));
             }
 
             if (!PermissibleRowTypes.Any(type => type.IsAssignableFrom(yType)))
             {
-                throw new ArgumentException(string.Format("argument y is of type {0} which is not supported", yType.Name));
+                throw new ArgumentException(string.Format("argument y is of type {0} which is not supported",
+                    yType.Name));
             }
-            
-            return BreadCrumbComparer.Compare((IBreadCrumb)x, (IBreadCrumb)y);
+
+            return BreadCrumbComparer.Compare((IBreadCrumb) x, (IBreadCrumb) y);
         }
     }
 }

--- a/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementsGroupRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementsGroupRowViewModel.cs
@@ -63,6 +63,14 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
         }
 
         /// <summary>
+        /// Gets the supporting row property needed for deprecatable browsers.
+        /// </summary>
+        public bool IsDeprecated
+        {
+            get { return false; }
+        }
+
+        /// <summary>
         /// The event-handler that is invoked by the subscription that listens for updates
         /// on the <see cref="Thing"/> that is being represented by the view-model
         /// </summary>

--- a/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementsSpecificationRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementsSpecificationEditor/RequirementsSpecificationRowViewModel.cs
@@ -68,15 +68,6 @@ namespace CDP4Requirements.ViewModels.RequirementsSpecificationEditor
         {
             this.OwnerShortName = this.Thing.Owner != null ? this.Thing.Owner.ShortName : string.Empty;
             this.BreadCrumb = this.Thing.BreadCrumb();
-            this.UpdateRowVisibility();
-        }
-
-        /// <summary>
-        /// Update the visibility of this row
-        /// </summary>
-        protected override void UpdateRowVisibility()
-        {
-            this.ShouldBeDisplayed = !this.IsDeprecated || this.IsDeprecatedDisplayed;
         }
     }
 }

--- a/Requirements/ViewModels/Rows/AndExpressionRowViewModel.cs
+++ b/Requirements/ViewModels/Rows/AndExpressionRowViewModel.cs
@@ -26,7 +26,7 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// the row-view-model representing a <see cref="AndExpression"/>
     /// </summary>
-    public class AndExpressionRowViewModel : CDP4CommonView.AndExpressionRowViewModel
+    public class AndExpressionRowViewModel : CDP4CommonView.AndExpressionRowViewModel, IDeprecatableThing
     {
         /// <summary>
         /// Backing field for <see cref="StringExpression"/>
@@ -98,6 +98,7 @@ namespace CDP4Requirements.ViewModels
             }
 
             this.UpdateStringExpression();
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
 
         /// <summary>
@@ -137,6 +138,14 @@ namespace CDP4Requirements.ViewModels
                 .Subscribe(_ => this.UpdateStringExpression());
 
             this.Disposables.Add(booleanExpressionsListener);
+
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                var containerIsDeprecatedSubscription = deprecatable.WhenAnyValue(vm => vm.IsDeprecated)
+                    .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
+
+                this.Disposables.Add(containerIsDeprecatedSubscription);
+            }
         }
 
         /// <summary>
@@ -145,6 +154,17 @@ namespace CDP4Requirements.ViewModels
         private void UpdateStringExpression()
         {
             this.StringExpression = this.ContainedRows.OfType<IRowViewModelBase<BooleanExpression>>().ToExpressionString(this.Thing);
+        }
+
+        /// <summary>
+        /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
+        /// </summary>
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
+        {
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                this.IsDeprecated = deprecatable.IsDeprecated;
+            }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/Rows/ExclusiveOrExpressionRowViewModel.cs
+++ b/Requirements/ViewModels/Rows/ExclusiveOrExpressionRowViewModel.cs
@@ -26,7 +26,7 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// the row-view-model representing a <see cref="ExclusiveOrExpression"/>
     /// </summary>
-    public class ExclusiveOrExpressionRowViewModel : CDP4CommonView.ExclusiveOrExpressionRowViewModel
+    public class ExclusiveOrExpressionRowViewModel : CDP4CommonView.ExclusiveOrExpressionRowViewModel, IDeprecatableThing
     {
         /// <summary>
         /// Backing field for <see cref="StringExpression"/>
@@ -100,6 +100,8 @@ namespace CDP4Requirements.ViewModels
                 this.RemoveReferencedExpressions();
                 this.UpdateStringExpression();
             }
+
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
 
         /// <summary>
@@ -155,6 +157,14 @@ namespace CDP4Requirements.ViewModels
                 .Subscribe(_ => this.UpdateStringExpression());
 
             this.Disposables.Add(booleanExpressionsListener);
+
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                var containerIsDeprecatedSubscription = deprecatable.WhenAnyValue(vm => vm.IsDeprecated)
+                    .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
+
+                this.Disposables.Add(containerIsDeprecatedSubscription);
+            }
         }
 
         /// <summary>
@@ -163,6 +173,17 @@ namespace CDP4Requirements.ViewModels
         private void UpdateStringExpression()
         {
             this.StringExpression = this.ContainedRows.OfType<IRowViewModelBase<BooleanExpression>>().ToExpressionString(this.Thing);
+        }
+
+        /// <summary>
+        /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
+        /// </summary>
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
+        {
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                this.IsDeprecated = deprecatable.IsDeprecated;
+            }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/Rows/NotExpressionRowViewModel.cs
+++ b/Requirements/ViewModels/Rows/NotExpressionRowViewModel.cs
@@ -26,7 +26,7 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// the row-view-model representing a <see cref="NotExpression"/>
     /// </summary>
-    public class NotExpressionRowViewModel : CDP4CommonView.NotExpressionRowViewModel
+    public class NotExpressionRowViewModel : CDP4CommonView.NotExpressionRowViewModel, IDeprecatableThing
     {
         /// <summary>
         /// Backing field for <see cref="StringExpression"/>
@@ -96,6 +96,7 @@ namespace CDP4Requirements.ViewModels
             }
 
             this.UpdateStringExpression();
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
 
         /// <summary>
@@ -135,6 +136,13 @@ namespace CDP4Requirements.ViewModels
                 .Subscribe(_ => this.UpdateStringExpression());
 
             this.Disposables.Add(booleanExpressionsListener);
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                var containerIsDeprecatedSubscription = deprecatable.WhenAnyValue(vm => vm.IsDeprecated)
+                    .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
+
+                this.Disposables.Add(containerIsDeprecatedSubscription);
+            }
         }
 
         /// <summary>
@@ -143,6 +151,17 @@ namespace CDP4Requirements.ViewModels
         private void UpdateStringExpression()
         {
             this.StringExpression = this.ContainedRows.OfType<IRowViewModelBase<BooleanExpression>>().ToExpressionString(this.Thing);
+        }
+
+        /// <summary>
+        /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
+        /// </summary>
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
+        {
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                this.IsDeprecated = deprecatable.IsDeprecated;
+            }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/Rows/OrExpressionRowViewModel.cs
+++ b/Requirements/ViewModels/Rows/OrExpressionRowViewModel.cs
@@ -26,7 +26,7 @@ namespace CDP4Requirements.ViewModels
     /// <summary>
     /// the row-view-model representing a <see cref="OrExpression"/>
     /// </summary>
-    public class OrExpressionRowViewModel : CDP4CommonView.OrExpressionRowViewModel
+    public class OrExpressionRowViewModel : CDP4CommonView.OrExpressionRowViewModel, IDeprecatableThing
     {
         /// <summary>
         /// Backing field for <see cref="StringExpression"/>
@@ -100,6 +100,7 @@ namespace CDP4Requirements.ViewModels
 
             this.UpdateStringExpression();
             this.RemoveReferencedExpressions();
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
 
         /// <summary>
@@ -155,6 +156,14 @@ namespace CDP4Requirements.ViewModels
                 .Subscribe(_ => this.UpdateStringExpression());
 
             this.Disposables.Add(booleanExpressionsListener);
+
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                var containerIsDeprecatedSubscription = deprecatable.WhenAnyValue(vm => vm.IsDeprecated)
+                    .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
+
+                this.Disposables.Add(containerIsDeprecatedSubscription);
+            }
         }
 
         /// <summary>
@@ -163,6 +172,17 @@ namespace CDP4Requirements.ViewModels
         private void UpdateStringExpression()
         {
             this.StringExpression = this.ContainedRows.OfType<IRowViewModelBase<BooleanExpression>>().ToExpressionString(this.Thing);
+        }
+
+        /// <summary>
+        /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
+        /// </summary>
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
+        {
+            if (this.ContainerViewModel is IDeprecatableThing deprecatable)
+            {
+                this.IsDeprecated = deprecatable.IsDeprecated;
+            }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/Rows/ParametricConstraintRowViewModel.cs
+++ b/Requirements/ViewModels/Rows/ParametricConstraintRowViewModel.cs
@@ -95,7 +95,7 @@ namespace CDP4Requirements.ViewModels
             }
 
             this.UpdateStringExpression();
-            this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel();
+            this.UpdateIsDeprecatedDerivedFromContainerRowViewModel();
         }
 
         /// <summary>
@@ -165,7 +165,7 @@ namespace CDP4Requirements.ViewModels
             if (this.ContainerViewModel is RequirementRowViewModel requirementRowViewModel)
             {
                 var containerIsDeprecatedSubscription = requirementRowViewModel.WhenAnyValue(vm => vm.IsDeprecated)
-                    .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel());
+                    .Subscribe(_ => this.UpdateIsDeprecatedDerivedFromContainerRowViewModel());
 
                 this.Disposables.Add(containerIsDeprecatedSubscription);
             }
@@ -188,7 +188,7 @@ namespace CDP4Requirements.ViewModels
         /// <summary>
         /// Updates the IsDeprecated property based on the value of the container <see cref="RequirementRowViewModel"/>
         /// </summary>
-        private void UpdateIsDeprecatedDerivedFromContainerRequirementRowViewModelModel()
+        private void UpdateIsDeprecatedDerivedFromContainerRowViewModel()
         {
             if (this.ContainerViewModel is RequirementRowViewModel requirementRowViewModel)
             {

--- a/Requirements/Views/RequirementsBrowser.xaml
+++ b/Requirements/Views/RequirementsBrowser.xaml
@@ -303,20 +303,16 @@
                                   HorizontalScrollbarVisibility="Auto"
                                   NavigationStyle="Cell"
                                   ShowHorizontalLines="False"
+                                  RowStyle="{StaticResource RowStyleDeprecated}"
                                   ShowIndicator="False"
                                   ShowNodeImages="False"
                                   ShowVerticalLines="False"
                                   FixedLineWidth="0"
+                                  FilterMode="Smart"
                                   TreeDerivationMode="HierarchicalDataTemplate"
                                   TreeLineStyle="Solid"
                                   VerticalScrollbarVisibility="Auto"
                                   ShowFilterPanelMode="Never">
-                        <dxg:TreeListView.RowStyle>
-                            <Style TargetType="{x:Type dxg:RowControl}">
-                                <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
-                            </Style>
-                        </dxg:TreeListView.RowStyle>
-
                         <dxg:TreeListView.FocusedRow>
                             <dynamic:ExpandoObject />
                         </dxg:TreeListView.FocusedRow>

--- a/Requirements/Views/RequirementsBrowser.xaml.cs
+++ b/Requirements/Views/RequirementsBrowser.xaml.cs
@@ -45,13 +45,13 @@ namespace CDP4Requirements.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                this.Control = this.RequirementBrowserTreeListControl;
+                this.FilterableControl = this.RequirementBrowserTreeListControl;
             }
         }
 
         /// <summary>
         /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
         /// </summary>
-        public DataControlBase Control { get; private set; }
+        public DataControlBase FilterableControl { get; private set; }
     }
 }

--- a/Requirements/Views/RequirementsBrowser.xaml.cs
+++ b/Requirements/Views/RequirementsBrowser.xaml.cs
@@ -8,15 +8,16 @@ namespace CDP4Requirements.Views
 {
     using CDP4Composition;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
-
+    using DevExpress.Xpf.Grid;
     using NLog;
 
     /// <summary>
     /// Interaction logic for RequirementsBrowser.xaml
     /// </summary>
     [PanelViewExport(RegionNames.LeftPanel)]
-    public partial class RequirementsBrowser : IPanelView
+    public partial class RequirementsBrowser : IPanelView, IPanelFilterableDataGridView
     {
         /// <summary>
         /// The NLog logger
@@ -44,8 +45,13 @@ namespace CDP4Requirements.Views
             if (initializeComponent)
             {
                 this.InitializeComponent();
-                FilterStringService.FilterString.AddTreeListControl(this.RequirementBrowserTreeListControl);
+                this.Control = this.RequirementBrowserTreeListControl;
             }
         }
+
+        /// <summary>
+        /// Gets the <see cref="DataControlBase"/> that is to be set up for filtering service.
+        /// </summary>
+        public DataControlBase Control { get; private set; }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [ ] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description

- Fixed bug where scrollbar dragging would become non-functional all of a sudden.
- RDL ribbon and browser cleanup, styles, ribbon groups spelling etc.
- Left and Right regions are now TabbedGroups so that browsers do not pile on indefinitely blocking the screen.
- Element Definition browser is now in central group by default.
- Added Favoriting functionality to the ParameterTypes browser. Use context menu to toggle whether a parameter type is favorited. Use button in the toolbar to toggle filter.
- Complete refactor of the filtering system to make deprecatable and favoritable filters work correctly together.
- Overhaul of browsers that make use of deprecated things to make it work with filtering (both grids and trees).

