### PR TITLE
#149 Adding a pane for details description on a row is clicked in Req…

### DIFF
--- a/CDP4Composition/Views/CommonThingControl.xaml
+++ b/CDP4Composition/Views/CommonThingControl.xaml
@@ -80,15 +80,6 @@
                           Glyph="{dx:DXImage Image=NewContact_16x16.png}"
                           Hint="Toggle filtering on favorite items."
                           IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"/>
-
-        <dxb:BarCheckItem 
-            IsChecked="{Binding ShowDetailsPanel}"
-            IsVisible="{Binding IsDetailsToggleVisible, ElementName=Toolbar}"
-            Content="Switching on details panel"
-            Description="Toggle on showing details of the selected item."
-            Glyph="{dx:DXImage Image=Fill_16x16.png}"
-            Hint="Toggle on showing details of the selected item."
-            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"/>
         <dxb:BarSplitButtonItem />
     </dxb:ToolBarControl>
 </UserControl>

--- a/CDP4Composition/Views/CommonThingControl.xaml
+++ b/CDP4Composition/Views/CommonThingControl.xaml
@@ -81,6 +81,14 @@
                           Hint="Toggle filtering on favorite items."
                           IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"/>
 
+        <dxb:BarCheckItem 
+            IsChecked="{Binding ShowDetailsPanel}"
+            IsVisible="{Binding IsDetailsToggleVisible, ElementName=Toolbar}"
+            Content="Switching on details panel"
+            Description="Toggle on showing details of the selected item."
+            Glyph="{dx:DXImage Image=Fill_16x16.png}"
+            Hint="Toggle on showing details of the selected item."
+            IsEnabled="{Binding HasSession, UpdateSourceTrigger=PropertyChanged}"/>
         <dxb:BarSplitButtonItem />
     </dxb:ToolBarControl>
 </UserControl>

--- a/CDP4Composition/Views/CommonThingControl.xaml.cs
+++ b/CDP4Composition/Views/CommonThingControl.xaml.cs
@@ -31,7 +31,7 @@ namespace CDP4Composition.Views
         private readonly static DependencyProperty IsFavoriteToggleVisibleProperty = DependencyProperty.Register("IsFavoriteToggleVisible", typeof(bool), typeof(CommonThingControl));
 
         /// <summary>
-        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="IsFavoriteToggleVisible"/> setter method.
+        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="IsDetailsToggleVisible"/> setter method.
         /// </summary>
         private readonly static DependencyProperty IsDetailsToggleVisibleProperty = DependencyProperty.Register("IsDetailsToggleVisible", typeof(bool), typeof(CommonThingControl));
 
@@ -42,6 +42,7 @@ namespace CDP4Composition.Views
         {
             this.InitializeComponent();
             this.IsFavoriteToggleVisible = false;
+            this.IsDetailsToggleVisible = false;
         }
 
         /// <summary>

--- a/CDP4Composition/Views/CommonThingControl.xaml.cs
+++ b/CDP4Composition/Views/CommonThingControl.xaml.cs
@@ -31,6 +31,11 @@ namespace CDP4Composition.Views
         private readonly static DependencyProperty IsFavoriteToggleVisibleProperty = DependencyProperty.Register("IsFavoriteToggleVisible", typeof(bool), typeof(CommonThingControl));
 
         /// <summary>
+        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="IsFavoriteToggleVisible"/> setter method.
+        /// </summary>
+        private readonly static DependencyProperty IsDetailsToggleVisibleProperty = DependencyProperty.Register("IsDetailsToggleVisible", typeof(bool), typeof(CommonThingControl));
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CommonThingControl"/> class.
         /// </summary>
         public CommonThingControl()
@@ -46,6 +51,15 @@ namespace CDP4Composition.Views
         {
             get { return this.GetValue(GridViewProperty) as GridDataViewBase; }
             set { this.SetValue(GridViewProperty, value); }
+        }
+
+        /// <summary>
+        /// The boolean that enables or disables the visibility of the Details toggle buttons.
+        /// </summary>
+        public bool IsDetailsToggleVisible
+        {
+            get { return this.GetValue(IsDetailsToggleVisibleProperty) is bool ? (bool)this.GetValue(IsDetailsToggleVisibleProperty) : false; }
+            set { this.SetValue(IsDetailsToggleVisibleProperty, value); }
         }
 
         /// <summary>

