### PR TITLE
[Add] owner combobox to RelationShipMatrix configuration; fixes #140

### DIFF
--- a/RelationshipMatrix.Tests/CDP4RelationshipMatrix.Tests.csproj
+++ b/RelationshipMatrix.Tests/CDP4RelationshipMatrix.Tests.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Converters\NameContentConverterTestFixture.cs" />
     <Compile Include="Converters\ColumnWidthConverterTestFixture.cs" />
     <Compile Include="Converters\ColumnFixedConverterTestFixture.cs" />
+    <Compile Include="Converters\OrderedDomainOfExpertiseListConverterTestFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RelationshipMatrixModuleTestFixture.cs" />
     <Compile Include="Ribbon\RelationshipMatrixRibbonViewModelTestFixture.cs" />

--- a/RelationshipMatrix.Tests/Converters/OrderedDomainOfExpertiseListConverterTestFixture.cs
+++ b/RelationshipMatrix.Tests/Converters/OrderedDomainOfExpertiseListConverterTestFixture.cs
@@ -1,0 +1,95 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedDomainOfExpertiseListConverterTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4RelationshipMatrix.Tests.Converters
+{
+    using System;
+    using System.Collections.Generic;
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4RelationshipMatrix.Converters;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="OrderedDomainOfExpertiseListConverter"/> class.
+    /// </summary>
+    [TestFixture]
+    public class OrderedDomainOfExpertiseListConverterTestFixture
+    {
+        private OrderedDomainOfExpertiseListConverter orderedDomainOfExpertiseListConverter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.orderedDomainOfExpertiseListConverter = new OrderedDomainOfExpertiseListConverter();
+        }
+
+        [Test]
+        public void Verify_that_when_Convert_is_called_sorted_list_of_DomainOfExpertise_is_returned()
+        {
+            var domainOfExpertise_1 = new DomainOfExpertise() {Name = "CCC"};
+            var domainOfExpertise_2 = new DomainOfExpertise() { Name = "BBB" };
+            var domainOfExpertise_3 = new DomainOfExpertise() { Name = "AAA" };
+
+            var domains = new List<DomainOfExpertise> {domainOfExpertise_1, domainOfExpertise_2, domainOfExpertise_3};
+
+            var result = this.orderedDomainOfExpertiseListConverter.Convert(domains, null, null, null) as List<DomainOfExpertise>;
+
+            Assert.That(result[0], Is.EqualTo(domainOfExpertise_3));
+            Assert.That(result[1], Is.EqualTo(domainOfExpertise_2));
+            Assert.That(result[2], Is.EqualTo(domainOfExpertise_1));
+        }
+
+        [Test]
+        public void Verify_That_when_Convert_is_called_on_not_a_list_of_DomainOfExpertise_no_exceptions_thrown()
+        {
+            var things = new List<Thing>();
+            
+            Assert.DoesNotThrow(() =>
+            {
+                var result = this.orderedDomainOfExpertiseListConverter.Convert(things, null, null, null) as List<DomainOfExpertise>;
+
+                Assert.That(result, Is.Empty);
+
+            });
+        }
+
+        [Test]
+        public void Verify_that_when_ConvertBack_is_called_sorted_list_of_DomainOfExpertise_is_returned()
+        {
+            var domainOfExpertise_1 = new DomainOfExpertise() { Name = "CCC" };
+            var domainOfExpertise_2 = new DomainOfExpertise() { Name = "BBB" };
+            var domainOfExpertise_3 = new DomainOfExpertise() { Name = "AAA" };
+
+            var domains = new List<DomainOfExpertise> { domainOfExpertise_1, domainOfExpertise_2, domainOfExpertise_3 };
+
+            var result = this.orderedDomainOfExpertiseListConverter.Convert(domains, null, null, null) as List<DomainOfExpertise>;
+
+            Assert.That(result[0], Is.EqualTo(domainOfExpertise_3));
+            Assert.That(result[1], Is.EqualTo(domainOfExpertise_2));
+            Assert.That(result[2], Is.EqualTo(domainOfExpertise_1));
+        }
+    }
+}

