### PR TITLE
Partially Fixes 267

### DIFF
--- a/CDP4Composition/Mvvm/BrowserViewModelBase.cs
+++ b/CDP4Composition/Mvvm/BrowserViewModelBase.cs
@@ -455,7 +455,6 @@ namespace CDP4Composition.Mvvm
             }
         }
 
-
         /// <summary>
         /// Execute the <see cref="DeleteCommand"/>
         /// </summary>
@@ -663,6 +662,13 @@ namespace CDP4Composition.Mvvm
         }
 
         /// <summary>
+        /// Gets a value indicating whether it is possible to Delete the Selected Thing />
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> that needs to be checked</param>
+        /// <returns>True if delete is allowed, otherwise false</returns>
+        protected virtual bool IsDeleteAllowed(Thing thing) => true;
+
+        /// <summary>
         /// Write the inline operations to the Data-access-layer
         /// </summary>
         /// <param name="transaction">The <see cref="ThingTransaction"/> that contains the operations</param>
@@ -784,7 +790,7 @@ namespace CDP4Composition.Mvvm
             var canDelete = this.WhenAnyValue(
                 vm => vm.SelectedThing,
                 vm => vm.CanWriteSelectedThing,
-                (selection, canWrite) => selection != null && canWrite && !(selection.Thing is IDeprecatableThing) && !(selection.Thing is ActualFiniteState));
+                (selection, canWrite) => selection != null && canWrite && !(selection.Thing is IDeprecatableThing) && !(selection.Thing is ActualFiniteState) && this.IsDeleteAllowed(selection.Thing));
 
             this.DeleteCommand = ReactiveCommand.Create(canDelete);
             this.DeleteCommand.Subscribe(_ => this.ExecuteDeleteCommand());

--- a/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
@@ -587,6 +587,24 @@ namespace CDP4Requirements.ViewModels
         }
 
         /// <summary>
+        /// Gets a value indicating whether it is possible to Delete the Selected Thing />
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> that needs to be checked</param>
+        /// <returns>True if delete is allowed, otherwise false</returns>
+        protected override bool IsDeleteAllowed(Thing thing)
+        {
+            if (thing is RelationalExpression relationalExpression)
+            {
+                if (!(relationalExpression.Container is ParametricConstraint parametricConstraint) || (parametricConstraint.Expression.OfType<RelationalExpression>().Count() <= 1))
+                {
+                    return false;
+                }
+            }
+
+            return base.IsDeleteAllowed(thing);
+        }
+
+        /// <summary>
         /// Populate the context menu
         /// </summary>
         public override void PopulateContextMenu()


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Delete last RelationalExpression in RequirementsBrowser is not allowed anymore in UI: Menu option is disabled.

Server fix (error when anyone manages to do a delete request on tha last RelationalExpression) is another issue: https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/issues/90