### PR TITLE
Feat/231 - fixes #231 refactoring thing icon overlay

### DIFF
--- a/BasicRdl/Views/CategoryBrowser.xaml
+++ b/BasicRdl/Views/CategoryBrowser.xaml
@@ -73,13 +73,10 @@
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
-
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/ConstantsBrowser.xaml
+++ b/BasicRdl/Views/ConstantsBrowser.xaml
@@ -75,10 +75,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18" MinWidth="18">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/Dialogs/ArrayParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/ArrayParameterTypeDialog.xaml
@@ -21,6 +21,7 @@
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/ErrorTemplate.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -74,14 +75,10 @@
                                 </dxg:TableView>
                             </dxg:GridControl.View>
                             <dxg:GridControl.Columns>
-                                <dxg:GridColumn Width="20"
-                                                MinWidth="20"
-                                                AllowEditing="False"
-                                                FixedWidth="True">
+                                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                     <dxg:GridColumn.DisplayTemplate>
                                         <ControlTemplate>
-                                            <Image Width="16"
-                                                   Height="16">
+                                            <Image Style="{StaticResource ThingIcon}">
                                                 <Image.Source>
                                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/BasicRdl/Views/Dialogs/CompoundParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/CompoundParameterTypeDialog.xaml
@@ -22,6 +22,7 @@
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/ErrorTemplate.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -93,14 +94,10 @@
                                 </dxg:TableView>
                             </dxg:GridControl.View>
                             <dxg:GridControl.Columns>
-                                <dxg:GridColumn Width="20"
-                                                MinWidth="20"
-                                                FixedWidth="True"
-                                                AllowEditing="False">
+                                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                     <dxg:GridColumn.DisplayTemplate>
                                         <ControlTemplate>
-                                            <Image Width="16"
-                                                   Height="16">
+                                            <Image Style="{StaticResource ThingIcon}">
                                                 <Image.Source>
                                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/BasicRdl/Views/Dialogs/DerivedUnitDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DerivedUnitDialog.xaml
@@ -18,6 +18,9 @@
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -92,14 +95,10 @@
                         </dxg:TableView>
                     </dxg:GridControl.View>
                     <dxg:GridControl.Columns>
-
-                        <dxg:GridColumn Width="18"
-                                                MinWidth="18"
-                                                FixedWidth="True">
+                        <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                             <dxg:GridColumn.DisplayTemplate>
                                 <ControlTemplate>
-                                    <Image Width="16"
-                                               Height="16">
+                                    <Image Style="{StaticResource ThingIcon}">
                                         <Image.Source>
                                             <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                 <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/BasicRdl/Views/Dialogs/GlossaryDialog.xaml
+++ b/BasicRdl/Views/Dialogs/GlossaryDialog.xaml
@@ -17,6 +17,9 @@
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -84,13 +87,10 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-                            <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                            <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                 <dxg:GridColumn.DisplayTemplate>
                                     <ControlTemplate>
-                                        <Image Width="16"
-                                               Height="16">
+                                        <Image Style="{StaticResource ThingIcon}">
                                             <Image.Source>
                                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/BasicRdl/Views/FileTypeBrowser.xaml
+++ b/BasicRdl/Views/FileTypeBrowser.xaml
@@ -75,10 +75,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18" MinWidth="18">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/GlossaryBrowser.xaml
+++ b/BasicRdl/Views/GlossaryBrowser.xaml
@@ -26,9 +26,7 @@
                 <dxc:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dxc:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -47,9 +45,7 @@
                 <dxc:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dxc:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/MeasurementScalesBrowser.xaml
+++ b/BasicRdl/Views/MeasurementScalesBrowser.xaml
@@ -89,12 +89,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/MeasurementUnitsBrowser.xaml
+++ b/BasicRdl/Views/MeasurementUnitsBrowser.xaml
@@ -89,12 +89,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/ParameterTypesBrowser.xaml
+++ b/BasicRdl/Views/ParameterTypesBrowser.xaml
@@ -77,13 +77,10 @@
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                Fixed="Left"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus"

--- a/BasicRdl/Views/ReferenceSourceBrowser.xaml
+++ b/BasicRdl/Views/ReferenceSourceBrowser.xaml
@@ -75,10 +75,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18" MinWidth="18">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/RulesBrowser.xaml
+++ b/BasicRdl/Views/RulesBrowser.xaml
@@ -78,13 +78,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                Fixed="Left"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/BasicRdl/Views/SiteRdlClosingDialog.xaml
+++ b/BasicRdl/Views/SiteRdlClosingDialog.xaml
@@ -17,51 +17,53 @@
              mc:Ignorable="d"
              Title="Select site RDL to close">
     <dx:DXWindow.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-        <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:ClosingSiteRdlSessionRowViewModel}" 
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:SiteRdlRowViewModel}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                                Height="16">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <dx:MeasurePixelSnapper>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:ClosingSiteRdlSessionRowViewModel}" 
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
                         <ContentPresenter x:Name="defaultRowPresenter"
                                           Content="{Binding}"
                                           ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                    </dx:MeasurePixelSnapper>
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:SiteRdlRowViewModel}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <dx:MeasurePixelSnapper>
+                            <ContentPresenter x:Name="defaultRowPresenter"
+                                              Content="{Binding}"
+                                              ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                        </dx:MeasurePixelSnapper>
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+        </ResourceDictionary>
     </dx:DXWindow.Resources>
     <Grid>
         <Grid.RowDefinitions>

