### PR TITLE
Fix/gh346 crash on requirement verification

### DIFF
--- a/Requirements/Extensions/WritableRequirementStateOfComplianceExtensions.cs
+++ b/Requirements/Extensions/WritableRequirementStateOfComplianceExtensions.cs
@@ -1,6 +1,6 @@
 ﻿// ------------------------------------------------------------------------------------------------
 // <copyright file="WritableRequirementStateOfComplianceMethods.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2019 RHEA System S.A.
+//   Copyright (c) 2015-2020 RHEA System S.A.
 // </copyright>
 // -----------------------------------------------------------------------------------------------
 
@@ -9,7 +9,6 @@ namespace CDP4Requirements.Extensions
     using System;
     using System.Collections.Generic;
     using System.Reactive.Linq;
-    using System.Threading.Tasks;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;

--- a/Requirements/Extensions/WritableRequirementStateOfComplianceExtensions.cs
+++ b/Requirements/Extensions/WritableRequirementStateOfComplianceExtensions.cs
@@ -73,16 +73,6 @@ namespace CDP4Requirements.Extensions
         /// <param name="requirementStateOfComplianceChangedEvent">The <see cref="RequirementStateOfComplianceChangedEvent"/></param>
         private static void SetRequirementStateOfCompliance(IHaveWritableRequirementStateOfCompliance requirementStateOfComplianceObject, RequirementStateOfComplianceChangedEvent requirementStateOfComplianceChangedEvent)
         {
-            if (requirementStateOfComplianceObject.RequirementStateOfCompliance == RequirementStateOfCompliance.Calculating)
-            {
-                if (requirementStateOfComplianceChangedEvent.RequirementStateOfCompliance != RequirementStateOfCompliance.Calculating)
-                {
-                    Task.Delay(500).ContinueWith(_ => requirementStateOfComplianceObject.RequirementStateOfCompliance = requirementStateOfComplianceChangedEvent.RequirementStateOfCompliance);
-
-                    return;
-                }
-            }
-
             requirementStateOfComplianceObject.RequirementStateOfCompliance = requirementStateOfComplianceChangedEvent.RequirementStateOfCompliance;
         }
     }


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Because verification was so fast, the busy indicator never showed up. 
We introduced a delay of 500 milliseconds (Task.Delay) before hiding the busy indicators.
In the old DevExpress version this was not a problem, but from version 18.2 and higher, DevExpress added a check that forbids these kind of operations.
Removed the delay.