### PR TITLE
Parameters not showing up in Publication tree when copied from another EngineeringModel with values

### DIFF
--- a/EngineeringModel.Tests/ViewModels/PublicationBrowser/PublicationBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/PublicationBrowser/PublicationBrowserViewModelTestFixture.cs
@@ -166,7 +166,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels
             var viewmodel = new PublicationBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
 
             Assert.AreEqual(1, viewmodel.Publications.Count);
-            Assert.AreEqual(3, viewmodel.Publications[0].ContainedRows.Count);
+            Assert.AreEqual(4, viewmodel.Publications[0].ContainedRows.Count);
             Assert.That(viewmodel.Caption, Is.Not.Null.Or.Empty);
             Assert.That(viewmodel.ToolTip, Is.Not.Null.Or.Empty);
             Assert.That(viewmodel.DataSource, Is.Not.Null.Or.Empty);

--- a/EngineeringModel.Tests/ViewModels/PublicationBrowser/PublicationBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/PublicationBrowser/PublicationBrowserViewModelTestFixture.cs
@@ -46,6 +46,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels
         private Publication publication;
         private Parameter parameter1;
         private Parameter parameter2;
+        private Parameter parameter3;
         private ParameterOverride parameterOverride1;
         private DomainOfExpertise domain;
         private DomainOfExpertise otherDomain;
@@ -67,11 +68,11 @@ namespace CDP4EngineeringModel.Tests.ViewModels
             this.modelsetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri) { Name = "model" };
             this.iterationsetup = new IterationSetup(Guid.NewGuid(), this.cache, this.uri);
             this.person = new Person(Guid.NewGuid(), this.cache, this.uri);
-            this.domain = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "domain", ShortName = "DMN"};
+            this.domain = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "domain", ShortName = "DMN" };
             this.otherDomain = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "otherDomain", ShortName = "ODMN" };
             this.participant = new Participant(Guid.NewGuid(), this.cache, this.uri) { Person = this.person, SelectedDomain = this.domain };
 
-            this.modelsetup.ActiveDomain = new List<DomainOfExpertise>() {this.domain,this.otherDomain};
+            this.modelsetup.ActiveDomain = new List<DomainOfExpertise>() { this.domain, this.otherDomain };
 
             this.elementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri);
 
@@ -87,9 +88,10 @@ namespace CDP4EngineeringModel.Tests.ViewModels
             this.iteration.Element.Add(this.elementDefinition);
             this.publication = new Publication(Guid.NewGuid(), this.cache, this.uri);
 
-            this.parameter1 = new Parameter(Guid.NewGuid(), this.cache, this.uri){ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { Name = "paramtype1", ShortName = "pat1" }, Owner = this.domain };
+            this.parameter1 = new Parameter(Guid.NewGuid(), this.cache, this.uri) { ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { Name = "paramtype1", ShortName = "pat1" }, Owner = this.domain };
             this.parameter2 = new Parameter(Guid.NewGuid(), this.cache, this.uri) { ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { Name = "paramtype2", ShortName = "pat2" }, Owner = this.domain };
-            
+            this.parameter3= new Parameter(Guid.NewGuid(), this.cache, this.uri) { ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { Name = "paramtypeadd", ShortName = "padd" }, Owner = this.domain };
+
             var parameterforoverride = new Parameter(Guid.NewGuid(), this.cache, this.uri) { ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { Name = "paramtype3", ShortName = "pat3" } };
 
             // Test input
@@ -98,12 +100,14 @@ namespace CDP4EngineeringModel.Tests.ViewModels
             this.SetScalarValueSet(valueSet);
             parameterforoverride.ValueSet.Add(valueSet);
 
-            parameter1.ValueSet.Add(valueSet.Clone(false));
+            this.parameter1.ValueSet.Add(valueSet.Clone(false));
+            this.parameter3.ValueSet.Add(valueSet.Clone(false));
 
-            this.parameterOverride1 = new ParameterOverride(Guid.NewGuid(), this.cache, this.uri) { Parameter = parameterforoverride};
+            this.parameterOverride1 = new ParameterOverride(Guid.NewGuid(), this.cache, this.uri) { Parameter = parameterforoverride };
 
             this.elementDefinition.Parameter.Add(this.parameter1);
             this.elementDefinition.Parameter.Add(this.parameter2);
