### PR TITLE
Made non-functional buttons invisible

### DIFF
--- a/CDP4Composition/Views/CommonThingControl.xaml
+++ b/CDP4Composition/Views/CommonThingControl.xaml
@@ -48,22 +48,25 @@
             Converter={dx:FormatStringConverter FormatString={}Inspect {0}}}" />
 
         <dxb:BarButtonItem Command="{Binding RefreshCommand}"
+                           IsVisible="False"
                                Glyph="{dx:DXImage Image=Refresh2_16x16.png}"
                                Hint="{Binding SelectedThingClassKindString,
             Converter={dx:FormatStringConverter FormatString={}Refresh {0}}}" />
 
         <dxb:BarButtonItem Command="{Binding ExportCommand}"
+                           IsVisible="False"
                                Glyph="{dx:DXImage Image=Export_16x16.png}"
                                Hint="{Binding SelectedThingClassKindString,
             Converter={dx:FormatStringConverter FormatString={}Export {0}}}" />
 
-        <dxb:BarSplitButtonItem />
+        <dxb:BarSplitButtonItem IsVisible="False"/>
 
         <dxb:BarButtonItem Command="{Binding HelpCommand}"
+                           IsVisible="False"
                            Glyph="{dx:DXImage Image=Info_16x16.png}"
                            Hint="Show Help" />
 
-        <dxb:BarSplitButtonItem />
+        <dxb:BarSplitButtonItem IsVisible="False"/>
 
         <dxb:BarButtonItem ItemClick="ButtonBase_OnClick"
                            Glyph="{dx:DXImage Image=Zoom_16x16.png}"

--- a/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowserRibbon.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowserRibbon.xaml
@@ -9,7 +9,8 @@
                                 Name="FileStoreRibbonPageGroup"
                                 ContainerRegionName="{x:Static cdp4Composition:RegionNames.ModelRibbonPageRegion}"
                                 MergeOrder="70"
-                                ShowCaptionButton="False">
+                                ShowCaptionButton="False"
+                                IsVisible="False">
     <dxr:RibbonPageGroup.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowserRibbon.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowserRibbon.xaml
@@ -9,7 +9,8 @@
                                 Name="DomainFileStoreRibbonPageGroup"
                                 ContainerRegionName="{x:Static cdp4Composition:RegionNames.ModelRibbonPageRegion}"
                                 MergeOrder="70"
-                                ShowCaptionButton="False">
+                                ShowCaptionButton="False"
+                                IsVisible="False">
     <dxr:RibbonPageGroup.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
- Refresh, export and help buttons are now invisible for all browser windows.
- Common File Store and Domain File Store buttons are now invisible in ribbon menu.
