### PR TITLE
#279 Fixes for contextual expand and collapse menu

### DIFF
--- a/CDP4Composition/Mvvm/BrowserViewModelBase.cs
+++ b/CDP4Composition/Mvvm/BrowserViewModelBase.cs
@@ -99,7 +99,7 @@ namespace CDP4Composition.Mvvm
         /// Backing field for <see cref="IsAddButtonEnabled"/> property
         /// </summary>
         private bool isAddButtonEnabled;
-        
+
         /// <summary>
         /// Backing Field for Caption
         /// </summary>
@@ -751,6 +751,7 @@ namespace CDP4Composition.Mvvm
         private void ExecuteExpandRows()
         {
             var rowViewModelBase = this.SelectedThing;
+
             if (rowViewModelBase != null)
             {
                 rowViewModelBase.ExpandAllRows();
@@ -838,36 +839,36 @@ namespace CDP4Composition.Mvvm
                 return;
             }
 
-            if (this.SelectedThing is FolderRowViewModel)
+            if (!(this.SelectedThing is FolderRowViewModel))
             {
-                return;
-            }
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Edit", "CTRL+E", this.UpdateCommand, MenuItemKind.Edit));
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Inspect", "CTRL+I", this.InspectCommand, MenuItemKind.Inspect));
 
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Edit", "CTRL+E", this.UpdateCommand, MenuItemKind.Edit));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Inspect", "CTRL+I", this.InspectCommand, MenuItemKind.Inspect));
+                var deprecableThing = this.SelectedThing.Thing as IDeprecatableThing;
 
-            var deprecableThing = this.SelectedThing.Thing as IDeprecatableThing;
-            if (deprecableThing == null)
-            {
-                this.ContextMenu.Add(new ContextMenuItemViewModel(string.Format("Delete this {0}", this.camelCaseToSpaceConverter.Convert(this.SelectedThing.Thing.ClassKind, null, null, null)), "", this.DeleteCommand, MenuItemKind.Delete));
-            }
-            else
-            {
-                this.ContextMenu.Add(new ContextMenuItemViewModel(deprecableThing.IsDeprecated ? "Un-Deprecate" : "Deprecate", "", this.DeprecateCommand, MenuItemKind.Deprecate));
-            }
-
-            var categorizableThing = this.SelectedThing.Thing as ICategorizableThing;
-            if (categorizableThing != null && categorizableThing.Category.Any())
-            {
-                var categoriesMenu = new ContextMenuItemViewModel("Categories", "", null, MenuItemKind.None);
-
-                foreach (var category in categorizableThing.Category)
+                if (deprecableThing == null)
                 {
-                    var removeCategory = new ContextMenuItemViewModel($" Remove {category.Name} [{category.ShortName}]", "", this.RemoveCategoryFromSelectedThing, category, this.PermissionService.CanWrite(this.SelectedThing.Thing), MenuItemKind.Edit);
-                    categoriesMenu.SubMenu.Add(removeCategory);
+                    this.ContextMenu.Add(new ContextMenuItemViewModel(string.Format("Delete this {0}", this.camelCaseToSpaceConverter.Convert(this.SelectedThing.Thing.ClassKind, null, null, null)), "", this.DeleteCommand, MenuItemKind.Delete));
+                }
+                else
+                {
+                    this.ContextMenu.Add(new ContextMenuItemViewModel(deprecableThing.IsDeprecated ? "Un-Deprecate" : "Deprecate", "", this.DeprecateCommand, MenuItemKind.Deprecate));
                 }
 
-                this.ContextMenu.Add(categoriesMenu);
+                var categorizableThing = this.SelectedThing.Thing as ICategorizableThing;
+
+                if (categorizableThing != null && categorizableThing.Category.Any())
+                {
+                    var categoriesMenu = new ContextMenuItemViewModel("Categories", "", null, MenuItemKind.None);
+
+                    foreach (var category in categorizableThing.Category)
+                    {
+                        var removeCategory = new ContextMenuItemViewModel($" Remove {category.Name} [{category.ShortName}]", "", this.RemoveCategoryFromSelectedThing, category, this.PermissionService.CanWrite(this.SelectedThing.Thing), MenuItemKind.Edit);
+                        categoriesMenu.SubMenu.Add(removeCategory);
+                    }
+
+                    this.ContextMenu.Add(categoriesMenu);
+                }
             }
 
             if (this.SelectedThing != null && this.SelectedThing.ContainedRows.Count > 0)

