### PR TITLE
refactor FilterStringService: - poprosal

### DIFF
--- a/BasicRdl.Tests/BasicRdlRibbonViewModelTestFixture.cs
+++ b/BasicRdl.Tests/BasicRdlRibbonViewModelTestFixture.cs
@@ -14,6 +14,7 @@ namespace BasicRdl.Tests
     using CDP4Common.SiteDirectoryData;
     using CDP4Composition;
     using CDP4Composition.Navigation;
+    using CDP4Composition.Services;
     using CDP4Composition.Services.FavoritesService;
     using CDP4Dal;
     using CDP4Dal.Events;
@@ -34,12 +35,14 @@ namespace BasicRdl.Tests
         private readonly Uri uri = new Uri("http://test.com");
         private Person person;
         private Mock<IFavoritesService> favoritesService;
+        private Mock<IFilterStringService> filterStringService;
 
         [SetUp]
         public void Setup()
         {
             RxApp.MainThreadScheduler = Scheduler.CurrentThread;
 
+            this.filterStringService = new Mock<IFilterStringService>();
             this.permissionService = new Mock<IPermissionService>();
             this.permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
             this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
@@ -53,6 +56,7 @@ namespace BasicRdl.Tests
             this.session = new Mock<ISession>();
             this.siteDir = new SiteDirectory(Guid.NewGuid(), null, this.uri);
             this.person = new Person(Guid.NewGuid(), null, this.uri) { GivenName = "John", Surname = "Doe" };
+            
             ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
             this.serviceLocator.Setup(x => x.GetInstance<IPanelNavigationService>()).Returns(this.navigation.Object);
             this.serviceLocator.Setup(x => x.GetInstance<IFavoritesService>()).Returns(this.favoritesService.Object);
@@ -60,6 +64,7 @@ namespace BasicRdl.Tests
             this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new HashSet<ReferenceDataLibrary>(this.siteDir.SiteReferenceDataLibrary));
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
         }
 
         [TearDown]

--- a/BasicRdl.Tests/OfficeRibbon/BasicRdlRibbonPartTestFixture.cs
+++ b/BasicRdl.Tests/OfficeRibbon/BasicRdlRibbonPartTestFixture.cs
@@ -19,6 +19,7 @@ namespace BasicRdl.Tests
     using CDP4Composition;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
     using CDP4Composition.Services.FavoritesService;
     using CDP4Dal;
     using CDP4Dal.Events;
@@ -51,6 +52,7 @@ namespace BasicRdl.Tests
         private Mock<ISession> session;
         private Person person;
         private Mock<IFavoritesService> favoritesService;
+        private Mock<IFilterStringService> filterStringService;
 
         [SetUp]
         public void SetUp()
@@ -70,6 +72,7 @@ namespace BasicRdl.Tests
             this.panelNavigationService = new Mock<IPanelNavigationService>();
             this.dialogNavigationService = new Mock<IThingDialogNavigationService>();
             this.serviceLocator = new Mock<IServiceLocator>();
+            this.filterStringService = new Mock<IFilterStringService>();
 
             this.permittingPermissionService = new Mock<IPermissionService>();
             this.permittingPermissionService.Setup(x => x.CanRead(It.IsAny<Thing>())).Returns(true);
@@ -89,8 +92,8 @@ namespace BasicRdl.Tests
             this.ribbonPart = new BasicRdlRibbonPart(this.order, this.panelNavigationService.Object, null, null, null, this.favoritesService.Object);
 
             ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
-            this.serviceLocator.Setup(x => x.GetInstance<IThingDialogNavigationService>())
-                .Returns(this.dialogNavigationService.Object);
+            this.serviceLocator.Setup(x => x.GetInstance<IThingDialogNavigationService>()).Returns(this.dialogNavigationService.Object);
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
         }
 
         [TearDown]

--- a/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
@@ -16,9 +16,11 @@ namespace BasicRdl.Tests.ViewModels
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
     using CDP4Composition.Services.FavoritesService;
+    using CDP4Composition.Services;
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Permission;
+    using Microsoft.Practices.ServiceLocation;
     using Moq;
     using NUnit.Framework;
 