--- a/CDP4Composition/Views/CommonThingControl.xaml.cs
+++ b/CDP4Composition/Views/CommonThingControl.xaml.cs
@@ -31,18 +31,12 @@ namespace CDP4Composition.Views
         private readonly static DependencyProperty IsFavoriteToggleVisibleProperty = DependencyProperty.Register("IsFavoriteToggleVisible", typeof(bool), typeof(CommonThingControl));
 
         /// <summary>
-        /// The declaration of the <see cref="DependencyProperty"/> that is accessible via the <see cref="IsDetailsToggleVisible"/> setter method.
-        /// </summary>
-        private readonly static DependencyProperty IsDetailsToggleVisibleProperty = DependencyProperty.Register("IsDetailsToggleVisible", typeof(bool), typeof(CommonThingControl));
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="CommonThingControl"/> class.
         /// </summary>
         public CommonThingControl()
         {
             this.InitializeComponent();
             this.IsFavoriteToggleVisible = false;
-            this.IsDetailsToggleVisible = false;
         }
 
         /// <summary>
@@ -52,15 +46,6 @@ namespace CDP4Composition.Views
         {
             get { return this.GetValue(GridViewProperty) as GridDataViewBase; }
             set { this.SetValue(GridViewProperty, value); }
-        }
-
-        /// <summary>
-        /// The boolean that enables or disables the visibility of the Details toggle buttons.
-        /// </summary>
-        public bool IsDetailsToggleVisible
-        {
-            get { return this.GetValue(IsDetailsToggleVisibleProperty) is bool ? (bool)this.GetValue(IsDetailsToggleVisibleProperty) : false; }
-            set { this.SetValue(IsDetailsToggleVisibleProperty, value); }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
@@ -56,6 +56,11 @@ namespace CDP4Requirements.ViewModels
         private static RequirementsSpecificationComparer SpecComparer = new RequirementsSpecificationComparer();
 
         /// <summary>
+        /// Backing field for <see cref="ShowDetailsPanel"/>
+        /// </summary>
+        private bool showDetailsPanel;
+
+        /// <summary>
         /// Backing field for <see cref="CanCreateReqSpec"/>
         /// </summary>
         private bool canCreateReqSpec;
@@ -129,10 +134,10 @@ namespace CDP4Requirements.ViewModels
         {
             this.Caption = $"{PanelCaption}, iteration_{this.Thing.IterationSetup.IterationNumber}";
             this.ToolTip =
-                $"{((EngineeringModel) this.Thing.Container).EngineeringModelSetup.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
+                $"{((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
 
             this.ReqSpecificationRows = new DisposableReactiveList<RequirementsSpecificationRowViewModel>();
-            var model = (EngineeringModel) this.Thing.Container;
+            var model = (EngineeringModel)this.Thing.Container;
             this.ActiveParticipant = model.GetActiveParticipant(this.Session.ActivePerson);
 
             this.ComputeUserDependentPermission();
@@ -143,6 +148,15 @@ namespace CDP4Requirements.ViewModels
             this.UpdateProperties();
 
             this.openRequirementsSpecificationEditorViewModels = new List<RequirementsSpecificationEditorViewModel>();
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to display details pane for selected item.
+        /// </summary>
+        public bool ShowDetailsPanel
+        {
+            get { return this.showDetailsPanel; }
+            set { this.RaiseAndSetIfChanged(ref this.showDetailsPanel, value); }
         }
 
         /// <summary>
@@ -356,7 +370,7 @@ namespace CDP4Requirements.ViewModels
                 var row = new RequirementsSpecificationRowViewModel(spec, this.Session, this);
                 this.ReqSpecificationRows.SortedInsert(row, SpecComparer);
 
-                var orderPt = OrderHandlerService.GetOrderParameterType((EngineeringModel) this.Thing.TopContainer);
+                var orderPt = OrderHandlerService.GetOrderParameterType((EngineeringModel)this.Thing.TopContainer);
 
                 if (orderPt != null)
                 {
@@ -364,11 +378,11 @@ namespace CDP4Requirements.ViewModels
                             CDPMessageBus.Current.Listen<ObjectChangedEvent>(
                                 typeof(RequirementsContainerParameterValue)),
                             objectChange =>
-                                (((RequirementsContainerParameterValue) objectChange.ChangedThing).ParameterType ==
+                                (((RequirementsContainerParameterValue)objectChange.ChangedThing).ParameterType ==
                                  orderPt) && spec.ParameterValue.Contains(objectChange.ChangedThing))
                         .ObserveOn(RxApp.MainThreadScheduler)
                         .Subscribe(
-                            x => this.UpdateSpecRowPosition((RequirementsSpecification) x.ChangedThing.Container));
+                            x => this.UpdateSpecRowPosition((RequirementsSpecification)x.ChangedThing.Container));
 
                     this.Disposables.Add(orderListener);
                 }
@@ -503,6 +517,8 @@ namespace CDP4Requirements.ViewModels
         protected override void InitializeCommands()
         {
             base.InitializeCommands();
+
+            this.ShowDetailsPanel = true;
 
             this.CreateCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateReqSpec));
             this.CreateCommand.Subscribe(_ => this.ExecuteCreateCommand<RequirementsSpecification>(this.Thing));
