### PR TITLE
Rule verification list browser now scales fine with 4k; fixes #236

### DIFF
--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListBrowserViewModel.cs
@@ -70,7 +70,7 @@ namespace CDP4EngineeringModel.ViewModels
         /// <summary>
         /// The Panel Caption
         /// </summary>
-        private const string PanelCaption = "Rule verification lists";
+        private const string PanelCaption = "Rule Verification Lists";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RuleVerificationListBrowserViewModel"/> class.

--- a/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
+++ b/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
@@ -104,7 +104,6 @@
             <views:BrowserHeader Grid.Row="1" />
 
             <dxg:TreeListControl Grid.Row="2"
-                             MaxHeight="1080"
                              ItemsSource="{Binding RuleVerificationListRowViewModels}"
                              SelectedItem="{Binding SelectedThing,
                                                     Mode=TwoWay,
@@ -120,7 +119,6 @@
                 </dxmvvm:Interaction.Behaviors>
                 <dxg:TreeListControl.View>
                     <dxg:TreeListView Name="View"
-                                  MaxHeight="1080"
                                   AllowEditing="False"
                                   AutoWidth="true"
                                   ExpandStateFieldName="IsExpanded"


### PR DESCRIPTION
Verified all other browsers for 4K compatibility as well.

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [ ] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
Removed maxheight property from rule verification list browser. Browser title now correctly uses Title Case