--- a/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
@@ -1,8 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationshipMatrixViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4RelationshipMatrix.Tests.ViewModel
 {
@@ -19,6 +38,10 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
     using NUnit.Framework;
     using ViewModels;
 
+    /// <summary>
+    /// Suite of tests for the <see cref="RelationshipMatrixViewModel"/> class.
+    /// </summary>
+    [TestFixture]
     public class RelationshipMatrixViewModelTestFixture : ViewModelTestBase
     {
         private Mock<IDeprecatableToggleViewModel> toggle;
@@ -79,6 +102,9 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
                 new List<Category>(vm.SourceXConfiguration.PossibleCategories.Where(x => x.Iid == this.catEd2.Iid));
             vm.SourceYConfiguration.SelectedBooleanOperatorKind = CategoryBooleanOperatorKind.OR;
             vm.RelationshipConfiguration.SelectedRule = vm.RelationshipConfiguration.PossibleRules.Single();
+
+            vm.SourceXConfiguration.SelectedOwners.Add(this.domain);
+            vm.SourceYConfiguration.SelectedOwners.Add(this.domain);
 
             vm.SourceYConfiguration.IncludeSubcategories = false;
 

--- a/RelationshipMatrix.Tests/ViewModel/ViewModelTestBase.cs
+++ b/RelationshipMatrix.Tests/ViewModel/ViewModelTestBase.cs
@@ -1,8 +1,27 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ViewModelTestBase.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// ------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4RelationshipMatrix.Tests.ViewModel
 {
@@ -109,6 +128,7 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
             this.engineeringModelSetup.IterationSetup.Add(this.iterationSetup);
             this.engineeringModelSetup.RequiredRdl.Add(this.mrdl);
             this.engineeringModelSetup.Participant.Add(this.participant);
+            this.engineeringModelSetup.ActiveDomain.Add(this.domain);
 
             this.srdl.DefinedCategory.Add(this.catEd1);
             this.srdl.DefinedCategory.Add(this.catEd2);
@@ -119,11 +139,11 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
 
             this.model = new EngineeringModel(Guid.NewGuid(), this.assembler.Cache, this.uri) { EngineeringModelSetup = this.engineeringModelSetup };
             this.iteration = new Iteration(Guid.NewGuid(), this.assembler.Cache, this.uri) { IterationSetup = this.iterationSetup };
-            this.elementDef11 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed11", ShortName = "ed11" };
-            this.elementDef12 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed12", ShortName = "ed12" };
-            this.elementDef21 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed21", ShortName = "ed21" };
-            this.elementDef22 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed22", ShortName = "ed22" };
-            this.elementDef31 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed31", ShortName = "ed31" };
+            this.elementDef11 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed11", ShortName = "ed11", Owner = this.domain };
+            this.elementDef12 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed12", ShortName = "ed12", Owner = this.domain };
+            this.elementDef21 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed21", ShortName = "ed21", Owner = this.domain };
+            this.elementDef22 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed22", ShortName = "ed22", Owner = this.domain };
+            this.elementDef31 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ed31", ShortName = "ed31", Owner = this.domain };
 
             this.elementDef11.Category.Add(this.catEd1);
             this.elementDef12.Category.Add(this.catEd3);

--- a/RelationshipMatrix/CDP4RelationshipMatrix.csproj
+++ b/RelationshipMatrix/CDP4RelationshipMatrix.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Converters\BooleanToHighlightConverter.cs" />
     <Compile Include="Converters\BaseMatrixCellViewModelConverter.cs" />
     <Compile Include="Converters\DeprecatedOpacityConverter.cs" />
+    <Compile Include="Converters\OrderedDomainOfExpertiseListConverter.cs" />
     <Compile Include="Converters\PreviewMouseDownArgsConverter.cs" />
     <Compile Include="Converters\DeprecatedBackgroundConverter.cs" />
     <Compile Include="Converters\TooltipConverter.cs" />

--- a/RelationshipMatrix/Converters/OrderedDomainOfExpertiseListConverter.cs
+++ b/RelationshipMatrix/Converters/OrderedDomainOfExpertiseListConverter.cs
@@ -1,0 +1,88 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedDomainOfExpertiseListConverter.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4RelationshipMatrix.Converters
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Windows.Data;
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// The purpose of the <see cref="OrderedDomainOfExpertiseListConverter"/> is to convert
+    /// a <see cref="List{DomainOfExpertise}"/> to a sorted <see cref="List{DomainOfExpertise}"/> by Name 
+    /// </summary>
+    public class OrderedDomainOfExpertiseListConverter : IValueConverter
+    {
+        /// <summary>
+        /// The conversion method converts a <see cref="List{T}"/> of <see cref="DomainOfExpertise"/> to a sorted <see cref="List{DomainOfExpertise}"/> by Name.
+        /// </summary>
+        /// <param name="value">
+        /// The incoming value.
+        /// </param>
+        /// <param name="targetType">
+        /// The target type.
+        /// </param>
+        /// <param name="parameter">
+        /// The parameter passed on to this conversion.
+        /// </param>
+        /// <param name="culture">
+        /// The culture information.
+        /// </param>
+        /// <returns>
+        /// The <see cref="object"/> containing the same objects as the input collection.
+        /// </returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ((IList)value)?.Cast<DomainOfExpertise>().OrderBy(c => c.Name).ToList() ?? new List<DomainOfExpertise>();
+        }
+
+        /// <summary>
+        /// The conversion method converts a <see cref="List{T}"/> of <see cref="DomainOfExpertise"/> to a sorted <see cref="List{DomainOfExpertise}"/> by Name.
+        /// </summary>
+        /// <param name="value">
+        /// The incoming value.
+        /// </param>
+        /// <param name="targetType">
+        /// The target type.
+        /// </param>
+        /// <param name="parameter">
+        /// The parameter passed on to this conversion.
+        /// </param>
+        /// <param name="culture">
+        /// The culture information.
+        /// </param>
+        /// <returns>
+        /// The <see cref="object"/> containing the same objects as the input collection.
+        /// </returns>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return ((IList)value)?.Cast<DomainOfExpertise>().OrderBy(c => c.Name).ToList() ?? new List<DomainOfExpertise>();
+        }
+    }
+}