+            this.elementDefinition.Parameter.Add(this.parameter3);
             this.elementDefinition.Parameter.Add(parameterforoverride);
 
             var elementusage = new ElementUsage(Guid.NewGuid(), this.cache, this.uri);
@@ -113,6 +117,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels
 
             this.publication.PublishedParameter.Add(this.parameter1);
             this.publication.PublishedParameter.Add(this.parameter2);
+            this.publication.PublishedParameter.Add(this.parameter3);
             this.publication.PublishedParameter.Add(this.parameterOverride1);
 
             this.publication.CreatedOn = DateTime.Now;
@@ -161,7 +166,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels
             var viewmodel = new PublicationBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
 
             Assert.AreEqual(1, viewmodel.Publications.Count);
-            Assert.AreEqual(3, viewmodel.Publications[0].ContainedRows.Count);            
+            Assert.AreEqual(3, viewmodel.Publications[0].ContainedRows.Count);
             Assert.That(viewmodel.Caption, Is.Not.Null.Or.Empty);
             Assert.That(viewmodel.ToolTip, Is.Not.Null.Or.Empty);
             Assert.That(viewmodel.DataSource, Is.Not.Null.Or.Empty);
@@ -218,6 +223,17 @@ namespace CDP4EngineeringModel.Tests.ViewModels
         {
             var viewmodel = new PublicationBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
 
+            this.parameter3.ValueSet.First().Published = new ValueArray<string>(new List<string>() { "-" },
+                this.parameter3.ValueSet.First());
+            this.parameter3.ValueSet.First().ValueSwitch = ParameterSwitchKind.REFERENCE;
+            this.parameter3.ValueSet.First().Reference = new ValueArray<string>(new List<string>() { "20" },
+                this.parameter3.ValueSet.First());
+
+            CDPMessageBus.Current.SendObjectChangeEvent(this.parameter3, EventKind.Added);
+
+            Assert.AreEqual(2, viewmodel.Domains.Count);
+            Assert.AreEqual(1, viewmodel.Domains[0].ContainedRows.Count);
+
             this.parameter1.ValueSet.First().Published = new ValueArray<string>(new List<string>() { "-" },
                 this.parameter1.ValueSet.First());
             this.parameter1.ValueSet.First().ValueSwitch = ParameterSwitchKind.MANUAL;
@@ -227,23 +243,23 @@ namespace CDP4EngineeringModel.Tests.ViewModels
             CDPMessageBus.Current.SendObjectChangeEvent(this.parameter1.ValueSet[0], EventKind.Updated);
 
             Assert.AreEqual(2, viewmodel.Domains.Count);
-            Assert.AreEqual(0, viewmodel.Domains[0].ContainedRows.Count);
+            Assert.AreEqual(1, viewmodel.Domains[0].ContainedRows.Count);
 
             this.parameter1.ValueSet.First().Manual = new ValueArray<string>(new List<string> { "134" });
 
             CDPMessageBus.Current.SendObjectChangeEvent(this.parameter1.ValueSet.First(), EventKind.Updated);
-            Assert.AreEqual(1, viewmodel.Domains[0].ContainedRows.Count);
+            Assert.AreEqual(2, viewmodel.Domains[0].ContainedRows.Count);
 
             // verify that same row is updated
             this.parameter1.ValueSet.First().Manual = new ValueArray<string>(new List<string>() { "213" });
 
             CDPMessageBus.Current.SendObjectChangeEvent(this.parameter1.ValueSet[0], EventKind.Updated);
-            Assert.AreEqual(1, viewmodel.Domains[0].ContainedRows.Count);
+            Assert.AreEqual(2, viewmodel.Domains[0].ContainedRows.Count);
 
             // verify that ownership of the parameter is changed
             this.parameter1.Owner = otherDomain;
             CDPMessageBus.Current.SendObjectChangeEvent(this.parameter1, EventKind.Updated);
-            Assert.AreEqual(0, viewmodel.Domains[0].ContainedRows.Count);
+            Assert.AreEqual(1, viewmodel.Domains[0].ContainedRows.Count);
             Assert.AreEqual(1, viewmodel.Domains[1].ContainedRows.Count);
 
             // verify that value is removed
@@ -278,10 +294,10 @@ namespace CDP4EngineeringModel.Tests.ViewModels
             Assert.AreEqual(1, viewmodel.Domains[0].ContainedRows.Count);
 
             viewmodel.Domains[0].ToBePublished = true;
-            ((PublicationParameterOrOverrideRowViewModel) viewmodel.Domains[0].ContainedRows[0]).ToBePublished = true;
+            ((PublicationParameterOrOverrideRowViewModel)viewmodel.Domains[0].ContainedRows[0]).ToBePublished = true;
 
             Assert.IsTrue(viewmodel.Domains.Any(x => x.ToBePublished));
-            
+
             Assert.DoesNotThrowAsync(async () => viewmodel.ExecutePublishCommand());
 
             Assert.IsFalse(viewmodel.Domains.Any(x => x.ToBePublished));

--- a/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListViewModelTestFixture.cs
@@ -156,7 +156,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.RuleVerificationListBrowser
             });
 
             var viewmodel = new RuleVerificationListBrowserViewModel(this.iteration, this.participant, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
-            Assert.AreEqual("Rule verification lists, iteration_0", viewmodel.Caption);
+            Assert.AreEqual("Rule Verification Lists, iteration_0", viewmodel.Caption);
             Assert.AreEqual("model\nhttp://test.com/\n ", viewmodel.ToolTip);
             Assert.AreEqual("model", viewmodel.CurrentModel);
             Assert.AreEqual("domain []", viewmodel.DomainOfExpertise);

--- a/EngineeringModel/ViewModels/PublicationBrowser/PublicationBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/PublicationBrowser/PublicationBrowserViewModel.cs
@@ -52,7 +52,7 @@ namespace CDP4EngineeringModel.ViewModels
         /// The Panel Caption
         /// </summary>
         private const string PanelCaption = "Publications";
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PublicationBrowserViewModel"/> class
         /// </summary>
@@ -119,7 +119,7 @@ namespace CDP4EngineeringModel.ViewModels
         /// Gets the rows representing <see cref="Publication"/>s
         /// </summary>
         public DisposableReactiveList<PublicationRowViewModel> Publications { get; private set; }
-        
+
         /// <summary>
         /// Gets the rows representing <see cref="DomainOfExpertise"/>s
         /// </summary>
@@ -164,28 +164,38 @@ namespace CDP4EngineeringModel.ViewModels
         {
             var updatePublishableParameterListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ParameterValueSetBase))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated 