--- a/BasicRdl/Views/SiteRdlOpeningDialog.xaml
+++ b/BasicRdl/Views/SiteRdlOpeningDialog.xaml
@@ -17,45 +17,50 @@
              mc:Ignorable="d"
              Title="Select site RDL to open">
     <dx:DXWindow.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-        <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:SiteRdlSessionRowViewModel}" ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3"
-                               Source="{dx:DXImage Image=Database_16x16.png}" />
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
 
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:SiteRdlRowViewModel}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <dx:MeasurePixelSnapper>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:SiteRdlSessionRowViewModel}" ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Width="16"
+                                   Height="16"
+                                   Margin="3"
+                                   Source="{dx:DXImage Image=Database_16x16.png}" />
+                        </dx:PixelSnapper>
                         <ContentPresenter x:Name="defaultRowPresenter"
                                           Content="{Binding}"
                                           ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                    </dx:MeasurePixelSnapper>
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:SiteRdlRowViewModel}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <dx:MeasurePixelSnapper>
+                            <ContentPresenter x:Name="defaultRowPresenter"
+                                              Content="{Binding}"
+                                              ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                        </dx:MeasurePixelSnapper>
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+        </ResourceDictionary>
     </dx:DXWindow.Resources>
     <Grid>
         <Grid.RowDefinitions>

--- a/BasicRdl/Views/UnitPrefixBrowser.xaml
+++ b/BasicRdl/Views/UnitPrefixBrowser.xaml
@@ -74,10 +74,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18" MinWidth="18">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/CDP4BuiltInRules/CDP4BuiltInRules.csproj
+++ b/CDP4BuiltInRules/CDP4BuiltInRules.csproj
@@ -246,6 +246,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CDP4CommonView\CDP4CommonView.csproj">
+      <Project>{5e0e5c30-df40-4708-abae-4da03ec9b881}</Project>
+      <Name>CDP4CommonView</Name>
+      <Private>False</Private>
+    </ProjectReference>
     <ProjectReference Include="..\CDP4Composition\CDP4Composition.csproj">
       <Project>{866d3d1a-dea1-4c0d-a2ec-972cf450d0c4}</Project>
       <Name>CDP4Composition</Name>

--- a/CDP4BuiltInRules/Views/ErrorBrowser.xaml
+++ b/CDP4BuiltInRules/Views/ErrorBrowser.xaml
@@ -79,12 +79,10 @@
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/CDP4CommonView/Items/AliasLayoutGroup.xaml
+++ b/CDP4CommonView/Items/AliasLayoutGroup.xaml
@@ -17,6 +17,9 @@
                   MaxWidth="700">
     <dxlc:LayoutGroup.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dxlc:LayoutGroup.Resources>
@@ -83,13 +86,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16"
-                                   Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4CommonView/Items/CitationLayoutGroup.xaml
+++ b/CDP4CommonView/Items/CitationLayoutGroup.xaml
@@ -18,6 +18,9 @@
                   MaxWidth="1920">
     <dxlc:LayoutGroup.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dxlc:LayoutGroup.Resources>
@@ -87,13 +90,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16"
-                                   Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4CommonView/Items/DefinitionLayoutGroup.xaml
+++ b/CDP4CommonView/Items/DefinitionLayoutGroup.xaml
@@ -15,6 +15,9 @@
              MaxWidth="700">
     <dxlc:LayoutGroup.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dxlc:LayoutGroup.Resources>
@@ -83,13 +86,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16"
-                                    Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4CommonView/Items/HyperLinkLayoutGroup.xaml
+++ b/CDP4CommonView/Items/HyperLinkLayoutGroup.xaml
@@ -15,6 +15,9 @@
              MaxWidth="700">
     <dxlc:LayoutGroup.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dxlc:LayoutGroup.Resources>
@@ -81,13 +84,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16"
-                                    Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4CommonView/Resources/CDP4Styles.xaml
+++ b/CDP4CommonView/Resources/CDP4Styles.xaml
@@ -170,15 +170,15 @@
         </Style.Triggers>
     </Style>
     <Style x:Key="ThingIcon" TargetType="{x:Type Image}">
-        <Setter Property="Width" Value="24"/>
+        <Setter Property="Width" Value="28"/>
         <Setter Property="Height" Value="16"/>
         <Setter Property="Margin" Value="1"/>
         <Setter Property="HorizontalAlignment" Value="Center"/>
     </Style>
     <Style x:Key="ThingIconGridColumn" TargetType="{x:Type dxg:GridColumn}">
         <Setter Property="AllowResizing" Value="False" />
-        <Setter Property="Width" Value="26"/>
-        <Setter Property="MinWidth" Value="26"/>
+        <Setter Property="Width" Value="28"/>
+        <Setter Property="MinWidth" Value="28"/>
         <Setter Property="FixedWidth" Value="True"/>
         <Setter Property="AllowEditing" Value="False"/>
     </Style>

--- a/CDP4CommonView/Resources/CDP4Styles.xaml
+++ b/CDP4CommonView/Resources/CDP4Styles.xaml
@@ -169,7 +169,19 @@
             </EventTrigger>
         </Style.Triggers>
     </Style>