@@ -657,7 +673,7 @@ namespace CDP4Requirements.ViewModels
 
                     foreach (var relationship in binaryRelationships)
                     {
-                        var parameter = (ParameterOrOverrideBase) ((BinaryRelationship) relationship).Source;
+                        var parameter = (ParameterOrOverrideBase)((BinaryRelationship)relationship).Source;
                         var suffix = parameter is ParameterOverride ? " (Override)" : "";
 
                         relationshipMenu.SubMenu.Add(new ContextMenuItemViewModel(
@@ -680,7 +696,7 @@ namespace CDP4Requirements.ViewModels
                 this.CreateRequestForDeviationCommand, MenuItemKind.Create, ClassKind.RequestForDeviation));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Request for Waiver", "",
                 this.CreateRequestForWaiverCommand, MenuItemKind.Create, ClassKind.RequestForWaiver));
-            this.ContextMenu.Add(new ContextMenuItemViewModel("Verify Requirements", "", 
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Verify Requirements", "",
                 this.VerifyRequirementsCommand, MenuItemKind.Refresh, ClassKind.Requirement));
         }
 

--- a/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
@@ -56,11 +56,6 @@ namespace CDP4Requirements.ViewModels
         private static RequirementsSpecificationComparer SpecComparer = new RequirementsSpecificationComparer();
 
         /// <summary>
-        /// Backing field for <see cref="ShowDetailsPanel"/>
-        /// </summary>
-        private bool showDetailsPanel;
-
-        /// <summary>
         /// Backing field for <see cref="CanCreateReqSpec"/>
         /// </summary>
         private bool canCreateReqSpec;
@@ -148,15 +143,6 @@ namespace CDP4Requirements.ViewModels
             this.UpdateProperties();
 
             this.openRequirementsSpecificationEditorViewModels = new List<RequirementsSpecificationEditorViewModel>();
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to display details pane for selected item.
-        /// </summary>
-        public bool ShowDetailsPanel
-        {
-            get { return this.showDetailsPanel; }
-            set { this.RaiseAndSetIfChanged(ref this.showDetailsPanel, value); }
         }
 
         /// <summary>
@@ -517,8 +503,6 @@ namespace CDP4Requirements.ViewModels
         protected override void InitializeCommands()
         {
             base.InitializeCommands();
-
-            this.ShowDetailsPanel = true;
 
             this.CreateCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateReqSpec));
             this.CreateCommand.Subscribe(_ => this.ExecuteCreateCommand<RequirementsSpecification>(this.Thing));

