### PR TITLE
Partly fixes #184: check participant domain on insert and update

### DIFF
--- a/CDP4SiteDirectory.Tests/Dialogs/ParticipantDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/ParticipantDialogViewModelTestFixture.cs
@@ -1,6 +1,6 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="ParticipantDialogViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//   Copyright (c) 2015-2020 RHEA System S.A.
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 

--- a/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
@@ -178,7 +178,14 @@ namespace CDP4SiteDirectory.ViewModels
         protected override void UpdateOkCanExecute()
         {
             base.UpdateOkCanExecute();
-            this.OkCanExecute = this.OkCanExecute && this.SelectedPerson != null && this.SelectedRole != null && !this.Domain.IsEmpty && this.SelectedSelectedDomain != null && this.Domain.Any(x => x.Iid == this.SelectedSelectedDomain?.Iid);
+
+            this.OkCanExecute = 
+                this.OkCanExecute && 
+                this.SelectedPerson != null && 
+                this.SelectedRole != null && 
+                !this.Domain.IsEmpty && 
+                this.SelectedSelectedDomain != null && 
+                this.Domain.Any(x => x.Iid == this.SelectedSelectedDomain?.Iid);
         }
 
         /// <summary>
@@ -195,6 +202,12 @@ namespace CDP4SiteDirectory.ViewModels
             }
 
             this.UpdateOkCanExecute();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            this.domainSubScription?.Dispose();
         }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
@@ -204,6 +204,12 @@ namespace CDP4SiteDirectory.ViewModels
             this.UpdateOkCanExecute();
         }
 
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// a value indicating whether the class is being disposed of
+        /// </param>
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)
It should not be possible anymore to save a participant without a minimal of 1 DomainOfExpertise set in the edit- and create participant dialogs.

Other part of the fix for issue [#184](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/issues/184), regarding the user feedback, is solved in Webservice issue [#94](https://github.com/RHEAGROUP/CDP4-WebServices-Community-Edition/issues/94).