-
+    <Style x:Key="ThingIcon" TargetType="{x:Type Image}">
+        <Setter Property="Width" Value="24"/>
+        <Setter Property="Height" Value="16"/>
+        <Setter Property="Margin" Value="1"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+    </Style>
+    <Style x:Key="ThingIconGridColumn" TargetType="{x:Type dxg:GridColumn}">
+        <Setter Property="AllowResizing" Value="False" />
+        <Setter Property="Width" Value="26"/>
+        <Setter Property="MinWidth" Value="26"/>
+        <Setter Property="FixedWidth" Value="True"/>
+        <Setter Property="AllowEditing" Value="False"/>
+    </Style>
     <Style x:Key="NoBorderButton" TargetType="{x:Type Button}">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>

--- a/CDP4Composition/Services/IconCacheService/IconCacheService.cs
+++ b/CDP4Composition/Services/IconCacheService/IconCacheService.cs
@@ -96,6 +96,7 @@ namespace CDP4Composition.Services
         /// <param name="overlayUri">
         /// The uri of the overlay <see cref="BitmapSource"/>
         /// </param>
+        /// <param name="overlayPosition">The <see cref="OverlayPositionKind"/></param>
         /// <returns>
         /// An instance of <see cref="BitmapSource"/>
         /// </returns>

--- a/CDP4Composition/Services/IconCacheService/OverlayPositionKind.cs
+++ b/CDP4Composition/Services/IconCacheService/OverlayPositionKind.cs
@@ -6,6 +6,8 @@
 
 namespace CDP4Composition.Services
 {
+    using System.Linq;
+
     /// <summary>
     /// Assertion on the overlay position
     /// </summary>
@@ -30,5 +32,27 @@ namespace CDP4Composition.Services
         /// Asserts that the overlay shall be palced on the bottom right corner
         /// </summary>
         BottomRight
+    }
+
+    public static class OverlayPositionKindExtensions
+    {
+        public static bool IsTop(this OverlayPositionKind overlayPositionKind)
+        {
+            return new[] { OverlayPositionKind.TopLeft, OverlayPositionKind.TopRight }.Contains(overlayPositionKind);
+        }
+
+        public static bool IsLeft(this OverlayPositionKind overlayPositionKind)
+        {
+            return new[] { OverlayPositionKind.TopLeft, OverlayPositionKind.BottomLeft }.Contains(overlayPositionKind);
+        }
+
+        public static bool IsRight(this OverlayPositionKind overlayPositionKind)
+        {
+            return new[] { OverlayPositionKind.TopRight, OverlayPositionKind.BottomRight }.Contains(overlayPositionKind);
+        }
+        public static bool IsBottom(this OverlayPositionKind overlayPositionKind)
+        {
+            return new[] { OverlayPositionKind.BottomRight, OverlayPositionKind.BottomLeft }.Contains(overlayPositionKind);
+        }
     }
 }

--- a/CDP4Composition/Services/IconCacheService/OverlayPositionKind.cs
+++ b/CDP4Composition/Services/IconCacheService/OverlayPositionKind.cs
@@ -1,13 +1,11 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OverlayPositionKind.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016-2019 RHEA System S.A. All rights reserved
+//   Copyright (c) 2016-2020 RHEA System S.A. All rights reserved
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Composition.Services
 {
-    using System.Linq;
-
     /// <summary>
     /// Assertion on the overlay position
     /// </summary>
@@ -32,27 +30,5 @@ namespace CDP4Composition.Services
         /// Asserts that the overlay shall be palced on the bottom right corner
         /// </summary>
         BottomRight
-    }
-
-    public static class OverlayPositionKindExtensions
-    {
-        public static bool IsTop(this OverlayPositionKind overlayPositionKind)
-        {
-            return new[] { OverlayPositionKind.TopLeft, OverlayPositionKind.TopRight }.Contains(overlayPositionKind);
-        }
-
-        public static bool IsLeft(this OverlayPositionKind overlayPositionKind)
-        {
-            return new[] { OverlayPositionKind.TopLeft, OverlayPositionKind.BottomLeft }.Contains(overlayPositionKind);
-        }
-
-        public static bool IsRight(this OverlayPositionKind overlayPositionKind)
-        {
-            return new[] { OverlayPositionKind.TopRight, OverlayPositionKind.BottomRight }.Contains(overlayPositionKind);
-        }
-        public static bool IsBottom(this OverlayPositionKind overlayPositionKind)
-        {
-            return new[] { OverlayPositionKind.BottomRight, OverlayPositionKind.BottomLeft }.Contains(overlayPositionKind);
-        }
     }
 }

--- a/CDP4Composition/Utilities/IconUtilities.cs
+++ b/CDP4Composition/Utilities/IconUtilities.cs
@@ -153,7 +153,7 @@ namespace CDP4Common.Helpers
             using (var gr = Graphics.FromImage(img))
             {
                 gr.CompositingMode = CompositingMode.SourceOver;
-                gr.DrawImage(thingBitMapImage, GetMainImagePoint(overlayPosition, img, thingBitMapImage));
+                gr.DrawImage(thingBitMapImage, GetMainImagePoint(img, thingBitMapImage));
                 gr.DrawImage(overlayBitMapImage, GetOverlayPoint(overlayPosition, img, overlayBitMapImage));
             }
 