-                                        && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid 
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated
+                                        && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid
                                         && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing.Container as ParameterOrOverrideBase)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.UpdatePublishableParameter);
             this.Disposables.Add(updatePublishableParameterListener);
 
+            var addParameterListener =
+                CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ParameterOrOverrideBase))
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added
+                                           && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid
+                                           && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                    .Select(x => x.ChangedThing as ParameterOrOverrideBase)
+                    .ObserveOn(RxApp.MainThreadScheduler)
+                    .Subscribe(this.UpdatePublishableParameter);
+            this.Disposables.Add(addParameterListener);
+
             var updateParameterListener =
                  CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ParameterOrOverrideBase))
-                 .Where(objectChange => objectChange.EventKind == EventKind.Updated 
+                 .Where(objectChange => objectChange.EventKind == EventKind.Updated
                                     && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid
                                     && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                  .Select(x => x.ChangedThing as ParameterOrOverrideBase)
                  .ObserveOn(RxApp.MainThreadScheduler)
                  .Subscribe(this.RelocateParameterRowViewModel);
             this.Disposables.Add(updateParameterListener);
-            
+
             var removeParameterListener =
                  CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(ParameterOrOverrideBase))
-                 .Where(objectChange => objectChange.EventKind == EventKind.Removed 
-                                    && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid 
+                 .Where(objectChange => objectChange.EventKind == EventKind.Removed
+                                    && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid
                                     && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                  .Select(x => x.ChangedThing as ParameterOrOverrideBase)
                  .ObserveOn(RxApp.MainThreadScheduler)
@@ -194,8 +204,8 @@ namespace CDP4EngineeringModel.ViewModels
 
             var addPublicationListener =
                 CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(Publication))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Added 
-                                        && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid 
+                    .Where(objectChange => objectChange.EventKind == EventKind.Added
+                                        && objectChange.ChangedThing.CacheKey.Iteration == this.Thing.Iid
                                         && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .Select(x => x.ChangedThing as Publication)
                     .ObserveOn(RxApp.MainThreadScheduler)
@@ -218,22 +228,22 @@ namespace CDP4EngineeringModel.ViewModels
             this.Disposables.Add(updateDomainOfExpretiseListener);
 
             var engineeringModelSetupSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.CurrentEngineeringModelSetup)
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated 
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated
                                         && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(_ => this.UpdateProperties());
             this.Disposables.Add(engineeringModelSetupSubscription);
 
             var domainOfExpertiseSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(DomainOfExpertise))
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated 
-                                        && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber 
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated
+                                        && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber
                                         && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(_ => this.UpdateProperties());
             this.Disposables.Add(domainOfExpertiseSubscription);
 
             var iterationSetupSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.Thing.IterationSetup)
