### PR TITLE
[Add] ShowDeprecatedBrowserRibbonViewModel and FilterStringService to ribbonpart so views can be shown again in excel; fixes #271

### DIFF
--- a/CDP4SiteDirectory.Tests/OfficeRibbon/SiteDirectoryRibbonPartTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/OfficeRibbon/SiteDirectoryRibbonPartTestFixture.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SiteDirectoryRibbonPartTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -68,7 +87,7 @@ namespace CDP4SiteDirectory.Tests.OfficeRibbon
 
             this.session.Setup(x => x.PermissionService).Returns(this.permittingPermissionService.Object);
 
-            this.amountOfRibbonControls = 8;
+            this.amountOfRibbonControls = 9;
             this.order = 1;
 
             this.ribbonPart = new SiteDirectoryRibbonPart(this.order, this.panelNavigationService.Object, null, null, null);

--- a/CDP4SiteDirectory/Resources/RibbonXml/SiteDirectoryRibbon.xml
+++ b/CDP4SiteDirectory/Resources/RibbonXml/SiteDirectoryRibbon.xml
@@ -1,5 +1,6 @@
 ﻿<ribbonxml>
   <group id="SiteDirectory" label="Site Directory">
+    <button id="ShowHideDeprecatedThings" size="large" getLabel="GetLabel" supertip="Show or hide deprecated things in all browsers" onAction="OnAction" getEnabled="GetEnabled" imageMso="AutoFilterClassic"></button>
     <button id="ShowDomainsOfExpertise" size="large" label="Domains of expertise" supertip="Manage Domains of expertise" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
     <button id="ShowModels" size="large" label="Models" supertip="Manage Engineering Models" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>
     <button id="ShowLanguages" size="large" label="Languages" supertip="Manage Languages" onAction="OnAction" getEnabled="GetEnabled" getImage="GetImage"></button>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
ShowDeprecatedBrowserRibbonViewModel and FilterStringService to ribbonpart so views can be shown again in excel; fixes #271

<!-- Thanks for contributing to CDP4-IME! -->