@@ -164,8 +164,8 @@ namespace CDP4Common.Helpers
         /// Gets the starting <see cref="Point"/> where the overlay needs to be drawn
         /// </summary>
         /// <param name="overlayPosition">The <see cref="OverlayPositionKind"/></param>
-        /// <param name="targetImage"></param>
-        /// <param name="overlayBitMapImage"></param>
+        /// <param name="targetImage">The <see cref="Image"/> that the overlay is added to</param>
+        /// <param name="overlayBitMapImage">The overlay<see cref="Image"/></param>
         /// <returns>Starting <see cref="Point"/> where the overlay needs to be drawn</returns>
         private static Point GetOverlayPoint(OverlayPositionKind overlayPosition, Image targetImage, Image overlayBitMapImage)
         {
@@ -194,11 +194,10 @@ namespace CDP4Common.Helpers
         /// <summary>
         /// Gets the starting <see cref="Point"/> where the main image needs to be drawn
         /// </summary>
-        /// <param name="overlayPosition">The <see cref="OverlayPositionKind"/></param>
-        /// <param name="targetImage"></param>
-        /// <param name="thingBitMapImage"></param>
+        /// <param name="targetImage">The <see cref="Image"/> that the main image is added to</param>
+        /// <param name="thingBitMapImage">The main <see cref="Image"/></param>
         /// <returns>Starting <see cref="Point"/> where the main image needs to be drawn</returns>
-        private static Point GetMainImagePoint(OverlayPositionKind overlayPosition, Image targetImage, Image thingBitMapImage)
+        private static Point GetMainImagePoint(Image targetImage, Image thingBitMapImage)
         {
             var rightXpos = (targetImage.Width - thingBitMapImage.Width) / 2;
 

--- a/CDP4Composition/Utilities/IconUtilities.cs
+++ b/CDP4Composition/Utilities/IconUtilities.cs
@@ -146,7 +146,7 @@ namespace CDP4Common.Helpers
             var overlayBitMapImage = BitmapImage2Bitmap(overlay, (int)Math.Floor(thingBitMapImage.Width * 0.75D), (int)Math.Floor(thingBitMapImage.Height * 0.75D));
 
             var img = new Bitmap(
-                    (int)Math.Floor(thingBitMapImage.Width * 1.5D),
+                    (int)Math.Floor(thingBitMapImage.Width * 1.75D),
                     (int)Math.Floor(thingBitMapImage.Height * 1.0D),
                 System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 

--- a/CDP4ObjectBrowser/Views/ObjectBrowser.xaml
+++ b/CDP4ObjectBrowser/Views/ObjectBrowser.xaml
@@ -24,9 +24,7 @@
                                       ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}">
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
@@ -43,9 +41,7 @@
                                   ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}">
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4RelationshipEditor/Views/RelationshipEditor.xaml
+++ b/CDP4RelationshipEditor/Views/RelationshipEditor.xaml
@@ -44,8 +44,6 @@
                                 <TextBlock Text="{Binding ShortName}" Margin="10,0,10,10"></TextBlock>
                                 <TextBlock Text="{Binding Name}" Margin="10,0,10,10"></TextBlock>
                             </StackPanel>
-                            
-                            
                         </DataTemplate>
                     </Setter.Value>
                 </Setter>
@@ -94,7 +92,6 @@
 
                 </dxb:BarCheckItem>
             </dxb:ToolBarControl>-->
-            
                 <dxn:NavBarControl dx:ThemeManager.ThemeName="Seven" Margin="0,0,0,0" Background="Bisque" Compact="False">
                 <dxn:NavBarControl.View>
                     <dxn:ExplorerBarView/>

--- a/CDP4RelationshipEditor/Views/RelationshipEditor.xaml
+++ b/CDP4RelationshipEditor/Views/RelationshipEditor.xaml
@@ -15,40 +15,42 @@
              dx:ThemeManager.ThemeName="{Binding ThemeName}"
              d:DesignHeight="300" d:DesignWidth="650">
     <UserControl.Resources>
-        <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
-        <Style TargetType="diagram:NamedThingDiagramContentItem">
-            <Setter Property="CanMove" Value="True" />
-            <Setter Property="CanDelete" Value="True" />
-            <Setter Property="CanResize" Value="False" />
-            <Setter Property="CanRotate" Value="False" />
-            <Setter Property="ForegroundId" Value="Dark_5"/>
-            <Setter Property="BackgroundId" Value="White_2"/>
-            <Setter Property="Padding" Value="20"/>
-            <Setter Property="FontSize" Value="12"/>
-            <Setter>
-                <Setter.Property>ContentTemplate</Setter.Property>
-                <Setter.Value>
-                    <DataTemplate>
-                        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="10"
-                                    >
-                                <Image.Source>
-                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                        <Binding />
-                                    </MultiBinding>
-                                </Image.Source>
-                            </Image>
-                            <TextBlock Text="{Binding ShortName}" Margin="10,0,10,10"></TextBlock>
-                            <TextBlock Text="{Binding Name}" Margin="10,0,10,10"></TextBlock>
-                        </StackPanel>
-                        
-                        
-                    </DataTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
+            <Style TargetType="diagram:NamedThingDiagramContentItem">
+                <Setter Property="CanMove" Value="True" />
+                <Setter Property="CanDelete" Value="True" />
+                <Setter Property="CanResize" Value="False" />
+                <Setter Property="CanRotate" Value="False" />
+                <Setter Property="ForegroundId" Value="Dark_5"/>
+                <Setter Property="BackgroundId" Value="White_2"/>
+                <Setter Property="Padding" Value="20"/>
+                <Setter Property="FontSize" Value="12"/>
+                <Setter>
+                    <Setter.Property>ContentTemplate</Setter.Property>
+                    <Setter.Value>
+                        <DataTemplate>
+                            <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                <Image Style="{StaticResource ThingIcon}" Margin="10">
+                                    <Image.Source>
+                                        <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                            <Binding />
+                                        </MultiBinding>
+                                    </Image.Source>
+                                </Image>
+                                <TextBlock Text="{Binding ShortName}" Margin="10,0,10,10"></TextBlock>
+                                <TextBlock Text="{Binding Name}" Margin="10,0,10,10"></TextBlock>
+                            </StackPanel>
+                            
+                            
+                        </DataTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -139,10 +141,7 @@
                                         <MouseBinding MouseAction="LeftClick" Command="{Binding CreateRelationshipCommand}"/>
                                     </Border.InputBindings>
                                     <StackPanel Orientation="Horizontal">
-                                    <Image Width="16"
-                                           Height="16"
-                                           Margin="10"
-                                            >
+                                        <Image Style="{StaticResource ThingIcon}" Margin="10">
                                         <Image.Source>
                                             <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                 <Binding Path="Thing"/>

--- a/CDP4SiteDirectory/Views/Dialogs/EngineeringModelSetupSelectionDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/EngineeringModelSetupSelectionDialog.xaml
@@ -19,7 +19,12 @@
              navigation:ExtendedDialogResultCloser.DialogResult="{Binding DialogResult}"
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
-        <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
+        </ResourceDictionary>
     </dx:DXWindow.Resources>
     <Grid>
 
@@ -69,14 +74,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                Fixed="Left"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16"
-                                   Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4SiteDirectory/Views/Dialogs/ParticipantRoleDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/ParticipantRoleDialog.xaml
@@ -17,6 +17,9 @@
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -59,14 +62,10 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-
-                            <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                            <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                 <dxg:GridColumn.DisplayTemplate>
                                     <ControlTemplate>
-                                        <Image Width="16"
-                                               Height="16">
+                                        <Image Style="{StaticResource ThingIcon}">
                                             <Image.Source>
                                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/PersonDialog.xaml
@@ -21,6 +21,7 @@
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
                 <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/ErrorTemplate.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -309,13 +310,10 @@
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
 
-                            <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                            <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                 <dxg:GridColumn.DisplayTemplate>
                                     <ControlTemplate>
-                                        <Image Width="16"
-                                               Height="16">
+                                        <Image Style="{StaticResource ThingIcon}">
                                             <Image.Source>
                                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
@@ -410,14 +408,10 @@
                             </dxg:TableView>
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
-
-                            <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                            <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                 <dxg:GridColumn.DisplayTemplate>
                                     <ControlTemplate>
-                                        <Image Width="16"
-                                               Height="16">
+                                        <Image Style="{StaticResource ThingIcon}">
                                             <Image.Source>
                                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
@@ -497,13 +491,10 @@
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
 
-                            <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                            <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                 <dxg:GridColumn.DisplayTemplate>
                                     <ControlTemplate>
-                                        <Image Width="16"
-                                               Height="16">
+                                        <Image Style="{StaticResource ThingIcon}">
                                             <Image.Source>
                                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4SiteDirectory/Views/Dialogs/PersonRoleDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/PersonRoleDialog.xaml
@@ -17,6 +17,9 @@
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -60,13 +63,10 @@
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
 
-                            <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                            <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                 <dxg:GridColumn.DisplayTemplate>
                                     <ControlTemplate>
-                                        <Image Width="16"
-                                               Height="16">
+                                        <Image Style="{StaticResource ThingIcon}">
                                             <Image.Source>
                                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml
+++ b/CDP4SiteDirectory/Views/DomainOfExpertiseBrowser/DomainOfExpertiseBrowser.xaml
@@ -78,13 +78,10 @@
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                Fixed="Left"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/CDP4SiteDirectory/Views/ModelBrowser/ModelBrowser.xaml
+++ b/CDP4SiteDirectory/Views/ModelBrowser/ModelBrowser.xaml
@@ -29,9 +29,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -50,9 +48,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -71,9 +67,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -95,9 +89,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -119,9 +111,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/CDP4SiteDirectory/Views/NaturalLanguages/NaturalLanguageBrowser.xaml
+++ b/CDP4SiteDirectory/Views/NaturalLanguages/NaturalLanguageBrowser.xaml
@@ -74,13 +74,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                Fixed="Left"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml
+++ b/CDP4SiteDirectory/Views/OrganizationBrowser/OrganizationBrowser.xaml
@@ -23,9 +23,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -44,9 +42,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml
+++ b/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml
@@ -28,9 +28,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -52,9 +50,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}">
                                         <Binding Mode="OneWay"

