### PR TITLE
Saving mass budget config fixed

### DIFF
--- a/CDP4BudgetViewer/Config/BudgetConfig.cs
+++ b/CDP4BudgetViewer/Config/BudgetConfig.cs
@@ -106,8 +106,7 @@ namespace CDP4Budget.Config
                     ElementCategories = x.ElementCategories.Select(ec => ec.Iid).ToList()
                 }).ToList();
 
-            var massConfig = this.BudgetParameterConfig as MassBudgetParameterConfig;
-            if (massConfig != null)
+            if (this.BudgetParameterConfig is MassBudgetParameterConfig massConfig)
             {
                 var parameterConfigDto = new MassParameterConfigDto();
                 parameterConfigDto.ParameterType = massConfig.DryMassTuple.MainParameterType.Iid;
@@ -122,9 +121,7 @@ namespace CDP4Budget.Config
 
                 dto.ParameterConfig = parameterConfigDto;
             }
-
-            var genericConfig = this.BudgetParameterConfig as GenericBudgetParameterConfig;
-            if (genericConfig != null)
+            else if (this.BudgetParameterConfig is GenericBudgetParameterConfig genericConfig)
             {
                 var parameterConfigDto = new GenericParameterConfigDto();
                 parameterConfigDto.ParameterType = genericConfig.GenericTuple.MainParameterType.Iid;
@@ -134,7 +131,7 @@ namespace CDP4Budget.Config
             }
             else
             {
-                throw new NotImplementedException("only mass budget has been implemented");
+                throw new NotImplementedException("Only Mass and Generic budgets have been implemented.");
             }
 
             return dto;


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Source code was wrong. 
When saving generic config budget was implemented, the structure of the code was wrong, resulting in an error being thrown in the background when mass budget config was being saved.
Saving/restoring Both config types should work OK now.