-                    .Where(objectChange => objectChange.EventKind == EventKind.Updated 
+                    .Where(objectChange => objectChange.EventKind == EventKind.Updated
                                         && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber)
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(_ => this.UpdateProperties());
@@ -284,7 +294,7 @@ namespace CDP4EngineeringModel.ViewModels
 
             domainRow.ContainedRows.SortedInsert(parameterRow, rowComparer);
         }
-        
+
         /// <summary>
         /// Removes a publishable parameter row view-model if the <see cref="ParameterOrOverrideBase"/> is no longer publishable.
         /// </summary>
@@ -368,7 +378,7 @@ namespace CDP4EngineeringModel.ViewModels
                 parameterRow.IsCheckable = false;
                 listOfParams.Add(parameterRow);
             }
-            
+
             this.Publications.Add(row);
             row.ContainedRows.AddRange(listOfParams.OrderBy(r => r.Thing.ParameterType.Name));
         }
@@ -401,11 +411,11 @@ namespace CDP4EngineeringModel.ViewModels
             // fire off the publication
             var publication = new Publication(Guid.NewGuid(), null, null);
             var iteration = this.Thing.Clone(false);
-            
+
             iteration.Publication.Add(publication);
 
             publication.Container = iteration;
-            
+
             publication.PublishedParameter = parametersOrOverrides;
 
             this.IsBusy = true;
@@ -434,7 +444,7 @@ namespace CDP4EngineeringModel.ViewModels
                 this.IsBusy = false;
             }
         }
-        
+
         /// <summary>
         /// The <see cref="ObjectChangedEvent"/> handler
         /// </summary>
@@ -446,7 +456,7 @@ namespace CDP4EngineeringModel.ViewModels
             this.UpdateDomains();
             this.UpdateProperties();
         }
-        
+
         /// <summary>
         /// Update the properties of this view-model
         /// </summary>
@@ -489,7 +499,7 @@ namespace CDP4EngineeringModel.ViewModels
             {
                 this.AddPublicationRowViewModel(publication);
             }
-            
+
             this.Publications.Sort((o1, o2) => o1.Index.CompareTo(o2.Index));
         }
 
@@ -564,8 +574,8 @@ namespace CDP4EngineeringModel.ViewModels
         private void RemoveDomainOfExpretiseRowViewModel(DomainOfExpertise domain)
         {
             var domainRow = this.Domains.SingleOrDefault(vm => vm.Thing == domain);
-            
-            if (domainRow != null )
+
+            if (domainRow != null)
             {
                 this.Domains.RemoveAndDispose(domainRow);
             }
@@ -623,7 +633,7 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            
+
             foreach (var publication in this.Publications)
             {
                 publication.Dispose();


### PR DESCRIPTION
…it test

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
#171 adding a new event kind for the case of dragging element definition with parameters with values from another EngineeringModel.
#171 adding unit test for the added kind event subscription

<!-- Thanks for contributing to CDP4-IME! -->