--- a/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml
+++ b/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml
@@ -30,9 +30,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -51,9 +49,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -72,9 +68,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -93,9 +87,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -114,9 +106,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml
+++ b/CDP4SiteDirectory/Views/SiteRdlBrowser/SiteRdlBrowser.xaml
@@ -72,13 +72,10 @@
                 </dxg:TableView>
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                Fixed="Left"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
@@ -21,6 +21,7 @@
         <ResourceDictionary>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
                 <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/ErrorTemplate.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
@@ -84,14 +85,10 @@
                                 </dxg:TableView>
                             </dxg:GridControl.View>
                             <dxg:GridControl.Columns>
-                                <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True"
-                                            AllowEditing="False">
+                                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                     <dxg:GridColumn.DisplayTemplate>
                                         <ControlTemplate>
-                                            <Image Width="16"
-                                                   Height="16">
+                                            <Image Style="{StaticResource ThingIcon}">
                                                 <Image.Source>
                                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
@@ -162,13 +159,10 @@
                                 </dxg:TableView>
                             </dxg:GridControl.View>
                             <dxg:GridControl.Columns>
-                                <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                     <dxg:GridColumn.DisplayTemplate>
                                         <ControlTemplate>
-                                            <Image Width="16"
-                                               Height="16">
+                                            <Image Style="{StaticResource ThingIcon}">
                                                 <Image.Source>
                                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/EngineeringModel/Views/Dialogs/PossibleFiniteStateListDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/PossibleFiniteStateListDialog.xaml
