### PR TITLE
Imp/gh37 implement indication of default state on parameter value sets in ed browser and product tree; fixes #37

### DIFF
--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterStateRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterStateRowViewModel.cs
@@ -23,8 +23,8 @@ namespace CDP4EngineeringModel.ViewModels
         /// <summary>
         /// Backing field for <see cref="IsDefault"/>
         /// </summary>
-        
         private bool isDefault;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ParameterStateRowViewModel"/> class
         /// </summary>

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterStateRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterStateRowViewModel.cs
@@ -1,6 +1,6 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="ParameterStateRowViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//   Copyright (c) 2015-2020 RHEA System S.A.
 // </copyright>
 // -------------------------------------------------------------------------------------------------
 

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterStateRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterStateRowViewModel.cs
@@ -21,6 +21,11 @@ namespace CDP4EngineeringModel.ViewModels
     public class ParameterStateRowViewModel : ParameterValueBaseRowViewModel
     {
         /// <summary>
+        /// Backing field for <see cref="IsDefault"/>
+        /// </summary>
+        
+        private bool isDefault;
+        /// <summary>
         /// Initializes a new instance of the <see cref="ParameterStateRowViewModel"/> class
         /// </summary>
         /// <param name="parameterBase">The associated <see cref="ParameterBase"/></param>
@@ -34,6 +39,7 @@ namespace CDP4EngineeringModel.ViewModels
         {
             this.Name = this.ActualState.Name;
             this.State = this.ActualState.Name;
+            this.IsDefault = this.ActualState.IsDefault;
             this.Option = this.ActualOption;
 
             foreach (var possibleFiniteState in this.ActualState.PossibleState)
@@ -44,6 +50,15 @@ namespace CDP4EngineeringModel.ViewModels
                                    .Subscribe(x => { this.Name = this.ActualState.Name; });
                 this.Disposables.Add(stateListener);
             }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="PossibleFiniteState"/> is the default value of the <see cref="PossibleFiniteStateList"/>
+        /// </summary>
+        public bool IsDefault
+        {
+            get { return this.isDefault; }
+            set { this.RaiseAndSetIfChanged(ref this.isDefault, value); }
         }
     }
 }

--- a/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
+++ b/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
@@ -245,6 +245,12 @@
                                     <DataTrigger Binding="{Binding Path=Row.IsHighlighted}" Value="True">
                                         <Setter Property="Background" Value="Yellow"/>
                                     </DataTrigger>
+                                    <DataTrigger Binding="{Binding Row.IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                        <Setter Property="FontWeight" Value="Bold" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding Row.IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="False">
+                                        <Setter Property="FontWeight" Value="Normal" />
+                                    </DataTrigger>
                                 </Style.Triggers>
                                 <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
                             </Style>

--- a/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
+++ b/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
@@ -273,10 +273,16 @@
                             <ControlTemplate>
                                 <TextBlock Margin="5,0,0,0"
                                            VerticalAlignment="Center"
-                                           FontWeight="{Binding Path=RowData.Row.IsTopElement,
-                                                                Converter={StaticResource BooleanToFontWeightConverter},
-                                                                UpdateSourceTrigger=PropertyChanged}"
                                            Text="{Binding Path=RowData.Row.Name}" />
+                                <ControlTemplate.Triggers>
+                                    <DataTrigger Binding="{Binding Path=RowData.Row.IsTopElement, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                            <Setter Property="FontWeight" Value="Bold" />
+                                        </DataTrigger>
+                                    <DataTrigger Binding="{Binding Path=RowData.Row.IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                        <Setter Property="FontWeight" Value="Bold" />
+                                        </DataTrigger>
+                                </ControlTemplate.Triggers>
+
                             </ControlTemplate>
                         </dxg:TreeListColumn.DisplayTemplate>
                     </dxg:TreeListColumn>

--- a/ProductTree/ViewModels/ProductTreeRows/ActualFiniteStateRowViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeRows/ActualFiniteStateRowViewModel.cs
@@ -1,6 +1,6 @@
 ﻿// ------------------------------------------------------------------------------------------------
 // <copyright file="ActualFiniteStateRowViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//   Copyright (c) 2015-2020 RHEA System S.A.
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 

--- a/ProductTree/ViewModels/ProductTreeRows/ActualFiniteStateRowViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeRows/ActualFiniteStateRowViewModel.cs
@@ -37,6 +37,11 @@ namespace CDP4ProductTree.ViewModels
         private bool isPublishable;
 
         /// <summary>
+        /// Backing field for <see cref="IsDefault"/>
+        /// </summary>
+        private bool isDefault;
+
+        /// <summary>
         /// Backing field for the <see cref="OwnerShortName"/> property.
         /// </summary>
         private string ownerShortName;
@@ -56,6 +61,7 @@ namespace CDP4ProductTree.ViewModels
             : base(actualFiniteState, session, containerViewModel)
         {
             this.IsPublishable = false;
+            this.IsDefault = actualFiniteState.IsDefault;
 
             var parameterOrOverrideBaseRowViewModel = containerViewModel as ParameterOrOverrideBaseRowViewModel;
             if (parameterOrOverrideBaseRowViewModel != null)
@@ -82,6 +88,14 @@ namespace CDP4ProductTree.ViewModels
             set { this.RaiseAndSetIfChanged(ref this.isPublishable, value); }
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="PossibleFiniteState"/> is the default value of the <see cref="PossibleFiniteStateList"/>
+        /// </summary>
+        public bool IsDefault
+        {
+            get { return this.isDefault; }
+            set { this.RaiseAndSetIfChanged(ref this.isDefault, value); }
+        }
         /// <summary>
         /// Gets or sets the <see cref="ParameterSwitchKind"/>
         /// </summary>

--- a/ProductTree/Views/ProductTree.xaml
+++ b/ProductTree/Views/ProductTree.xaml
@@ -285,6 +285,12 @@
                                 <DataTrigger Binding="{Binding Path=Row.IsHighlighted}" Value="True">
                                     <Setter Property="Background" Value="Yellow"/>
                                 </DataTrigger>
+                                <DataTrigger Binding="{Binding Row.IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
+                                    <Setter Property="FontWeight" Value="Bold" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Row.IsDefault, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="False">
+                                    <Setter Property="FontWeight" Value="Normal" />
+                                </DataTrigger>
                             </Style.Triggers>
                             <Setter Property="ToolTip" Value="{Binding Row.Tooltip}" />
                         </Style>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
When a ParameterValueSet is associated to the default state it will show in bold in both the ElementDefinition tree and the Product Tree.