--- a/RelationshipMatrix/Settings/SourceConfiguration.cs
+++ b/RelationshipMatrix/Settings/SourceConfiguration.cs
@@ -1,8 +1,27 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SourceConfiguration.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -----------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4RelationshipMatrix.Settings
 {
@@ -25,6 +44,7 @@ namespace CDP4RelationshipMatrix.Settings
         public SourceConfiguration()
         {
             this.SelectedCategories = new List<Guid>();
+            this.SelectedOwners = new List<Guid>();
         }
 
         /// <summary>
@@ -40,6 +60,7 @@ namespace CDP4RelationshipMatrix.Settings
             this.SortOrder = SortOrder.Ascending;
 
             this.SelectedCategories.AddRange(source.SelectedCategories.Select(x => x.Iid));
+            this.SelectedOwners.AddRange(source.SelectedOwners.Select(x => x.Iid));
         }
 
         /// <summary>
@@ -64,6 +85,11 @@ namespace CDP4RelationshipMatrix.Settings
         /// Gets or sets the selected categories
         /// </summary>
         public List<Guid> SelectedCategories { get; set; }
+
+        /// <summary>
+        /// Gets or sets the selected domains of expertise (owners)
+        /// </summary>
+        public List<Guid> SelectedOwners { get; set; }
 
         /// <summary>
         /// Gets or sets the selected <see cref="CategoryBooleanOperatorKind"/>

--- a/RelationshipMatrix/ViewModels/MatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/MatrixViewModel.cs
@@ -1,8 +1,27 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="MatrixViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -----------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4RelationshipMatrix.ViewModels
 {
@@ -14,24 +33,17 @@ namespace CDP4RelationshipMatrix.ViewModels
     using System.Reactive.Linq;
     using System.Text;
     using System.Threading.Tasks;
-
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Extensions;
     using CDP4Common.SiteDirectoryData;
-
     using CDP4Composition.Services;
-
     using CDP4Dal;
     using CDP4Dal.Operations;
-
     using CDP4RelationshipMatrix.DataTypes;
     using CDP4RelationshipMatrix.Settings;
-
     using DevExpress.Xpf.Grid;
-
     using NLog;
-
     using ReactiveUI;
 
     /// <summary>
@@ -132,8 +144,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <summary>
         /// Dictionary that contains the current cells
         /// </summary>
-        private readonly Dictionary<string, MatrixCellViewModel> currentCells =
-            new Dictionary<string, MatrixCellViewModel>();
+        private readonly Dictionary<string, MatrixCellViewModel> currentCells = new Dictionary<string, MatrixCellViewModel>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MatrixViewModel" /> class
@@ -442,10 +453,10 @@ namespace CDP4RelationshipMatrix.ViewModels
 
             try
             {
-                sourceYThing = things.Where(x => x.ClassKind == sourceY.SelectedClassKind.Value).Cast<DefinedThing>()
+                sourceXThing = things.Where(x => x.ClassKind == sourceX.SelectedClassKind.Value).Cast<DefinedThing>()
                     .ToList();
 
-                sourceXThing = things.Where(x => x.ClassKind == sourceX.SelectedClassKind.Value).Cast<DefinedThing>()
+                sourceYThing = things.Where(x => x.ClassKind == sourceY.SelectedClassKind.Value).Cast<DefinedThing>()
                     .ToList();
             }
             catch (InvalidCastException)
@@ -458,9 +469,9 @@ namespace CDP4RelationshipMatrix.ViewModels
                 return;
             }
 
