### PR TITLE
Invalidate ActualFiniteStates while editing an ActualFiniteStateList; fixes #335

### DIFF
--- a/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
@@ -50,20 +50,20 @@ namespace CDP4EngineeringModel.ViewModels
         private ReactiveList<Option> includeOption;
         
         /// <summary>
-        /// Backing field for <see cref="IsActualFiniteStatesListValid"/>
+        /// Backing field for <see cref="AreActualFiniteStatesValid"/>
         /// </summary>
-        private bool isActualFiniteStatesListValid;
+        private bool areActualFiniteStatesValid;
 
         /// <summary>
-        /// Gets a value indicating whether the ActualFiniteStateList needs to be re-calculated or not
+        /// Gets a value indicating whether the ActualFiniteStates of this ActualFiniteStateList needs to be re-calculated or not
         /// </summary>
         /// <remarks>
         /// The value shall be set to false when any change is made on the possible finite state list
         /// </remarks>
-        public bool IsActualFiniteStatesListValid
+        public bool AreActualFiniteStatesValid
         {
-            get => this.isActualFiniteStatesListValid && base.IsNonEditableFieldReadOnly;
-            private set => this.RaiseAndSetIfChanged(ref this.isActualFiniteStatesListValid, value);
+            get => this.areActualFiniteStatesValid && base.IsNonEditableFieldReadOnly;
+            private set => this.RaiseAndSetIfChanged(ref this.areActualFiniteStatesValid, value);
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace CDP4EngineeringModel.ViewModels
             {
                 this.PossibleFiniteStateListRow.RemoveAndDispose(this.SelectedPossibleFiniteStateList);
                 this.RefreshPossibleFiniteStateListRows();
-                this.IsActualFiniteStatesListValid = false;
+                this.AreActualFiniteStatesValid = false;
             });
 
             this.MoveUpPossibleFiniteStateListCommand = ReactiveCommand.Create(canExecuteCommand);
@@ -233,7 +233,7 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ExecuteMoveUpCommand(this.PossibleFiniteStateListRow, this.SelectedPossibleFiniteStateList);
                     this.PossibleFiniteStateList = new ReactiveList<PossibleFiniteStateList>(this.PossibleFiniteStateListRow.Select(x => x.PossibleFiniteStateList));
-                    this.IsActualFiniteStatesListValid = false;
+                    this.AreActualFiniteStatesValid = false;
                 });
 
             this.MoveDownPossibleFiniteStateListCommand = ReactiveCommand.Create(canExecuteCommand);
@@ -242,7 +242,7 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ExecuteMoveDownCommand(this.PossibleFiniteStateListRow, this.SelectedPossibleFiniteStateList);
                     this.PossibleFiniteStateList = new ReactiveList<PossibleFiniteStateList>(this.PossibleFiniteStateListRow.Select(x => x.PossibleFiniteStateList));
-                    this.IsActualFiniteStatesListValid = false;
+                    this.AreActualFiniteStatesValid = false;
                 });
         }
 
@@ -253,7 +253,7 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.UpdateProperties();
             this.PopulatePossibleFiniteStateList();
-            this.IsActualFiniteStatesListValid = true;
+            this.AreActualFiniteStatesValid = true;
         }
 
         /// <summary>
@@ -341,7 +341,7 @@ namespace CDP4EngineeringModel.ViewModels
                 var possibleList = new List<PossibleFiniteStateList>(iteration.PossibleFiniteStateList.Except(this.usedPossibleStateList));
                 possibleList.Add(finiteStateList);
                 var row = new Dialogs.PossibleFiniteStateListRowViewModel(finiteStateList, this.Session, possibleList, this);
-                row.WhenAnyValue(r => r.PossibleFiniteStateList).Subscribe(_ => this.IsActualFiniteStatesListValid = false);
+                row.WhenAnyValue(r => r.PossibleFiniteStateList).Subscribe(_ => this.AreActualFiniteStatesValid = false);
                 this.PossibleFiniteStateListRow.Add(row);
             }
 
@@ -359,7 +359,7 @@ namespace CDP4EngineeringModel.ViewModels
             var row = new Dialogs.PossibleFiniteStateListRowViewModel(finiteStateList, this.Session, possibleList, this);
             this.PossibleFiniteStateListRow.Add(row);
             this.RefreshPossibleFiniteStateListRows();
-            this.IsActualFiniteStatesListValid = false;
+            this.AreActualFiniteStatesValid = false;
         }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // <copyright file="ActualFiniteStateListDialogViewModel.cs" company="RHEA System S.A.">
 //   Copyright (c) 2015-2020 RHEA System S.A.
 // </copyright>
@@ -48,6 +48,25 @@ namespace CDP4EngineeringModel.ViewModels
         /// Backing field for <see cref="ExcludeOption"/>s
         /// </summary>
         private ReactiveList<Option> includeOption;
