### PR TITLE
GH97

### DIFF
--- a/ProductTree.Tests/ProductTreeRows/ElementUsageRowViewModelTestFixture.cs
+++ b/ProductTree.Tests/ProductTreeRows/ElementUsageRowViewModelTestFixture.cs
@@ -366,7 +366,7 @@ namespace ProductTree.Tests.ProductTreeRows
             dropinfo.SetupProperty(x => x.Effects);
             await vm.Drop(dropinfo.Object);
 
-            this.thingCreator.Verify(x => x.CreateElementUsage(It.IsAny<ElementDefinition>(), It.IsAny<ElementDefinition>(), It.IsAny<DomainOfExpertise>(), It.IsAny<ISession>()));
+            this.thingCreator.Verify(x => x.CreateElementUsage(this.elementUsage.ElementDefinition, It.IsAny<ElementDefinition>(), It.IsAny<DomainOfExpertise>(), It.IsAny<ISession>()));
         }
     }
 }

--- a/ProductTree/ViewModels/ProductTreeRows/ElementUsageRowViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeRows/ElementUsageRowViewModel.cs
@@ -645,7 +645,7 @@ namespace CDP4ProductTree.ViewModels
 
                 if (elementDefinition.TopContainer == this.Thing.TopContainer)
                 {
-                    await this.ThingCreator.CreateElementUsage((ElementDefinition)this.Thing.Container, elementDefinition, currentDomain, this.Session);
+                    await this.ThingCreator.CreateElementUsage(this.Thing.ElementDefinition, elementDefinition, currentDomain, this.Session);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
- Bugfix dropping ElementDefinition on ElementUsage created new ElementDefinition on the ElementUsage's container level instead of its own level (ElementUsage.elementDefinition).
- Unit test now explicitly verifies if the correct ElementDefinition is used when creating a new ElementUsage in this drop-scenario.