-            var sourceXToUse = new List<DefinedThing>(this.FilterAndSortSourceByCategory(sourceXThing, sourceX));
+            var sourceXToUse = new List<DefinedThing>(this.FilterAndSortSourceByCategoryAndOwner(sourceXThing, sourceX));
 
-            var sourceYToUse = new List<DefinedThing>(this.FilterAndSortSourceByCategory(sourceYThing, sourceY));
+            var sourceYToUse = new List<DefinedThing>(this.FilterAndSortSourceByCategoryAndOwner(sourceYThing, sourceY));
 
             if (sourceYToUse.Count == 0 || sourceXToUse.Count == 0)
             {
@@ -720,7 +731,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <param name="source">The <see cref="Thing" /> to filter</param>
         /// <param name="sourceConfigurationViewModel">The filter and sort settings</param>
         /// <returns>The filtered <see cref="Thing" /></returns>
-        private IEnumerable<DefinedThing> FilterAndSortSourceByCategory(IReadOnlyList<DefinedThing> source,
+        private IEnumerable<DefinedThing> FilterAndSortSourceByCategoryAndOwner(IReadOnlyList<DefinedThing> source,
             SourceConfigurationViewModel sourceConfigurationViewModel)
         {
             var sourceXCatThing = new List<DefinedThing>();
@@ -740,10 +751,19 @@ namespace CDP4RelationshipMatrix.ViewModels
 
                 var thing = (ICategorizableThing) definedThing;
 
-                if (RelationshipMatrixViewModel.IsCategoryApplicableToConfiguration(thing, sourceConfigurationViewModel)
-                )
+                if (RelationshipMatrixViewModel.IsCategoryApplicableToConfiguration(thing, sourceConfigurationViewModel))
                 {
-                    sourceXCatThing.Add(definedThing);
+                    if (definedThing is IOwnedThing ownedThing)
+                    {
+                        if (sourceConfigurationViewModel.SelectedOwners.Contains(ownedThing.Owner))
+                        {
+                            sourceXCatThing.Add(definedThing);
+                        }
+                    }
+                    else
+                    {
+                        sourceXCatThing.Add(definedThing);
+                    }
                 }
             }
 

--- a/RelationshipMatrix/ViewModels/RelationshipMatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/RelationshipMatrixViewModel.cs
@@ -1,8 +1,27 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationshipMatrixViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -----------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4RelationshipMatrix.ViewModels
 {

--- a/RelationshipMatrix/ViewModels/SavedConfigurationDialogViewModel.cs
+++ b/RelationshipMatrix/ViewModels/SavedConfigurationDialogViewModel.cs
@@ -1,8 +1,27 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SavedConfigurationDialogViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -----------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4RelationshipMatrix.ViewModels
 {
@@ -118,7 +137,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         }
 
         /// <summary>
-        /// Executes the Ok Command
+        /// Executes the Ok Command and write the configuration to disk
         /// </summary>
         /// <returns>
         /// The <see cref="Task"/>.
@@ -136,7 +155,7 @@ namespace CDP4RelationshipMatrix.ViewModels
 
             try
             {
-                this.LoadingMessage = "Saving Cofiguration...";
+                this.LoadingMessage = "Saving Configuration...";
                 await Task.Run(() => this.pluginSettingService.Write(settings));
 
                 this.DialogResult = new SavedConfigurationResult(true);
@@ -152,7 +171,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         }
 
         /// <summary>
-        /// Executes the Cancel Command
+        /// Executes the Cancel Command and do not write the configuration to disk
         /// </summary>
         private void ExecuteCancel()
         {

--- a/RelationshipMatrix/Views/RelationshipMatrix.xaml
+++ b/RelationshipMatrix/Views/RelationshipMatrix.xaml
@@ -28,6 +28,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <converters:OrderedCategoryListConverter x:Key="OrderedCategoryListConverter" />
+            <converters:OrderedDomainOfExpertiseListConverter x:Key="OrderedDomainOfExpertiseListConverter" />
             <converters:ColumnFixedConverter x:Key="ColumnFixedConverter" />
             <converters:ColumnWidthConverter x:Key="ColumnWidthConverter" />
             <converters:NameContentConverter x:Key="NameContentConverter" />
@@ -403,7 +404,7 @@
                                                         </dxe:ComboBoxEdit>
                                                         <dxe:ComboBoxEdit Grid.Column="1"
                                                                               MinWidth="60"
-                                                                              ToolTip="Boolean Operator used to seperate the selected Categories."
+                                                                              ToolTip="Boolean Operator used to separate the selected Categories."
                                                                               Margin="5,0,0,0"
                                                                               EditValue="{Binding SourceXConfiguration.SelectedBooleanOperatorKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                                               ItemsSource="{Binding SourceXConfiguration.PossibleBooleanOperatorKinds, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -412,9 +413,31 @@
                                                 <dxlc:LayoutItem Label=" ">
                                                     <dxe:CheckEdit
                                                             EditValue="{Binding SourceXConfiguration.IncludeSubcategories, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                            Content="Include Subcategories of Selected"
-                                                            ToolTip="Recursivelly includes all subcategories of the selected Categories." />
+                                                            Content="Include Subcategories of the selected Category"
+                                                            ToolTip="Recursively includes all subcategories of the selected Categories." />
                                                 </dxlc:LayoutItem>
+
+                                                <dxlc:LayoutItem Label="Owners: ">
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <dxe:ComboBoxEdit
+                                                                Grid.Column="0"
+                                                                EditValue="{Binding SourceXConfiguration.SelectedOwners, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource OrderedDomainOfExpertiseListConverter}}"
+                                                                ItemsSource="{Binding SourceXConfiguration.PossibleOwners, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                                                AutoComplete="True"
+                                                                AllowNullInput="True"
+                                                                AllowDefaultButton="True"
+                                                                DisplayMember="Name">
+                                                            <dxe:ComboBoxEdit.StyleSettings>
+                                                                <dxe:CheckedComboBoxStyleSettings />
+                                                            </dxe:ComboBoxEdit.StyleSettings>
+                                                        </dxe:ComboBoxEdit>
+                                                    </Grid>
+                                                </dxlc:LayoutItem>
+
                                                 <dxlc:LayoutItem Label="Display:">
                                                     <dxe:ComboBoxEdit
                                                             EditValue="{Binding SourceXConfiguration.SelectedDisplayKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -477,7 +500,7 @@
                                                         </dxe:ComboBoxEdit>
                                                         <dxe:ComboBoxEdit Grid.Column="1"
                                                                               MinWidth="60"
-                                                                              ToolTip="Boolean Operator used to seperate the selected Categories."
+                                                                              ToolTip="Boolean Operator used to separate the selected Categories."
                                                                               Margin="5,0,0,0"
                                                                               EditValue="{Binding SourceYConfiguration.SelectedBooleanOperatorKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                                               ItemsSource="{Binding SourceYConfiguration.PossibleBooleanOperatorKinds, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -487,8 +510,30 @@
                                                     <dxe:CheckEdit
                                                             EditValue="{Binding SourceYConfiguration.IncludeSubcategories, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                             Content="Include Subcategories of Selected"
-                                                            ToolTip="Recursivelly includes all subcategories of the selected Categories." />
+                                                            ToolTip="Recursively includes all subcategories of the selected Categories." />
                                                 </dxlc:LayoutItem>
+
+                                                <dxlc:LayoutItem Label="Owners: ">
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="*" />
+                                                            <ColumnDefinition Width="Auto" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <dxe:ComboBoxEdit
+                                                            Grid.Column="0"
+                                                            EditValue="{Binding SourceYConfiguration.SelectedOwners, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource OrderedDomainOfExpertiseListConverter}}"
+                                                            ItemsSource="{Binding SourceYConfiguration.PossibleOwners, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                                            AutoComplete="True"
+                                                            AllowNullInput="True"
+                                                            AllowDefaultButton="True"
+                                                            DisplayMember="Name">
+                                                            <dxe:ComboBoxEdit.StyleSettings>
+                                                                <dxe:CheckedComboBoxStyleSettings />
+                                                            </dxe:ComboBoxEdit.StyleSettings>
+                                                        </dxe:ComboBoxEdit>
+                                                    </Grid>
+                                                </dxlc:LayoutItem>
+
                                                 <dxlc:LayoutItem Label="Display: ">
                                                     <dxe:ComboBoxEdit
                                                             EditValue="{Binding SourceYConfiguration.SelectedDisplayKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

see #140

Added a combobox to the configuration of the requirements matrix so a user can select one or more domains of expertise that the items in the matrix need to be owned by. This works as an extra filter. The selected domain of expertise is also saved/loaded to and from the settings file.


<!-- Thanks for contributing to CDP4-IME! -->

