### PR TITLE
Concatenating the scale to the shortname in order to be more descriptive

### DIFF
--- a/Requirements.Tests/RequirementBrowser/SimpleParameterValueRowViewModelTestFixture.cs
+++ b/Requirements.Tests/RequirementBrowser/SimpleParameterValueRowViewModelTestFixture.cs
@@ -68,7 +68,8 @@ namespace CDP4Requirements.Tests.RequirementBrowser
             var vm = new SimpleParameterValueRowViewModel(this.simpleParameterValue, this.session.Object, null);
 
             Assert.AreEqual(this.testParameterType.Name, vm.Name);
-            Assert.AreEqual(this.testParameterType.ShortName, vm.ShortName);            
+            vm.Scale.ShortName = "m";
+            Assert.AreEqual($"{this.testParameterType.ShortName} [{vm.Scale.ShortName}]", vm.ShortName);            
             Assert.That(vm.Definition, Is.Not.Null.Or.Empty);
             Assert.AreEqual("1, 2", vm.Definition);
         }

--- a/Requirements.Tests/RequirementBrowser/SimpleParameterValueRowViewModelTestFixture.cs
+++ b/Requirements.Tests/RequirementBrowser/SimpleParameterValueRowViewModelTestFixture.cs
@@ -41,8 +41,8 @@ namespace CDP4Requirements.Tests.RequirementBrowser
 
             this.simpleParameterValue = new SimpleParameterValue(Guid.NewGuid(), null, null)
             {
-                Scale = new CyclicRatioScale { Name = "a", ShortName = "e"},
-                ParameterType = new BooleanParameterType { Name = "a", ShortName = "a"}
+                Scale = new CyclicRatioScale { Name = "a", ShortName = "e" },
+                ParameterType = new BooleanParameterType { Name = "a", ShortName = "a" }
             };
 
             this.testParameterType = new DateParameterType(Guid.NewGuid(), null, null) { Name = "testPT", ShortName = "tpt" };
@@ -68,8 +68,9 @@ namespace CDP4Requirements.Tests.RequirementBrowser
             var vm = new SimpleParameterValueRowViewModel(this.simpleParameterValue, this.session.Object, null);
 
             Assert.AreEqual(this.testParameterType.Name, vm.Name);
-            vm.Scale.ShortName = "m";
-            Assert.AreEqual($"{this.testParameterType.ShortName} [{vm.Scale.ShortName}]", vm.ShortName);            
+            Assert.AreEqual($"{this.testParameterType.ShortName} [{vm.Scale.ShortName}]", vm.ShortName);
+            vm.Scale = null;
+            Assert.AreEqual(this.testParameterType.ShortName, vm.ShortName);
             Assert.That(vm.Definition, Is.Not.Null.Or.Empty);
             Assert.AreEqual("1, 2", vm.Definition);
         }

--- a/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
@@ -87,7 +87,7 @@ namespace CDP4Requirements.ViewModels
 
                 if (this.Scale != null)
                 {
-                    return string.Concat(this.shortName, "(", this.Scale.ShortName, ")");
+                    return $"{this.shortName} [{this.Scale.ShortName}]";
                 }
                 else
                 {

--- a/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/SimpleParameterValueRowViewModel.cs
@@ -16,7 +16,7 @@ namespace CDP4Requirements.ViewModels
     using CDP4Dal;
     using CDP4Dal.Events;
     using ReactiveUI;
-    
+
     /// <summary>
     /// The simple parameter value row view model.
     /// </summary>
@@ -82,7 +82,19 @@ namespace CDP4Requirements.ViewModels
         /// </summary>
         public string ShortName
         {
-            get { return this.shortName; }
+            get
+            {
+
+                if (this.Scale != null)
+                {
+                    return string.Concat(this.shortName, "(", this.Scale.ShortName, ")");
+                }
+                else
+                {
+                    return this.shortName;
+                }
+
+            }
             set { this.RaiseAndSetIfChanged(ref this.shortName, value); }
         }
 
@@ -142,7 +154,7 @@ namespace CDP4Requirements.ViewModels
             if (requirementRowViewModel != null)
             {
                 this.IsDeprecated = requirementRowViewModel.IsDeprecated;
-            }            
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [ ] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
Parameter type scale has been concatenated with the short name for display purpose only