@@ -28,15 +30,13 @@ namespace BasicRdl.Tests.ViewModels
     [TestFixture]
     public class ParameterTypesBrowserViewModelTestFixture
     {
-        /// <summary>
-        /// A mock of the session.
-        /// </summary>
         private Mock<ISession> session;
-
         private Mock<IPermissionService> permissionService;
         private Mock<IFavoritesService> favoritesService;
         private Mock<IPanelNavigationService> panelNavigationService;
         private Mock<IThingDialogNavigationService> dialogNavigationService;
+        private Mock<IFilterStringService> filterStringService;
+        private Mock<IServiceLocator> serviceLocator;
 
         /// <summary>
         /// The uri.
@@ -60,11 +60,16 @@ namespace BasicRdl.Tests.ViewModels
         [SetUp]
         public void Setup()
         {
+            this.serviceLocator = new Mock<IServiceLocator>();
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+
             this.session = new Mock<ISession>();
             this.panelNavigationService = new Mock<IPanelNavigationService>();
             this.dialogNavigationService = new Mock<IThingDialogNavigationService>();
-
+            this.filterStringService = new Mock<IFilterStringService>();
             this.permissionService = new Mock<IPermissionService>();
+
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
 
             this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
             this.permissionService.Setup(x => x.CanRead(It.IsAny<Thing>())).Returns(true);

--- a/BasicRdl.Tests/ViewModels/Ribbons/ParameterTypeRibbonViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Ribbons/ParameterTypeRibbonViewModelTestFixture.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -------------------------------------------------------------------------------------------------
 
+using CDP4Composition.Services;
+
 namespace BasicRdl.Tests.ViewModels.Ribbons
 {
     using System;
@@ -37,6 +39,7 @@ namespace BasicRdl.Tests.ViewModels.Ribbons
         private Mock<IDialogNavigationService> dialogNavigationService;
         private Mock<IPluginSettingsService> pluginSettingsService;
         private Mock<IFavoritesService> favoritesService;
+        private Mock<IFilterStringService> filterStringService;
 
         private readonly Uri uri = new Uri("http://www.rheagroup.com");
         private Mock<IServiceLocator> serviceLocator;
@@ -61,6 +64,7 @@ namespace BasicRdl.Tests.ViewModels.Ribbons
             this.pluginSettingsService = new Mock<IPluginSettingsService>();
             this.pluginSettingsService = new Mock<IPluginSettingsService>();
             this.favoritesService = new Mock<IFavoritesService>();
+            this.filterStringService = new Mock<IFilterStringService>();
 
             this.assembler = new Assembler(this.uri);
             this.cache = this.assembler.Cache;
@@ -70,6 +74,7 @@ namespace BasicRdl.Tests.ViewModels.Ribbons
             this.serviceLocator.Setup(x => x.GetInstance<IPanelNavigationService>()).Returns(this.panelNavigationService.Object);
             this.serviceLocator.Setup(x => x.GetInstance<IDialogNavigationService>()).Returns(this.dialogNavigationService.Object);
             this.serviceLocator.Setup(x => x.GetInstance<IPluginSettingsService>()).Returns(this.pluginSettingsService.Object);
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
 
             this.sitedir = new SiteDirectory(Guid.NewGuid(), this.cache, this.uri);
 

--- a/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTypesBrowserViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -24,6 +43,7 @@ namespace BasicRdl.ViewModels
     using CDP4Composition.Services.FavoritesService;
     using CDP4Dal;
     using CDP4Dal.Events;
+    using Microsoft.Practices.ServiceLocation;
     using ReactiveUI;
 
     /// <summary>
@@ -51,6 +71,11 @@ namespace BasicRdl.ViewModels
         /// The <see cref="IFavoritesService"/> used to work with favorite Things.
         /// </summary>
         private readonly IFavoritesService favoritesService;
+
+        /// <summary>
+        /// The (injected) <see cref="IFilterStringService"/>
+        /// </summary>
+        private IFilterStringService filterStringService;
 
         /// <summary>
         /// Backing field for the <see cref="ParameterTypes"/> property
@@ -323,7 +348,12 @@ namespace BasicRdl.ViewModels
         /// </summary>
         private void ExecuteToggleShowFavoriteCommand()
         {
-            FilterStringService.FilterString.RefreshFavoriteBrowser(this);
+            if (this.filterStringService == null)
+            {
+                this.filterStringService = ServiceLocator.Current.GetInstance<IFilterStringService>();
+            }
+
+            this.filterStringService.RefreshFavoriteBrowser(this);
         }
 
         /// <summary>

--- a/CDP4Composition.Tests/Navigation/PanelNavigationServiceTestFixture.cs
+++ b/CDP4Composition.Tests/Navigation/PanelNavigationServiceTestFixture.cs
@@ -1,8 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PanelNavigationServiceTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Composition.Tests.Navigation
 {
@@ -12,6 +31,7 @@ namespace CDP4Composition.Tests.Navigation
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Events;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
     using CDP4Composition.Tests.ViewModels;
     using CDP4Composition.Tests.Views;
     using CDP4Dal;
@@ -35,7 +55,7 @@ namespace CDP4Composition.Tests.Navigation
     {
         private Mock<IDialogNavigationService> dialogNavigationService;
         private Mock<IThingDialogNavigationService> thingDialogNavigationService;
-
+        private Mock<IFilterStringService> filterStringService;
         private Mock<ISession> session;
         private Mock<IPermissionService> permissionService; 
         private Mock<IRegionManager> regionManager;
@@ -58,8 +78,6 @@ namespace CDP4Composition.Tests.Navigation
 
         private Mock<INameMetaData> describeMetaData;
 
-
-
         private PanelNavigationService NavigationService;
 
         [SetUp]
@@ -69,6 +87,7 @@ namespace CDP4Composition.Tests.Navigation
 
             this.dialogNavigationService = new Mock<IDialogNavigationService>();
             this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
+            this.filterStringService = new Mock<IFilterStringService>();
 
             this.regionManager = new Mock<IRegionManager>();
             this.region = new Mock<IRegion>();
@@ -96,7 +115,7 @@ namespace CDP4Composition.Tests.Navigation
             this.viewModelList.Add(this.panelViewModel);
             this.viewModelList.Add(new PropertyGridViewModel());
 
-            this.NavigationService = new PanelNavigationService(this.viewList, this.viewModelList, this.regionManager.Object, this.viewModelDecoratedList);
+            this.NavigationService = new PanelNavigationService(this.viewList, this.viewModelList, this.regionManager.Object, this.viewModelDecoratedList, this.filterStringService.Object);
 
             this.session = new Mock<ISession>();
             this.permissionService = new Mock<IPermissionService>();
@@ -185,7 +204,7 @@ namespace CDP4Composition.Tests.Navigation
         public void VerifyThatNavigationServiceDoesNotThrowWhenPropertyGridNotFound()
         {
             this.NavigationService = new PanelNavigationService(new List<Lazy<IPanelView, IRegionMetaData>>(), new List<IPanelViewModel>(),
-                regionManager.Object, new List<Lazy<IPanelViewModel, INameMetaData>>());
+                regionManager.Object, new List<Lazy<IPanelViewModel, INameMetaData>>(), this.filterStringService.Object);
 
             Assert.DoesNotThrow(() => this.NavigationService.Open(new Person(Guid.NewGuid(), null, null), this.session.Object));
         }

--- a/CDP4Composition.Tests/Services/FilterStringServiceTestFixture.cs
+++ b/CDP4Composition.Tests/Services/FilterStringServiceTestFixture.cs
@@ -1,8 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FilterStringServiceTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Composition.Tests.Services
 {
@@ -43,25 +62,17 @@ namespace CDP4Composition.Tests.Services
         }
 
         [Test]
-        public void Verif_that_Deprecatable_Toggle_IsSet()
-        {
-            Assert.IsNull(FilterStringService.FilterString.DeprecatableToggleViewModel);
-
-            FilterStringService.FilterString.RegisterDeprecatableToggleViewModel(this.deprecatableToggle.Object);
-
-            Assert.IsNotNull(FilterStringService.FilterString.DeprecatableToggleViewModel);
-        }
-
-        [Test]
         public void Verify_that_registering_bad_view_does_not_work()
         {
-            Assert.AreEqual(0, FilterStringService.FilterString.OpenDeprecatedControls.Count);
-            Assert.AreEqual(0, FilterStringService.FilterString.OpenFavoriteControls.Count);
+            var filterStringService = new FilterStringService();
 
-            FilterStringService.FilterString.RegisterForService(this.badView.Object, this.badViewModel.Object);
+            Assert.AreEqual(0, filterStringService.OpenDeprecatedControls.Count);
+            Assert.AreEqual(0, filterStringService.OpenFavoriteControls.Count);
 
-            Assert.AreEqual(0, FilterStringService.FilterString.OpenDeprecatedControls.Count);
-            Assert.AreEqual(0, FilterStringService.FilterString.OpenFavoriteControls.Count);
+            filterStringService.RegisterForService(this.badView.Object, this.badViewModel.Object);
+
+            Assert.AreEqual(0, filterStringService.OpenDeprecatedControls.Count);
+            Assert.AreEqual(0, filterStringService.OpenFavoriteControls.Count);
         }
     }
 }

--- a/CDP4Composition/CDP4Composition.csproj
+++ b/CDP4Composition/CDP4Composition.csproj
@@ -248,7 +248,7 @@
     <Compile Include="Services\FavoritesService\FavoritesService.cs" />
     <Compile Include="Services\FavoritesService\IFavoritesService.cs" />
     <Compile Include="Mvvm\IHaveContainerViewModel.cs" />
-    <Compile Include="Services\FilterStringService.cs" />
+    <Compile Include="Services\FilterStringService\FilterStringService.cs" />
     <Compile Include="Mvvm\Behaviours\IExtendedDiagramOrgChartBehavior.cs" />
     <Compile Include="Mvvm\Behaviours\ItemsSourceHelper.cs" />
     <Compile Include="Mvvm\Behaviours\LayoutControlItemsSourceHelper.cs" />
@@ -283,6 +283,7 @@
     <Compile Include="Navigation\Interfaces\IOpenSaveFileDialogService.cs" />
     <Compile Include="Navigation\OpenSaveFileDialogService.cs" />
     <Compile Include="Services\CategoryApplicationValidationService.cs" />
+    <Compile Include="Services\FilterStringService\IFilterStringService.cs" />
     <Compile Include="Services\GridUpdateService.cs" />
     <Compile Include="Services\IconCacheService\IconCacheService.cs" />
     <Compile Include="Services\IconCacheService\IIconCacheService.cs" />

--- a/CDP4Composition/Navigation/PanelNavigationService.cs
+++ b/CDP4Composition/Navigation/PanelNavigationService.cs
@@ -1,8 +1,27 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PanelNavigationService.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// ------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Composition.Navigation
 {
@@ -40,6 +59,11 @@ namespace CDP4Composition.Navigation
         private readonly IRegionManager regionManager;
 
         /// <summary>
+        /// The (injected) <see cref="IFilterStringService"/>
+        /// </summary>
+        private readonly IFilterStringService filterStringService;
+
+        /// <summary>
         /// The logger for the current class
         /// </summary>
         private static Logger logger = LogManager.GetCurrentClassLogger();
@@ -62,13 +86,15 @@ namespace CDP4Composition.Navigation
         [ImportingConstructor]
         public PanelNavigationService([ImportMany] IEnumerable<Lazy<IPanelView, IRegionMetaData>> panelViewKinds,
             [ImportMany] IEnumerable<IPanelViewModel> panelViewModelKinds, IRegionManager regionManager,
-            [ImportMany] IEnumerable<Lazy<IPanelViewModel, INameMetaData>> panelViewModelDecorated)
+            [ImportMany] IEnumerable<Lazy<IPanelViewModel, INameMetaData>> panelViewModelDecorated,
+            IFilterStringService filterStringService)
         {
             var sw = new Stopwatch();
             sw.Start();
             logger.Debug("Instantiating the PanelNavigationService");
 
             this.regionManager = regionManager;
+            this.filterStringService = filterStringService;
             this.PanelViewKinds = new Dictionary<string, Lazy<IPanelView, IRegionMetaData>>();
 
             // TODO T2428 : PanelViewModelKinds seems to be always empty and is used only one time in the Open(Thing thing, ISession session) method. We should probably refactor this part of the code.
@@ -175,7 +201,7 @@ namespace CDP4Composition.Navigation
                 this.ViewModelViewPairs.Add(viewModel, view);
 
                 // register for Filter Service
-                FilterStringService.FilterString.RegisterForService(view, viewModel);
+                this.filterStringService.RegisterForService(view, viewModel);
 
                 var region = this.regionManager.Regions[lazyView.Metadata.Region];
                 region.Add(view, view.ToString() + Guid.NewGuid());
@@ -228,7 +254,7 @@ namespace CDP4Composition.Navigation
                         this.ViewModelViewPairs.Add(viewModel, view);
 
                         // register for Filter Service
-                        FilterStringService.FilterString.RegisterForService(view, viewModel);
+                        this.filterStringService.RegisterForService(view, viewModel);
                     }
                 }
 
@@ -448,7 +474,7 @@ namespace CDP4Composition.Navigation
             panelViewModel.Dispose();
 
             // unregister from filter string service
-            FilterStringService.FilterString.UnregisterFromService(panelView);
+            this.filterStringService.UnregisterFromService(panelView);
         }
     }
 }