@@ -20,6 +20,7 @@
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/ErrorTemplate.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -116,13 +117,10 @@
                                 </dxg:TableView>
                             </dxg:GridControl.View>
                             <dxg:GridControl.Columns>
-                                <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                     <dxg:GridColumn.DisplayTemplate>
                                         <ControlTemplate>
-                                            <Image Width="16"
-                                               Height="16">
+                                            <Image Style="{StaticResource ThingIcon}">
                                                 <Image.Source>
                                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
+++ b/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
@@ -41,9 +41,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" UpdateSourceTrigger="PropertyChanged"/>
@@ -62,9 +60,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -83,9 +79,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -105,9 +99,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -126,9 +118,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -147,9 +137,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" ConverterParameter="{x:Static commonData:ClassKind.Option}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -168,9 +156,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" ConverterParameter="{x:Static commonData:ClassKind.ActualFiniteState}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -189,9 +175,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3"
+                            <Image Style="{StaticResource ThingIcon}"
                                    Source="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/parameterComponent_32x32.png"/>
                         </dx:PixelSnapper>
                         <ContentPresenter x:Name="defaultRowPresenter"

--- a/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowser.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowser.xaml
@@ -32,9 +32,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -53,9 +51,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -74,9 +70,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowser.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowser.xaml
@@ -33,9 +33,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -54,9 +52,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -75,9 +71,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/EngineeringModel/Views/FiniteStateBrowser/FiniteStateBrowser.xaml
+++ b/EngineeringModel/Views/FiniteStateBrowser/FiniteStateBrowser.xaml
@@ -31,9 +31,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -52,9 +50,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -73,9 +69,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -94,9 +88,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -115,9 +107,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/EngineeringModel/Views/OptionBrowser/OptionBrowser.xaml
+++ b/EngineeringModel/Views/OptionBrowser/OptionBrowser.xaml
@@ -30,9 +30,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -112,13 +110,10 @@
             </dxg:GridControl.View>
             <dxg:GridControl.Columns>
 
-                <dxg:GridColumn Width="18"
-                                MinWidth="18"
-                                Fixed="Left"
-                                FixedWidth="True">
+                <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                     <dxg:GridColumn.DisplayTemplate>
                         <ControlTemplate>
-                            <Image Width="16" Height="16">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/EngineeringModel/Views/PublicationBrowser/PublicationBrowser.xaml
+++ b/EngineeringModel/Views/PublicationBrowser/PublicationBrowser.xaml
@@ -27,9 +27,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -48,9 +46,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -70,9 +66,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -92,9 +86,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/EngineeringModel/Views/RelationshipBrowser/RelationshipBrowser.xaml
+++ b/EngineeringModel/Views/RelationshipBrowser/RelationshipBrowser.xaml
@@ -32,9 +32,7 @@
                                   ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}">
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
@@ -50,9 +48,7 @@
             <DataTemplate DataType="{x:Type CDP4CommonView:MultiRelationshipRowViewModel}">
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
@@ -68,9 +64,7 @@
             <DataTemplate DataType="{x:Type CDP4CommonView:BinaryRelationshipRowViewModel}">
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
+++ b/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
@@ -52,9 +52,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -73,9 +71,7 @@
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
+                        <Image Style="{StaticResource ThingIcon}">
                             <Image.Source>
                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/ProductTree/Views/ProductTree.xaml
+++ b/ProductTree/Views/ProductTree.xaml
@@ -32,9 +32,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -53,9 +51,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -74,9 +70,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -95,9 +89,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ProductTreeIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
@@ -117,9 +109,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -138,11 +128,8 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3"
+                            <Image Style="{StaticResource ThingIcon}"
                                    Source="pack://application:,,,/CDP4Composition;component/Resources/Images/Thing/parameterComponent_32x32.png"/>
-
                         </dx:PixelSnapper>
                         <ContentPresenter x:Name="defaultRowPresenter"
                                               Content="{Binding}"

--- a/Requirements/Views/Dialogs/RequirementsGroupDialog.xaml
+++ b/Requirements/Views/Dialogs/RequirementsGroupDialog.xaml
@@ -16,6 +16,9 @@
 
     <dx:DXWindow.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