+        
+        /// <summary>
+        /// Backing field for <see cref="IsValueSetEditable"/>
+        /// </summary>
+        private bool isValueSetEditable;
+
+        /// <summary>
+        /// Gets a value indicating whether the value set may be edited
+        /// </summary>
+        /// <remarks>
+        /// The value shall be set to false when any change is made on the possible finite state list
+        /// </remarks>
+        public bool IsValueSetEditable
+        {
+            get => this.isValueSetEditable && base.IsNonEditableFieldReadOnly;
+            private set => this.RaiseAndSetIfChanged(ref this.isValueSetEditable, value);
+        }
+
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActualFiniteStateListDialogViewModel"/> class.
@@ -207,6 +226,7 @@ namespace CDP4EngineeringModel.ViewModels
             {
                 this.PossibleFiniteStateListRow.RemoveAndDispose(this.SelectedPossibleFiniteStateList);
                 this.RefreshPossibleFiniteStateListRows();
+                this.IsValueSetEditable = false;
             });
 
             this.MoveUpPossibleFiniteStateListCommand = ReactiveCommand.Create(canExecuteCommand);
@@ -215,6 +235,7 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ExecuteMoveUpCommand(this.PossibleFiniteStateListRow, this.SelectedPossibleFiniteStateList);
                     this.PossibleFiniteStateList = new ReactiveList<PossibleFiniteStateList>(this.PossibleFiniteStateListRow.Select(x => x.PossibleFiniteStateList));
+                    this.IsValueSetEditable = false;
                 });
 
             this.MoveDownPossibleFiniteStateListCommand = ReactiveCommand.Create(canExecuteCommand);
@@ -223,6 +244,7 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ExecuteMoveDownCommand(this.PossibleFiniteStateListRow, this.SelectedPossibleFiniteStateList);
                     this.PossibleFiniteStateList = new ReactiveList<PossibleFiniteStateList>(this.PossibleFiniteStateListRow.Select(x => x.PossibleFiniteStateList));
+                    this.IsValueSetEditable = false;
                 });
         }
 
@@ -233,6 +255,7 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.UpdateProperties();
             this.PopulatePossibleFiniteStateList();
+            this.IsValueSetEditable = true;
         }
 
         /// <summary>
@@ -320,6 +343,7 @@ namespace CDP4EngineeringModel.ViewModels
                 var possibleList = new List<PossibleFiniteStateList>(iteration.PossibleFiniteStateList.Except(this.usedPossibleStateList));
                 possibleList.Add(finiteStateList);
                 var row = new Dialogs.PossibleFiniteStateListRowViewModel(finiteStateList, this.Session, possibleList, this);
+                row.WhenAnyValue(r => r.PossibleFiniteStateList).Subscribe(_ => this.IsValueSetEditable = false);
                 this.PossibleFiniteStateListRow.Add(row);
             }
 
@@ -337,6 +361,7 @@ namespace CDP4EngineeringModel.ViewModels
             var row = new Dialogs.PossibleFiniteStateListRowViewModel(finiteStateList, this.Session, possibleList, this);
             this.PossibleFiniteStateListRow.Add(row);
             this.RefreshPossibleFiniteStateListRows();
+            this.IsValueSetEditable = false;
         }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
@@ -50,23 +50,21 @@ namespace CDP4EngineeringModel.ViewModels
         private ReactiveList<Option> includeOption;
         
         /// <summary>
-        /// Backing field for <see cref="IsValueSetEditable"/>
+        /// Backing field for <see cref="IsActualFiniteStatesListValid"/>
         /// </summary>
-        private bool isValueSetEditable;
+        private bool isActualFiniteStatesListValid;
 
         /// <summary>
-        /// Gets a value indicating whether the value set may be edited
+        /// Gets a value indicating whether the ActualFiniteStateList needs to be re-calculated or not
         /// </summary>
         /// <remarks>
         /// The value shall be set to false when any change is made on the possible finite state list
         /// </remarks>
-        public bool IsValueSetEditable
+        public bool IsActualFiniteStatesListValid
         {
-            get => this.isValueSetEditable && base.IsNonEditableFieldReadOnly;
-            private set => this.RaiseAndSetIfChanged(ref this.isValueSetEditable, value);
+            get => this.isActualFiniteStatesListValid && base.IsNonEditableFieldReadOnly;
+            private set => this.RaiseAndSetIfChanged(ref this.isActualFiniteStatesListValid, value);
         }
-
-
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActualFiniteStateListDialogViewModel"/> class.
@@ -226,7 +224,7 @@ namespace CDP4EngineeringModel.ViewModels
             {
                 this.PossibleFiniteStateListRow.RemoveAndDispose(this.SelectedPossibleFiniteStateList);
                 this.RefreshPossibleFiniteStateListRows();
-                this.IsValueSetEditable = false;
+                this.IsActualFiniteStatesListValid = false;
             });
 
             this.MoveUpPossibleFiniteStateListCommand = ReactiveCommand.Create(canExecuteCommand);
@@ -235,7 +233,7 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ExecuteMoveUpCommand(this.PossibleFiniteStateListRow, this.SelectedPossibleFiniteStateList);
                     this.PossibleFiniteStateList = new ReactiveList<PossibleFiniteStateList>(this.PossibleFiniteStateListRow.Select(x => x.PossibleFiniteStateList));