--- a/CDP4Composition/Services/FilterStringService/IFilterStringService.cs
+++ b/CDP4Composition/Services/FilterStringService/IFilterStringService.cs
@@ -1,0 +1,68 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="FilterStringService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Services
+{
+    /// <summary>
+    /// The purpose of the <see cref="FilterStringService"/> is to set the <see cref="DevExpress.Xpf.Grid.DataControlBase.FilterString"/> property
+    /// on registered view/view model combinations.
+    /// </summary>
+    public interface IFilterStringService
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="CDP4Common.CommonData.IDeprecatableThing"/> are visible.
+        /// </summary>
+        bool ShowDeprecatedThings { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether only favorited <see cref="Thing"/> are visible.
+        /// </summary>
+        bool ShowOnlyFavorites { get; set; }
+
+        /// <summary>
+        /// Registers a filterable panel view and viewmodel combo to this service.
+        /// </summary>
+        /// <param name="view">The view that is to be registered</param>
+        /// <param name="viewModel">The viewmodel that is to be registered</param>
+        void RegisterForService(IPanelView view, IPanelViewModel viewModel);
+
+        /// <summary>
+        /// Unregisters a panel view from all relevant collections.
+        /// </summary>
+        /// <param name="view">The view to unregister.</param>
+        void UnregisterFromService(IPanelView view);
+
+        /// <summary>
+        /// Refresh all <see cref="OpenDeprecatedControls"/>.
+        /// </summary>
+        void RefreshDeprecatableFilterAll();
+
+        /// <summary>
+        /// Refresh a favoratable grid or tree control.
+        /// </summary>
+        /// <param name="vm">The ViewModel of type <see cref="IFavoritesBrowserViewModel"/> to refresh</param>
+        void RefreshFavoriteBrowser(IFavoritesBrowserViewModel vm);
+    }
+}

