### PR TITLE
Refactoring display of arraytype parameters

### DIFF
--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
@@ -269,18 +269,12 @@ namespace CDP4EngineeringModel.ViewModels
             this.Switch = valueSet.ValueSwitch;
             this.Formula = this.GetDisplayValueFromValueSet(valueSet.Formula);
             this.Computed = this.GetDisplayValueFromValueSet(valueSet.Computed);
-
-            this.Manual = valueSet.Manual.Any()
-                ? this.GetDisplayValueFromValueSet(valueSet.Manual).ToValueSetObject(this.ParameterType)
-                : ValueSetConverter.DefaultObject(this.ParameterType);
-
-            this.Reference = valueSet.Reference.Any()
-                ? this.GetDisplayValueFromValueSet(valueSet.Reference).ToValueSetObject(this.ParameterType)
-                : ValueSetConverter.DefaultObject(this.ParameterType);
+            this.Manual = this.GetDisplayValueFromValueSet(valueSet.Manual);
+            this.Reference = this.GetDisplayValueFromValueSet(valueSet.Reference);
+            this.Published = this.GetDisplayValueFromValueSet(valueSet.Published);
 
             this.State = valueSet.ActualState == null ? "-" : valueSet.ActualState.ShortName;
             this.Option = valueSet.ActualOption;
-            this.Published = this.GetDisplayValueFromValueSet(valueSet.Published);
         }
 
         /// <summary>
@@ -290,17 +284,20 @@ namespace CDP4EngineeringModel.ViewModels
         /// <returns>Display friendly <see cref="string"/></returns>
         private string GetDisplayValueFromValueSet(ValueArray<string> valueArray)
         {
-            if (valueArray.Count > 1)
+            if (valueArray.Any())
             {
-                return null;
+                if (valueArray.Count > 1)
+                {
+                    return string.Empty;
+                }
+
+                if (valueArray.Count == 1)
+                {
+                    return valueArray.First().ToValueSetObject(this.ParameterType)?.ToString();
+                }
             }
 
-            if (valueArray.Count == 1)
-            {
-                return valueArray.First();
-            }
-
-            return "-";
+            return ValueSetConverter.DefaultObject(this.ParameterType)?.ToString();
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
@@ -1,6 +1,6 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOrOverrideBaseRowViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//   Copyright (c) 2015-2020 RHEA System S.A.
 // </copyright>
 // -------------------------------------------------------------------------------------------------
 
@@ -259,20 +259,19 @@ namespace CDP4EngineeringModel.ViewModels
         /// </param>
         private void SetProperties(ParameterValueSetBase valueSet)
         {
-            this.Value = this.GetDisplayValueFromValueSet(valueSet.ActualValue);
-
             if (this.ContainedRows.Count == 0)
             {
                 this.ScaleShortName = this.Thing.Scale == null ? "-" : this.Thing.Scale.ShortName;
             }
 
-            this.Switch = valueSet.ValueSwitch;
-            this.Formula = this.GetDisplayValueFromValueSet(valueSet.Formula);
+            this.Value = this.GetDisplayValueFromValueSet(valueSet.ActualValue);
+            this.Formula = this.GetDisplayValueFromValueSet(valueSet.Formula, false);
             this.Computed = this.GetDisplayValueFromValueSet(valueSet.Computed);
             this.Manual = this.GetDisplayValueFromValueSet(valueSet.Manual);
             this.Reference = this.GetDisplayValueFromValueSet(valueSet.Reference);
             this.Published = this.GetDisplayValueFromValueSet(valueSet.Published);
 
+            this.Switch = valueSet.ValueSwitch;
             this.State = valueSet.ActualState == null ? "-" : valueSet.ActualState.ShortName;
             this.Option = valueSet.ActualOption;
         }
@@ -281,20 +280,20 @@ namespace CDP4EngineeringModel.ViewModels
         /// Returns a value from a valueset that is usefull to display in the UI
         /// </summary>
         /// <param name="valueArray">The <see cref="ValueArray{string}"/></param>
+        /// <param name="valueConformsToParameterType">States that the value must be compliant with the <see cref="ParameterType"/> value format.</param>
         /// <returns>Display friendly <see cref="string"/></returns>
-        private string GetDisplayValueFromValueSet(ValueArray<string> valueArray)
+        private string GetDisplayValueFromValueSet(ValueArray<string> valueArray, bool valueConformsToParameterType = true)
         {
-            if (valueArray.Any())
+            if (valueArray.Count > 1)
             {
-                if (valueArray.Count > 1)
-                {
-                    return string.Empty;
-                }
+                return string.Empty;
+            }
 
-                if (valueArray.Count == 1)
-                {
-                    return valueArray.First().ToValueSetObject(this.ParameterType)?.ToString();
-                }
+            if (valueArray.Count == 1)
+            {
+                var value = valueArray.First();
+
+                return valueConformsToParameterType ? value.ToValueSetObject(this.ParameterType)?.ToString() : value;
             }
 
             return ValueSetConverter.DefaultObject(this.ParameterType)?.ToString();

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
@@ -259,7 +259,7 @@ namespace CDP4EngineeringModel.ViewModels
         /// </param>
         private void SetProperties(ParameterValueSetBase valueSet)
         {
-            this.Value = valueSet.ActualValue.Any() ? valueSet.ActualValue.First() : "-";
+            this.Value = this.GetDisplayValueFromValueSet(valueSet.ActualValue);
 
             if (this.ContainedRows.Count == 0)
             {
@@ -267,20 +267,40 @@ namespace CDP4EngineeringModel.ViewModels
             }
 
             this.Switch = valueSet.ValueSwitch;
-            this.Formula = valueSet.Formula.Any() ? valueSet.Formula.First() : "-";
-            this.Computed = valueSet.Computed.Any() ? valueSet.Computed.First() : "-";
+            this.Formula = this.GetDisplayValueFromValueSet(valueSet.Formula);
+            this.Computed = this.GetDisplayValueFromValueSet(valueSet.Computed);
 
             this.Manual = valueSet.Manual.Any()
-                ? valueSet.Manual.First().ToValueSetObject(this.ParameterType)
+                ? this.GetDisplayValueFromValueSet(valueSet.Manual).ToValueSetObject(this.ParameterType)
                 : ValueSetConverter.DefaultObject(this.ParameterType);
 
             this.Reference = valueSet.Reference.Any()
-                ? valueSet.Reference.First().ToValueSetObject(this.ParameterType)
+                ? this.GetDisplayValueFromValueSet(valueSet.Reference).ToValueSetObject(this.ParameterType)
                 : ValueSetConverter.DefaultObject(this.ParameterType);
 
             this.State = valueSet.ActualState == null ? "-" : valueSet.ActualState.ShortName;
             this.Option = valueSet.ActualOption;
-            this.Published = valueSet.Published.Any() ? valueSet.Published.First() : "-";
+            this.Published = this.GetDisplayValueFromValueSet(valueSet.Published);
+        }
+
+        /// <summary>
+        /// Returns a value from a valueset that is usefull to display in the UI
+        /// </summary>
+        /// <param name="valueArray">The <see cref="ValueArray{string}"/></param>
+        /// <returns>Display friendly <see cref="string"/></returns>
+        private string GetDisplayValueFromValueSet(ValueArray<string> valueArray)
+        {
+            if (valueArray.Count > 1)
+            {
+                return null;
+            }
+
+            if (valueArray.Count == 1)
+            {
+                return valueArray.First();
+            }
+
+            return "-";
         }
 
         /// <summary>


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Arraytype (multivalue type) parameters now show nothing in the UI instead of the string representation of the first value in the array.