@@ -96,13 +99,10 @@
                         </dxg:GridControl.View>
                         <dxg:GridControl.Columns>
 
-                            <dxg:GridColumn Width="18"
-                                            MinWidth="18"
-                                            FixedWidth="True">
+                            <dxg:GridColumn Style="{StaticResource ThingIconGridColumn}">
                                 <dxg:GridColumn.DisplayTemplate>
                                     <ControlTemplate>
-                                        <Image Width="16"
-                                               Height="16">
+                                        <Image Style="{StaticResource ThingIcon}">
                                             <Image.Source>
                                                 <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                     <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>

--- a/Requirements/Views/ReqIf/RequirementSpecificationMappingDialog.xaml
+++ b/Requirements/Views/ReqIf/RequirementSpecificationMappingDialog.xaml
@@ -19,227 +19,216 @@
     Height="800" 
     Width="900">
     <dx:DXWindow.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-        <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
 
-        <DataTemplate x:Key="InactiveTemplate">
-            <TextBox Name="PART_Editor"
-                    Visibility="Collapsed"/>
-        </DataTemplate>
-        
-        <views1:ScaleCellTemplateSelector x:Key="ScaleCellTemplateSelector"
-                                          InactiveTemplate="{StaticResource InactiveTemplate}">
-            <views1:ScaleCellTemplateSelector.ScaleCellTemplate>
-                <DataTemplate>
-                    <dxe:ComboBoxEdit Name="PART_Editor"
-                                      DisplayMember="Name"
-                                      IsTextEditable="False"
-                                      ItemsSource="{Binding RowData.Row.PossibleScales}"
-                                      ShowCustomItems="False"
-                                      ShowBorder="True"
-                                      AllowNullInput="False">
-                    </dxe:ComboBoxEdit>
-                </DataTemplate>
-            </views1:ScaleCellTemplateSelector.ScaleCellTemplate>
-        </views1:ScaleCellTemplateSelector>
-        <views1:CategorizableThingCellTemplateSelector x:Key="CategorizableThingCellTemplateSelector"
-                                                       InactiveTemplate="{StaticResource InactiveTemplate}">
-            <views1:CategorizableThingCellTemplateSelector.CategoryCellTemplate>
-                <DataTemplate>
-                    <dxe:ComboBoxEdit Name="PART_Editor" 
-                                      DisplayMember="Name"
-                                      SeparatorString=", "
-                                      IsTextEditable="False"
-                                      ItemsSource="{Binding RowData.Row.CategoryList, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                      ShowCustomItems="False"
-                                      IsReadOnly="True"
-                                      ShowBorder="True"
-                                      NullText="-"
-                                      ShowNullText="True">
-                        <dxe:ComboBoxEdit.StyleSettings>
-                            <dxe:CheckedComboBoxStyleSettings />
-                        </dxe:ComboBoxEdit.StyleSettings>
-                    </dxe:ComboBoxEdit>
-                </DataTemplate>
-            </views1:CategorizableThingCellTemplateSelector.CategoryCellTemplate>
-        </views1:CategorizableThingCellTemplateSelector>
-        
-        
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementsSpecificationRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
 
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementsGroupRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-        
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+            <DataTemplate x:Key="InactiveTemplate">
+                <TextBox Name="PART_Editor"
+                        Visibility="Collapsed"/>
+            </DataTemplate>
+            
+            <views1:ScaleCellTemplateSelector x:Key="ScaleCellTemplateSelector"
+                                              InactiveTemplate="{StaticResource InactiveTemplate}">
+                <views1:ScaleCellTemplateSelector.ScaleCellTemplate>
+                    <DataTemplate>
+                        <dxe:ComboBoxEdit Name="PART_Editor"
+                                          DisplayMember="Name"
+                                          IsTextEditable="False"
+                                          ItemsSource="{Binding RowData.Row.PossibleScales}"
+                                          ShowCustomItems="False"
+                                          ShowBorder="True"
+                                          AllowNullInput="False">
+                        </dxe:ComboBoxEdit>
+                    </DataTemplate>
+                </views1:ScaleCellTemplateSelector.ScaleCellTemplate>
+            </views1:ScaleCellTemplateSelector>
+            <views1:CategorizableThingCellTemplateSelector x:Key="CategorizableThingCellTemplateSelector"
+                                                           InactiveTemplate="{StaticResource InactiveTemplate}">
+                <views1:CategorizableThingCellTemplateSelector.CategoryCellTemplate>
+                    <DataTemplate>
+                        <dxe:ComboBoxEdit Name="PART_Editor" 
+                                          DisplayMember="Name"
+                                          SeparatorString=", "
+                                          IsTextEditable="False"
+                                          ItemsSource="{Binding RowData.Row.CategoryList, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
+                                          ShowCustomItems="False"
+                                          IsReadOnly="True"
+                                          ShowBorder="True"
+                                          NullText="-"
+                                          ShowNullText="True">
+                            <dxe:ComboBoxEdit.StyleSettings>
+                                <dxe:CheckedComboBoxStyleSettings />
+                            </dxe:ComboBoxEdit.StyleSettings>
+                        </dxe:ComboBoxEdit>
+                    </DataTemplate>
+                </views1:CategorizableThingCellTemplateSelector.CategoryCellTemplate>
+            </views1:CategorizableThingCellTemplateSelector>
+            
+            
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementsSpecificationRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
 