--- a/CDP4SiteDirectory.Tests/OfficeRibbon/SiteDirectoryRibbonPartTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/OfficeRibbon/SiteDirectoryRibbonPartTestFixture.cs
@@ -36,6 +36,8 @@ namespace CDP4SiteDirectory.Tests.OfficeRibbon
     using CDP4Composition;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
+
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Permission;
@@ -58,6 +60,7 @@ namespace CDP4SiteDirectory.Tests.OfficeRibbon
         private Mock<IPanelNavigationService> panelNavigationService;
         private Mock<IThingDialogNavigationService> dialogNavigationService;
         private Mock<IPermissionService> permittingPermissionService;
+        private Mock<IFilterStringService> filterStringService;
         private Mock<ISession> session;
         private Person person;
         private SiteDirectoryRibbonPart ribbonPart;
@@ -78,6 +81,8 @@ namespace CDP4SiteDirectory.Tests.OfficeRibbon
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.panelNavigationService = new Mock<IPanelNavigationService>();
             this.dialogNavigationService = new Mock<IThingDialogNavigationService>();
+            this.filterStringService = new Mock<IFilterStringService>();
+
             this.serviceLocator = new Mock<IServiceLocator>();
 
             this.permittingPermissionService = new Mock<IPermissionService>();
@@ -90,11 +95,14 @@ namespace CDP4SiteDirectory.Tests.OfficeRibbon
             this.amountOfRibbonControls = 9;
             this.order = 1;
 