--- a/Requirements/Views/RequirementsBrowser.xaml
+++ b/Requirements/Views/RequirementsBrowser.xaml
@@ -7,6 +7,8 @@
              xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
              xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
              xmlns:dynamic="clr-namespace:System.Dynamic;assembly=System.Core"
+             xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:services="clr-namespace:CDP4Composition.Services;assembly=CDP4Composition"
              xmlns:viewModels="clr-namespace:CDP4Requirements.ViewModels"
@@ -310,9 +312,10 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <views:CommonThingControl GridView="{Binding ElementName=View}"/>
+            <views:CommonThingControl GridView="{Binding ElementName=View}" IsDetailsToggleVisible="True" />
 
             <views:BrowserHeader Grid.Row="1" />
 
@@ -360,7 +363,7 @@
                         <dxg:TreeListView.FocusedRow>
                             <dynamic:ExpandoObject />
                         </dxg:TreeListView.FocusedRow>
-                        
+
                         <dxg:TreeListView.ContextMenu>
                             <ContextMenu Name="RowContextMenu" />
                         </dxg:TreeListView.ContextMenu>
@@ -371,7 +374,26 @@
                     <KeyBinding Gesture="CTRL+E" Command="{Binding Path=UpdateCommand}"></KeyBinding>
                 </dxg:TreeListControl.InputBindings>
             </dxg:TreeListControl>
-            <StackPanel Grid.Row="3" Orientation="Horizontal" >
+            <dxlc:LayoutGroup Grid.Row="3"
+                              MinHeight="120"
+                              Header="Requirement Details"
+                              View="GroupBox"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch"
+                              IsCollapsible="True"
+                              Orientation="Vertical"
+                              GroupBoxDisplayMode="Normal"
+                              Visibility="{Binding ShowDetailsPanel, Converter={dx:BooleanToVisibilityConverter}}">
+                <dxlc:LayoutItem VerticalAlignment="Stretch">
+                    <dxe:TextEdit EditValue="{Binding Path=SelectedThing.Tooltip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
+                                  VerticalScrollBarVisibility="Auto"
+                                  VerticalContentAlignment="Top"
+                                  TextWrapping="Wrap"
+                                  Height="Auto"
+                                  IsReadOnly="True"/>
+                </dxlc:LayoutItem>
+            </dxlc:LayoutGroup>
+            <StackPanel Grid.Row="4" Orientation="Horizontal" >
                 <CheckBox Name="ShowSimpleParameterValues" Margin="4,0,0,0" VerticalAlignment="Center" FontSize="10"
                           Content="Show Simple Parameter Values"  IsChecked="{Binding IsSimpleParameterValuesDisplayed,
                                                                     Mode=TwoWay,

--- a/Requirements/Views/RequirementsBrowser.xaml
+++ b/Requirements/Views/RequirementsBrowser.xaml
@@ -315,7 +315,7 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <views:CommonThingControl GridView="{Binding ElementName=View}" IsDetailsToggleVisible="True" />
+            <views:CommonThingControl GridView="{Binding ElementName=View}" />
 
             <views:BrowserHeader Grid.Row="1" />
 
@@ -382,8 +382,7 @@
                               VerticalAlignment="Stretch"
                               IsCollapsible="True"
                               Orientation="Vertical"
-                              GroupBoxDisplayMode="Normal"
-                              Visibility="{Binding ShowDetailsPanel, Converter={dx:BooleanToVisibilityConverter}}">
+                              GroupBoxDisplayMode="Normal">
                 <dxlc:LayoutItem VerticalAlignment="Stretch">
                     <dxe:TextEdit EditValue="{Binding Path=SelectedThing.Tooltip, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" 
                                   VerticalScrollBarVisibility="Auto"


### PR DESCRIPTION
…uirements browser. Also a toggle button has been added to the toolbar making the pane visible/invisible.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
#149 A pane has been added in Requirements browser, that displays the requirements details once the user select a row. As an additional feature, a new toggle button has been added to the toolbar permitting the user to show or hide the pane.