-        <HierarchicalDataTemplate DataType="{x:Type cdp4Composition:FolderRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementsGroupRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+            
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
 
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:SimpleParameterValueRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementsContainerParameterValueRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+            <HierarchicalDataTemplate DataType="{x:Type cdp4Composition:FolderRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
 
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:BinaryRelationshipRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-        
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:RelationshipParameterValueRowViewModel}"
-                                  ItemsSource="{Binding ContainedRows}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3">
-                            <Image.Source>
-                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
-                                </MultiBinding>
-                            </Image.Source>
-                        </Image>
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:SimpleParameterValueRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementsContainerParameterValueRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
 
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:BinaryRelationshipRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+            
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:RelationshipParameterValueRowViewModel}"
+                                      ItemsSource="{Binding ContainedRows}">
+                <dx:MeasurePixelSnapper>
+                    <StackPanel Orientation="Horizontal">
+                        <dx:PixelSnapper>
+                            <Image Style="{StaticResource ThingIcon}">
+                                <Image.Source>
+                                    <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}"/>
+                                    </MultiBinding>
+                                </Image.Source>
+                            </Image>
+                        </dx:PixelSnapper>
+                        <ContentPresenter x:Name="defaultRowPresenter"
+                                          Content="{Binding}"
+                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                    </StackPanel>
+                </dx:MeasurePixelSnapper>
+            </HierarchicalDataTemplate>
+        </ResourceDictionary>
     </dx:DXWindow.Resources>
 
     <Grid>

--- a/Requirements/Views/ReqIf/RequirementSpecificationMappingDialog.xaml
+++ b/Requirements/Views/ReqIf/RequirementSpecificationMappingDialog.xaml
@@ -69,7 +69,6 @@
                 </views1:CategorizableThingCellTemplateSelector.CategoryCellTemplate>
             </views1:CategorizableThingCellTemplateSelector>
             
-            
             <HierarchicalDataTemplate DataType="{x:Type viewModels:RequirementsSpecificationRowViewModel}"
                                       ItemsSource="{Binding ContainedRows}">
                 <dx:MeasurePixelSnapper>

--- a/Requirements/Views/RequirementsBrowser.xaml
+++ b/Requirements/Views/RequirementsBrowser.xaml
@@ -47,9 +47,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -71,9 +69,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -95,9 +91,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -116,9 +110,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -140,9 +132,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -164,9 +154,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -188,9 +176,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -212,9 +198,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -236,9 +220,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -260,9 +242,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -284,9 +264,7 @@
                             <userControls:LoadingControl Margin="3,3,0,3" Diameter="16" Color1="Gray" Color2="Transparent" Visibility="{Binding Path=Row.RequirementStateOfCompliance, Converter={StaticResource RequirementStateOfComplianceToVisibilityConverter}}"/>
                         </dx:PixelSnapper>
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
@@ -305,9 +283,7 @@
                 <dx:MeasurePixelSnapper>
                     <StackPanel Orientation="Horizontal">
                         <dx:PixelSnapper>
-                            <Image Width="16"
-                                   Height="16"
-                                   Margin="3">
+                            <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                         <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />

--- a/Requirements/Views/RequirementsSpecificationEditor.xaml
+++ b/Requirements/Views/RequirementsSpecificationEditor.xaml
@@ -12,6 +12,9 @@
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/CDP4Styles.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
             <cdp4Composition:ThingToIconUriConverter x:Key="ThingToIconUriConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"></BooleanToVisibilityConverter>
 
@@ -26,7 +29,7 @@
                                 CornerRadius="8,8,3,3"
                                 Visibility="{Binding Path=ShouldBeDisplayed, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <StackPanel Orientation="Horizontal">
-                                <Image Width="16" Height="16" Margin="3" >
+                                <Image Style="{StaticResource ThingIcon}">
                                     <Image.Source>
                                         <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                             <Binding Path="Thing" />
@@ -50,8 +53,7 @@
                                 CornerRadius="8,8,3,3"
                                 Visibility="{Binding Path=ShouldBeDisplayed, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource BooleanToVisibilityConverter}}">
                             <dxlc:LayoutControl Margin="8 0 0 0" Orientation="Vertical">
-
-                                <Image HorizontalAlignment="Left" Width="16" Height="16" Margin="3" >
+                                <Image Style="{StaticResource ThingIcon}">
                                     <Image.Source>
                                         <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                             <Binding Path="Thing" />
@@ -95,7 +97,7 @@
                         <Border Margin="4" Background="Linen" BorderBrush="Silver" BorderThickness="1" CornerRadius="8,8,3,3">
                             <dxlc:LayoutGroup Margin="3" Orientation="Vertical">
                                 <StackPanel Orientation="Horizontal">
-                                    <Image Width="16" Height="16" Margin="3" >
+                                    <Image Style="{StaticResource ThingIcon}">
                                         <Image.Source>
                                             <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
                                                 <Binding Path="Thing" />


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
White space is added to the left and right of (Thing) Icons, so total width is now 28 pixels (was 16 pixels). 
The overlays are now 75% of the original Thing images' width and height (was 50%). 

Should be the same for every Thing icon in the system (TreeViews and GridControls).