-                    this.IsValueSetEditable = false;
+                    this.IsActualFiniteStatesListValid = false;
                 });
 
             this.MoveDownPossibleFiniteStateListCommand = ReactiveCommand.Create(canExecuteCommand);
@@ -244,7 +242,7 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ExecuteMoveDownCommand(this.PossibleFiniteStateListRow, this.SelectedPossibleFiniteStateList);
                     this.PossibleFiniteStateList = new ReactiveList<PossibleFiniteStateList>(this.PossibleFiniteStateListRow.Select(x => x.PossibleFiniteStateList));
-                    this.IsValueSetEditable = false;
+                    this.IsActualFiniteStatesListValid = false;
                 });
         }
 
@@ -255,7 +253,7 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.UpdateProperties();
             this.PopulatePossibleFiniteStateList();
-            this.IsValueSetEditable = true;
+            this.IsActualFiniteStatesListValid = true;
         }
 
         /// <summary>
@@ -343,7 +341,7 @@ namespace CDP4EngineeringModel.ViewModels
                 var possibleList = new List<PossibleFiniteStateList>(iteration.PossibleFiniteStateList.Except(this.usedPossibleStateList));
                 possibleList.Add(finiteStateList);
                 var row = new Dialogs.PossibleFiniteStateListRowViewModel(finiteStateList, this.Session, possibleList, this);
-                row.WhenAnyValue(r => r.PossibleFiniteStateList).Subscribe(_ => this.IsValueSetEditable = false);
+                row.WhenAnyValue(r => r.PossibleFiniteStateList).Subscribe(_ => this.IsActualFiniteStatesListValid = false);
                 this.PossibleFiniteStateListRow.Add(row);
             }
 
@@ -361,7 +359,7 @@ namespace CDP4EngineeringModel.ViewModels
             var row = new Dialogs.PossibleFiniteStateListRowViewModel(finiteStateList, this.Session, possibleList, this);
             this.PossibleFiniteStateListRow.Add(row);
             this.RefreshPossibleFiniteStateListRows();
-            this.IsValueSetEditable = false;
+            this.IsActualFiniteStatesListValid = false;
         }
     }
 }

--- a/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
@@ -129,7 +129,7 @@
                                      SelectedItem="{Binding SelectedActualState,
                                                             Mode=TwoWay,
                                                             UpdateSourceTrigger=PropertyChanged}"
-                                     IsEnabled="{Binding IsActualFiniteStatesListValid}"
+                                     IsEnabled="{Binding AreActualFiniteStatesValid}"
                                      SelectionMode="Row">
                             <dxg:GridControl.View>
                                 <dxg:TableView Name="ActualFiniteStateView"

--- a/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
@@ -1,4 +1,4 @@
-﻿<dx:DXWindow x:Class="CDP4EngineeringModel.Views.ActualFiniteStateListDialog"
+<dx:DXWindow x:Class="CDP4EngineeringModel.Views.ActualFiniteStateListDialog"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -13,7 +13,6 @@
              xmlns:cdp4Composition="clr-namespace:CDP4Composition;assembly=CDP4Composition"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
              xmlns:engineeringModelData="clr-namespace:CDP4Common.EngineeringModelData;assembly=CDP4Common"
-             xmlns:xtraEditors="clr-namespace:DevExpress.XtraEditors;assembly=DevExpress.XtraEditors.v19.2"
              Height="700"
              MaxWidth="800"
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"

--- a/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
@@ -13,6 +13,7 @@
              xmlns:cdp4Composition="clr-namespace:CDP4Composition;assembly=CDP4Composition"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
              xmlns:engineeringModelData="clr-namespace:CDP4Common.EngineeringModelData;assembly=CDP4Common"
+             xmlns:xtraEditors="clr-namespace:DevExpress.XtraEditors;assembly=DevExpress.XtraEditors.v19.2"
              Height="700"
              MaxWidth="800"
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"
@@ -129,6 +130,7 @@
                                      SelectedItem="{Binding SelectedActualState,
                                                             Mode=TwoWay,
                                                             UpdateSourceTrigger=PropertyChanged}"
+                                     IsEnabled="{Binding IsValueSetEditable}"
                                      SelectionMode="Row">
                             <dxg:GridControl.View>
                                 <dxg:TableView Name="ActualFiniteStateView"

--- a/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ActualFiniteStateListDialog.xaml
@@ -129,7 +129,7 @@
                                      SelectedItem="{Binding SelectedActualState,
                                                             Mode=TwoWay,
                                                             UpdateSourceTrigger=PropertyChanged}"
-                                     IsEnabled="{Binding IsValueSetEditable}"
+                                     IsEnabled="{Binding IsActualFiniteStatesListValid}"
                                      SelectionMode="Row">
                             <dxg:GridControl.View>
                                 <dxg:TableView Name="ActualFiniteStateView"


### PR DESCRIPTION
When Creating/Editing ActualFiniteStateLists the ActualFiniteStates can be invalidated; fixes #335

# Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
When Creating/Editing ActualFiniteStateLists the ActualFiniteStates can be invalidated; fixes #335