--- a/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
@@ -273,27 +273,27 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(1, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(2, viewmodel.ContextMenu.Count);
 
             viewmodel.SelectedThing = iterationFolderRow;
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(1, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(2, viewmodel.ContextMenu.Count);
 
             var participantRow = participantFolderRow.ContainedRows.OfType<ModelParticipantRowViewModel>().Single(x => x.Name == "blabla blabla");
             viewmodel.SelectedThing = participantRow;
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(5, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(4, viewmodel.ContextMenu.Count);
 
             var iterationRow = iterationFolderRow.ContainedRows.Single();
             viewmodel.SelectedThing = iterationRow;
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(5, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(4, viewmodel.ContextMenu.Count);
         }
 
         [Test]
@@ -341,20 +341,20 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(1, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(2, viewmodel.ContextMenu.Count);
 
             viewmodel.SelectedThing = iterationFolderRow;
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(1, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(2, viewmodel.ContextMenu.Count);
 
             var participantRow = participantFolderRow.ContainedRows.OfType<ModelParticipantRowViewModel>().Single(x => x.Name == "blabla blabla");
             viewmodel.SelectedThing = participantRow;
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(4, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(3, viewmodel.ContextMenu.Count);
             foreach (var conMenu in viewmodel.ContextMenu)
             {
                 Assert.AreNotEqual("Delete this Participant", conMenu.Header);
@@ -365,7 +365,7 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(5, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(4, viewmodel.ContextMenu.Count);
         }
 
         [Test]
@@ -438,7 +438,7 @@ namespace CDP4SiteDirectory.Tests
             Assert.IsTrue(viewmodel.CanCreateIterationSetup);
             Assert.IsTrue(viewmodel.CanCreateEngineeringModelSetup);
             viewmodel.PopulateContextMenu();
-            Assert.AreEqual(1, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(2, viewmodel.ContextMenu.Count);
 
             viewmodel.CreateIterationSetupCommand.Execute(null);
             this.thingDialogNavigationService.Verify(x => x.Navigate(It.IsAny<IterationSetup>(), It.IsAny<IThingTransaction>(), this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, It.IsAny<EngineeringModelSetup>(), null));

--- a/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml
+++ b/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml
@@ -101,6 +101,7 @@
                 <dxg:TreeListView x:Name="View"
                                   AllowEditing="False"
                                   AutoWidth="False"
+                                  ExpandStateFieldName="IsExpanded"
                                   HorizontalScrollbarVisibility="Auto"
                                   NavigationStyle="Cell"
                                   ShowHorizontalLines="False"

--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -569,26 +569,26 @@ namespace CDP4EngineeringModel.Tests
 
             vm.SelectedThing = defRow.ContainedRows[0];
             vm.PopulateContextMenu();
-            Assert.AreEqual(10, vm.ContextMenu.Count);
+            Assert.AreEqual(9, vm.ContextMenu.Count);
 
             vm.SelectedThing = defRow.ContainedRows[1];
             vm.PopulateContextMenu();
-            Assert.AreEqual(10, vm.ContextMenu.Count);
+            Assert.AreEqual(9, vm.ContextMenu.Count);
 
             var usageRow = defRow.ContainedRows[2];
             var usage2Row = defRow.ContainedRows[3];
 
             vm.SelectedThing = usageRow;
             vm.PopulateContextMenu();
-            Assert.AreEqual(6, vm.ContextMenu.Count);
+            Assert.AreEqual(7, vm.ContextMenu.Count);
 
             vm.SelectedThing = usageRow.ContainedRows.Single();
             vm.PopulateContextMenu();
-            Assert.AreEqual(10, vm.ContextMenu.Count);
+            Assert.AreEqual(9, vm.ContextMenu.Count);
 
             vm.SelectedThing = usage2Row.ContainedRows.Single();
             vm.PopulateContextMenu();
-            Assert.AreEqual(10, vm.ContextMenu.Count);
+            Assert.AreEqual(9, vm.ContextMenu.Count);
 
             vm.Dispose();
         }

--- a/EngineeringModel.Tests/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModelTestFixture.cs
@@ -204,7 +204,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.FiniteStateBrowser
             viewmodel.SelectedThing = psRow;
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
-            Assert.AreEqual(8, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(7, viewmodel.ContextMenu.Count);
 
             // execute set default
             Assert.IsTrue(viewmodel.CanSetAsDefault);

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -448,6 +448,15 @@ namespace CDP4EngineeringModel.ViewModels
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Review Item Discrepancy", "", this.CreateReviewItemDiscrepancyCommand, MenuItemKind.Create, ClassKind.ReviewItemDiscrepancy));
 
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Navigates to Element Definition", "", this.ChangeFocusCommand, MenuItemKind.Navigate, ClassKind.ElementDefinition));
+
+                if (this.SelectedThing.ContainedRows.Count > 0)
+                {
+                    this.ContextMenu.Add(
+                        this.SelectedThing.IsExpanded ?
+                        new ContextMenuItemViewModel("Collapse Rows", "", this.CollpaseRowsCommand, MenuItemKind.None, ClassKind.NotThing) :
+                        new ContextMenuItemViewModel("Expand Rows", "", this.ExpandRowsCommand, MenuItemKind.None, ClassKind.NotThing));
+                }
+
                 return;
             }
 

--- a/EngineeringModel/ViewModels/PublicationBrowser/PublicationBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/PublicationBrowser/PublicationBrowserViewModel.cs
@@ -606,7 +606,16 @@ namespace CDP4EngineeringModel.ViewModels
         /// </summary>
         public override void PopulateContextMenu()
         {
+            base.PopulateContextMenu();
             this.ContextMenu.Clear();
+
+            if (this.SelectedThing != null && this.SelectedThing.ContainedRows.Count > 0)
+            {
+                this.ContextMenu.Add(
+                    this.SelectedThing.IsExpanded ?
+                    new ContextMenuItemViewModel("Collapse Rows", "", this.CollpaseRowsCommand, MenuItemKind.None, ClassKind.NotThing) :
+                    new ContextMenuItemViewModel("Expand Rows", "", this.ExpandRowsCommand, MenuItemKind.None, ClassKind.NotThing));
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/Views/PublicationBrowser/PublicationBrowser.xaml
+++ b/EngineeringModel/Views/PublicationBrowser/PublicationBrowser.xaml
@@ -120,49 +120,49 @@
                          BorderEffect="Default"
                          BorderEffectColor="Blue">
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
-        <dxb:ToolBarControl Height="30">
-            <dxb:BarButtonItem Command="{Binding PublishCommand}"
+            <dxb:ToolBarControl Height="30">
+                <dxb:BarButtonItem Command="{Binding PublishCommand}"
                                Glyph="{dx:DXImage Image=CreateModelDifferences_16x16.png}"
                                IsEnabled="{Binding CanCreatePublication, UpdateSourceTrigger=PropertyChanged}"
                                Hint="Publish" />
 
-            <dxb:BarButtonItem Command="{Binding RefreshCommand}"
+                <dxb:BarButtonItem Command="{Binding RefreshCommand}"
                                Glyph="{dx:DXImage Image=Refresh2_16x16.png}"
                                Hint="{Binding SelectedThingClassKindString,
                                               Converter={dx:FormatStringConverter FormatString={}Refresh {0}}}" />
 
-            <dxb:BarButtonItem Command="{Binding ExportCommand}"
+                <dxb:BarButtonItem Command="{Binding ExportCommand}"
                                Glyph="{dx:DXImage Image=Export_16x16.png}"
                                Hint="{Binding SelectedThingClassKindString,
                                               Converter={dx:FormatStringConverter FormatString={}Export {0}}}" />
 
-            <dxb:BarSplitButtonItem />
+                <dxb:BarSplitButtonItem />
 
-            <dxb:BarButtonItem Command="{Binding HelpCommand}"
+                <dxb:BarButtonItem Command="{Binding HelpCommand}"
                                Glyph="{dx:DXImage Image=Info_16x16.png}"
                                Hint="Show Help" />
 
-            <dxb:BarSplitButtonItem />
+                <dxb:BarSplitButtonItem />
 
-        </dxb:ToolBarControl>
+            </dxb:ToolBarControl>
 
-        <views:BrowserHeader Grid.Row="1" />
+            <views:BrowserHeader Grid.Row="1" />
 
-        <Grid Grid.Row="2">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="5" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
-            <dxg:TreeListControl x:Name="TreeListToBePublished"
+            <Grid Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="5" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <dxg:TreeListControl x:Name="TreeListToBePublished"
                                  Grid.Row="0"
                                  IsEnabled="{Binding CanCreatePublication, UpdateSourceTrigger=PropertyChanged}"
                                  ItemsSource="{Binding Path=Domains}"
@@ -170,23 +170,24 @@
                                                         Mode=TwoWay,
                                                         UpdateSourceTrigger=PropertyChanged}"
                                  services:GridUpdateService.UpdateStarted="{Binding HasUpdateStarted}">
-                <dxmvvm:Interaction.Behaviors>
-                    <cdp4Composition:ContextMenuBehavior />
-                </dxmvvm:Interaction.Behaviors>
-                <i:Interaction.Behaviors>
-                    <dragDrop:FrameworkElementDragBehavior />
-                </i:Interaction.Behaviors>
-                <dxg:TreeListControl.Columns>
-                    <dxg:TreeListColumn FieldName="Name" Header="Domain" />
-                    <dxg:TreeListColumn FieldName="Value" Header="New Value" />
-                    <dxg:TreeListColumn FieldName="Published" Header="Old Value" />
-                    <dxg:TreeListColumn FieldName="PercentageChange" Header="% Changed" />
-                    <dxg:TreeListColumn FieldName="ModelCode" Header="Model Code" />
-                </dxg:TreeListControl.Columns>
-                <dxg:TreeListControl.View>
-                    <dxg:TreeListView x:Name="ViewToBePublished"
+                    <dxmvvm:Interaction.Behaviors>
+                        <cdp4Composition:ContextMenuBehavior />
+                    </dxmvvm:Interaction.Behaviors>
+                    <i:Interaction.Behaviors>
+                        <dragDrop:FrameworkElementDragBehavior />
+                    </i:Interaction.Behaviors>
+                    <dxg:TreeListControl.Columns>
+                        <dxg:TreeListColumn FieldName="Name" Header="Domain" />
+                        <dxg:TreeListColumn FieldName="Value" Header="New Value" />
+                        <dxg:TreeListColumn FieldName="Published" Header="Old Value" />
+                        <dxg:TreeListColumn FieldName="PercentageChange" Header="% Changed" />
+                        <dxg:TreeListColumn FieldName="ModelCode" Header="Model Code" />
+                    </dxg:TreeListControl.Columns>
+                    <dxg:TreeListControl.View>
+                        <dxg:TreeListView x:Name="ViewToBePublished"
                                       AllowEditing="False"
                                       AutoWidth="False"
+                                      ExpandStateFieldName="IsExpanded"
                                       HorizontalScrollbarVisibility="Auto"
                                       NavigationStyle="Cell"
                                       ShowHorizontalLines="False"
@@ -196,31 +197,35 @@
                                       TreeDerivationMode="HierarchicalDataTemplate"
                                       TreeLineStyle="Solid"
                                       VerticalScrollbarVisibility="Auto">
-                        <dxg:TreeListView.ContextMenu>
-                            <ContextMenu Name="RowContextMenuPublication" />
-                        </dxg:TreeListView.ContextMenu>
-                    </dxg:TreeListView>
-                </dxg:TreeListControl.View>
-            </dxg:TreeListControl>
-            <GridSplitter Grid.Row="1"
+                            <dxg:TreeListView.ContextMenu>
+                                <ContextMenu Name="RowContextMenuPublication" />
+                            </dxg:TreeListView.ContextMenu>
+                        </dxg:TreeListView>
+                    </dxg:TreeListControl.View>
+                </dxg:TreeListControl>
+                <GridSplitter Grid.Row="1"
                           Height="5"
                           HorizontalAlignment="Stretch" />
-            <dxg:TreeListControl x:Name="TreeList"
+                <dxg:TreeListControl x:Name="TreeList"
                                  Grid.Row="2"
                                  ItemsSource="{Binding Path=Publications}"
                                  SelectedItem="{Binding SelectedThing,
                                                         Mode=TwoWay,
                                                         UpdateSourceTrigger=PropertyChanged}"
                                  services:GridUpdateService.UpdateStarted="{Binding HasUpdateStarted}">
-                <dxg:TreeListControl.Columns>
-                    <dxg:TreeListColumn FieldName="Name" Header="Created On" />
-                    <dxg:TreeListColumn FieldName="OwnerShortName" Header="Domain" />
-                    <dxg:TreeListColumn FieldName="ModelCode" Header="Model Code" />
-                </dxg:TreeListControl.Columns>
-                <dxg:TreeListControl.View>
-                    <dxg:TreeListView x:Name="View"
+                    <dxmvvm:Interaction.Behaviors>
+                        <cdp4Composition:ContextMenuBehavior />
+                    </dxmvvm:Interaction.Behaviors>
+                    <dxg:TreeListControl.Columns>
+                        <dxg:TreeListColumn FieldName="Name" Header="Created On" />
+                        <dxg:TreeListColumn FieldName="OwnerShortName" Header="Domain" />
+                        <dxg:TreeListColumn FieldName="ModelCode" Header="Model Code" />
+                    </dxg:TreeListControl.Columns>
+                    <dxg:TreeListControl.View>
+                        <dxg:TreeListView x:Name="View"
                                       AllowEditing="False"
                                       AutoWidth="False"
+                                      ExpandStateFieldName="IsExpanded"
                                       HorizontalScrollbarVisibility="Auto"
                                       NavigationStyle="Cell"
                                       ShowHorizontalLines="False"
@@ -230,25 +235,18 @@
                                       TreeDerivationMode="HierarchicalDataTemplate"
                                       TreeLineStyle="Solid"
                                       VerticalScrollbarVisibility="Auto">
-                        <dxg:TreeListView.ContextMenu>
-                            <ContextMenu Name="RowContextMenu" ItemsSource="{Binding ContextMenu}">
-                                <ContextMenu.ItemContainerStyle>
-                                    <Style TargetType="{x:Type MenuItem}">
-                                        <Setter Property="Header" Value="{Binding Header}" />
-                                        <Setter Property="Command" Value="{Binding MenuCommand}" />
-                                    </Style>
-                                </ContextMenu.ItemContainerStyle>
-                            </ContextMenu>
-                        </dxg:TreeListView.ContextMenu>
-                    </dxg:TreeListView>
-                </dxg:TreeListControl.View>
-                <dxg:TreeListControl.InputBindings>
-                    <KeyBinding Gesture="CTRL+I" Command="{Binding Path=InspectCommand}"></KeyBinding>
-                    <KeyBinding Gesture="CTRL+E" Command="{Binding Path=UpdateCommand}"></KeyBinding>
-                </dxg:TreeListControl.InputBindings>
-            </dxg:TreeListControl>
+                            <dxg:TreeListView.ContextMenu>
+                                <ContextMenu Name="RowContextMenuPublicationRow" />
+                            </dxg:TreeListView.ContextMenu>
+                        </dxg:TreeListView>
+                    </dxg:TreeListControl.View>
+                    <dxg:TreeListControl.InputBindings>
+                        <KeyBinding Gesture="CTRL+I" Command="{Binding Path=InspectCommand}"></KeyBinding>
+                        <KeyBinding Gesture="CTRL+E" Command="{Binding Path=UpdateCommand}"></KeyBinding>
+                    </dxg:TreeListControl.InputBindings>
+                </dxg:TreeListControl>
+            </Grid>
         </Grid>
-    </Grid>
 
     </dx:LoadingDecorator>
 </UserControl>

--- a/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
+++ b/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
@@ -127,6 +127,7 @@
                                   MaxHeight="1080"
                                   AllowEditing="False"
                                   AutoWidth="true"
+                                  ExpandStateFieldName="IsExpanded"
                                   ExpandCollapseNodesOnNavigation="True"
                                   HorizontalScrollbarVisibility="Auto"
                                   ShowHorizontalLines="False"

--- a/ProductTree.Tests/ProductTreeViewModelTestFixture.cs
+++ b/ProductTree.Tests/ProductTreeViewModelTestFixture.cs
@@ -305,7 +305,7 @@ namespace ProductTree.Tests
             vm.SelectedThing = paramRow;
 
             vm.PopulateContextMenu();
-            Assert.AreEqual(7, vm.ContextMenu.Count);
+            Assert.AreEqual(6, vm.ContextMenu.Count);
 
             Assert.IsTrue(vm.DeleteSubscriptionCommand.CanExecute(null));
             Assert.AreEqual(1, paramRow.Thing.ParameterSubscription.Count);
@@ -384,7 +384,7 @@ namespace ProductTree.Tests
             this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()));
 
             vm.PopulateContextMenu();
-            Assert.AreEqual(6, vm.ContextMenu.Count);
+            Assert.AreEqual(5, vm.ContextMenu.Count);
         }
 
         [Test]
@@ -414,7 +414,7 @@ namespace ProductTree.Tests
             var elemDef = vm.TopElement.Single();
             vm.SelectedThing = elemDef;
             vm.PopulateContextMenu();
-            Assert.AreEqual(5, vm.ContextMenu.Count);
+            Assert.AreEqual(4, vm.ContextMenu.Count);
         }
 
         [Test]


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [ ] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
#279 Expand and collapse fixes for following browsers

Engineering models browser:

    participants
    iterations
    active domains

Element Definitions browser:

    Element Usage

Person roles browser:

    person role (folder item)
    participant role (folder item)

Finite States browser:

    Possible Finite State List (folder item)
    Actual Finite State List (folder item)

Relationships browser:

    Binary Relationships (folder item)
    Multi Relationships (folder item)

Publications browser

    domain row with parameters to be published

Requirements browser:

    Parametric Constraints (folder item)
    Simple Parameter Values (folder item)

For CDP4 Object Browser a new issue should be open since we do not have a context menu implementation.

Menus have been added for
Organizations browser

    organization

Rule Verification lists browser

    Rule verification list