-            this.ribbonPart = new SiteDirectoryRibbonPart(this.order, this.panelNavigationService.Object, null, null, null);
-
             ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
             this.serviceLocator.Setup(x => x.GetInstance<IThingDialogNavigationService>())
                 .Returns(this.dialogNavigationService.Object);
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
+
+            this.ribbonPart = new SiteDirectoryRibbonPart(this.order, this.panelNavigationService.Object, null, null, null);
+
+            
         }
 
         public void TearDown()

--- a/CDP4SiteDirectory.Tests/ShowDeprecatedRibbonViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/ShowDeprecatedRibbonViewModelTestFixture.cs
@@ -6,9 +6,14 @@
 
 namespace CDP4SiteDirectory.Tests
 {
+    using CDP4Composition.Services;
+
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4SiteDirectory.ViewModels;
+
+    using Microsoft.Practices.ServiceLocation;
+
     using Moq;
     using NUnit.Framework;
 
@@ -16,11 +21,19 @@ namespace CDP4SiteDirectory.Tests
     public class ShowDeprecatedRibbonViewModelTestFixture
     {
         private Mock<ISession> session;
+        private Mock<IServiceLocator> serviceLocator;
+        private Mock<IFilterStringService> filterStringService;
 
         [SetUp]
         public void Setup()
         {
             this.session = new Mock<ISession>();
+            this.filterStringService = new Mock<IFilterStringService>();
+
+            this.serviceLocator = new Mock<IServiceLocator>();
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
         }
 
         [TearDown]

--- a/CDP4SiteDirectory/OfficeRibbon/SiteDirectoryRibbonPart.cs
+++ b/CDP4SiteDirectory/OfficeRibbon/SiteDirectoryRibbonPart.cs
@@ -109,7 +109,6 @@ namespace CDP4SiteDirectory
             CDPMessageBus.Current.Listen<SessionEvent>().Subscribe(this.SessionChangeEventHandler);
 
             this.showDeprecatedBrowserRibbonViewModel = new ShowDeprecatedBrowserRibbonViewModel();
-            FilterStringService.FilterString.RegisterDeprecatableToggleViewModel(this.showDeprecatedBrowserRibbonViewModel);
         }
 
         /// <summary>

--- a/RelationshipMatrix.Tests/ViewModel/RelationshipConfigurationViewModelTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/RelationshipConfigurationViewModelTestFixture.cs
@@ -1,8 +1,27 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationshipConfigurationViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//    Copyright (c) 2015-2019 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru.
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4RelationshipMatrix.Tests.ViewModel
 {

--- a/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/RelationshipMatrixViewModelTestFixture.cs
@@ -34,6 +34,7 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4RelationshipMatrix.Settings;
+    using Microsoft.Practices.ServiceLocation;
     using Moq;
     using NUnit.Framework;
     using ViewModels;
@@ -44,17 +45,15 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
     [TestFixture]
     public class RelationshipMatrixViewModelTestFixture : ViewModelTestBase
     {
-        private Mock<IDeprecatableToggleViewModel> toggle;
+        private Mock<IServiceLocator> serviceLocator;
+        
 
         [SetUp]
         public override void Setup()
         {
             base.Setup();
 
-            this.toggle = new Mock<IDeprecatableToggleViewModel>();
-            this.toggle.Setup(x => x.ShowDeprecatedThings).Returns(true);
-
-            FilterStringService.FilterString.RegisterDeprecatableToggleViewModel(this.toggle.Object);
+            
         }
 
         [Test]

--- a/RelationshipMatrix.Tests/ViewModel/ViewModelTestBase.cs
+++ b/RelationshipMatrix.Tests/ViewModel/ViewModelTestBase.cs
@@ -35,19 +35,23 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+    using CDP4Composition.Services;
     using CDP4Dal;
     using CDP4Dal.Permission;
+    using Microsoft.Practices.ServiceLocation;
     using Moq;
     using ViewModels;
     using ViewModels.DialogResult;
 
     public abstract class ViewModelTestBase
     {
+        private Mock<IServiceLocator> serviceLocator;
         protected Mock<IPanelNavigationService> panelNavigationService;
         protected Mock<IThingDialogNavigationService> thingDialogNavigationService;
         protected Mock<IDialogNavigationService> dialogNavigationService;
         protected Mock<IPermissionService> permissionService;
         protected Mock<IPluginSettingsService> pluginService;
+        private Mock<IFilterStringService> filterStringService;
         protected Mock<ISession> session;
 
         protected RelationshipMatrixPluginSettings settings;
@@ -83,6 +87,9 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
 
         public virtual void Setup()
         {
+            this.serviceLocator = new Mock<IServiceLocator>();
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+            this.filterStringService = new Mock<IFilterStringService>();
             this.panelNavigationService = new Mock<IPanelNavigationService>();
             this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
             this.dialogNavigationService = new Mock<IDialogNavigationService>();
@@ -96,8 +103,9 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
             this.permissionService = new Mock<IPermissionService>();
             this.pluginService = new Mock<IPluginSettingsService>();
             this.session = new Mock<ISession>();
-            this.assembler = new Assembler(this.uri);
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
 
+            this.assembler = new Assembler(this.uri);
             this.sitedir = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri);
             this.iterationSetup = new IterationSetup(Guid.NewGuid(), this.assembler.Cache, this.uri);

--- a/RelationshipMatrix/ViewModels/MatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/MatrixViewModel.cs
@@ -43,6 +43,7 @@ namespace CDP4RelationshipMatrix.ViewModels
     using CDP4RelationshipMatrix.DataTypes;
     using CDP4RelationshipMatrix.Settings;
     using DevExpress.Xpf.Grid;
+    using Microsoft.Practices.ServiceLocation;
     using NLog;
     using ReactiveUI;
 
@@ -55,6 +56,11 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// a value indicating whether the instance is disposed
         /// </summary>
         private bool isDisposed;
+
+        /// <summary>
+        /// The (injected) <see cref="IFilterStringService"/>
+        /// </summary>
+        private IFilterStringService filterStringService;
 
         /// <summary>
         /// The logger for the current class
@@ -154,6 +160,10 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <param name="settings">The module settings</param>
         public MatrixViewModel(ISession session, Iteration iteration, RelationshipMatrixPluginSettings settings)
         {
+            
+            this.filterStringService = ServiceLocator.Current.GetInstance<IFilterStringService>();
+            this.IsDeprecatedDisplayed = this.filterStringService.ShowDeprecatedThings;
+
             this.Disposables = new List<IDisposable>();
 
             this.Records = new ReactiveList<IDictionary<string, MatrixCellViewModel>>();
@@ -271,7 +281,7 @@ namespace CDP4RelationshipMatrix.ViewModels
         /// <summary>
         /// Gets or sets a value indicating whether deprecated items are shown
         /// </summary>
-        public bool IsDeprecatedDisplayed { get; set; } = !FilterStringService.FilterString.DeprecatableToggleViewModel.ShowDeprecatedThings;
+        public bool IsDeprecatedDisplayed { get; set; }
 
         /// <summary>
         /// Gets or sets the records used for row construction.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[WIP] refactor FilterStringService:
  - Use MEF to manage instance and inject in panelNavigationService
  - Use ServiceLocator to get access to the IFilterStringService (as singleton)
  - remove dependency on IDeprecatableToggleViewModel

some work to be done (fix some unit tests); but functionality seems to work again, and IMHO a bit less indirection. 

<!-- Thanks for contributing to CDP4-IME! -->

