### PR TITLE
DomainFileStore and Folder Dialogs

### DIFF
--- a/EngineeringModel.Tests/Dialogs/DomainFileStoreDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/DomainFileStoreDialogViewModelTestFixture.cs
@@ -1,0 +1,170 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DomainFileStoreDialogViewModelTestFixture.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Tests.Dialogs
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive.Concurrency;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.MetaInfo;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+
+    using CDP4Dal;
+    using CDP4Dal.DAL;
+    using CDP4Dal.Operations;
+    using CDP4Dal.Permission;
+
+    using CDP4EngineeringModel.ViewModels;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="DomainFileStoreDialogViewModel"/>
+    /// </summary>
+    [TestFixture]
+    public class DomainFileStoreDialogViewModelTestFixture
+    {
+        private Uri uri = new Uri("http://www.rheagroup.com");
+        private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
+        private IThingTransaction thingTransaction;
+        private Mock<ISession> session;
+        private Mock<IPermissionService> permissionService;
+        private Mock<IThingDialogNavigationService> thingDialogNavigationService;
+
+        private Iteration iterationClone;
+        private EngineeringModel engineeringModel;
+        private DomainOfExpertise domainOfExpertise;
+        private Participant participant;
+
+        private DomainFileStore domainFileStore;
+
+        [SetUp]
+        public void SetUp()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+
+            this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
+            this.session = new Mock<ISession>();
+            this.permissionService = new Mock<IPermissionService>();
+
+            this.domainOfExpertise = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "system", ShortName = "SYS" };
+
+            this.participant = new Participant(Guid.NewGuid(), this.cache, this.uri);
+            this.participant.Domain.Add(this.domainOfExpertise);
+
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri);
+            engineeringModelSetup.ActiveDomain.Add(this.domainOfExpertise);
+            var srdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri) { Name = "testRDL", ShortName = "test" };
+            var category = new Category(Guid.NewGuid(), this.cache, this.uri) { Name = "test Category", ShortName = "testCategory" };
+            category.PermissibleClass.Add(ClassKind.ElementDefinition);
+            srdl.DefinedCategory.Add(category);
+            var mrdl = new ModelReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri) { RequiredRdl = srdl };
+            engineeringModelSetup.RequiredRdl.Add(mrdl);
+            srdl.DefinedCategory.Add(new Category(Guid.NewGuid(), this.cache, this.uri));
+            this.engineeringModel = new EngineeringModel(Guid.NewGuid(), this.cache, this.uri);
+            this.engineeringModel.EngineeringModelSetup = engineeringModelSetup;
+            var iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri);
+            this.engineeringModel.Iteration.Add(iteration);
+            this.domainFileStore = new DomainFileStore(Guid.NewGuid(), this.cache, this.uri);
+            iteration.DomainFileStore.Add(this.domainFileStore);
+
+            this.cache.TryAdd(new CacheKey(iteration.Iid, null), new Lazy<Thing>(() => iteration));
+            this.iterationClone = iteration.Clone(false);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(iteration);
+            this.thingTransaction = new ThingTransaction(transactionContext, this.iterationClone);
+
+            var dal = new Mock<IDal>();
+            this.session.Setup(x => x.DalVersion).Returns(new Version(1, 1, 0));
+            this.session.Setup(x => x.Dal).Returns(dal.Object);
+
+            var openIterations = new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>();
+            openIterations.Add(iteration, new Tuple<DomainOfExpertise, Participant>(this.domainOfExpertise, this.participant));
+
+            this.session.Setup(x => x.OpenIterations).Returns(openIterations);
+
+            dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());
+        }
+
+        [Test]
+        public void VerifyThatDefaultConstructorIsAvailable()
+        {
+            var domainFileStoreDialogViewModel = new DomainFileStoreDialogViewModel();
+            Assert.IsNotNull(domainFileStoreDialogViewModel);
+        }
+
+        [Test]
+        public void VerifyThatPropertiesAreSet()
+        {
+            var name = "name";
+            var createdOn = DateTime.UtcNow;
+
+            this.domainFileStore.Name = name;
+            this.domainFileStore.CreatedOn = createdOn;
+            this.domainFileStore.Owner = this.domainOfExpertise;
+
+            var domainFileStoreDialogViewModel = new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            Assert.AreEqual(name, domainFileStoreDialogViewModel.Name);
+            Assert.AreEqual(createdOn, domainFileStoreDialogViewModel.CreatedOn);
+            Assert.AreEqual(this.domainOfExpertise, domainFileStoreDialogViewModel.SelectedOwner);
+            Assert.AreSame(this.iterationClone, domainFileStoreDialogViewModel.Container);
+            Assert.IsTrue(domainFileStoreDialogViewModel.PossibleOwner.Any());
+        }
+
+        [Test]
+        public void VerifyOkExecute()
+        {
+            var name = "name";
+            var createdOn = DateTime.UtcNow;
+
+            this.domainFileStore.Name = name;
+            this.domainFileStore.CreatedOn = createdOn;
+            this.domainFileStore.Owner = this.domainOfExpertise;
+
+            var domainFileStoreDialogViewModel = new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            domainFileStoreDialogViewModel.OkCommand.Execute(null);
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()));
+        }
+
+        [Test]
+        public void VerifyCanOkExecute()
+        {
+            var name = "name";
+            var createdOn = DateTime.UtcNow;
+
+            var domainFileStoreDialogViewModel = new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            Assert.IsFalse(domainFileStoreDialogViewModel.OkCanExecute);
+            domainFileStoreDialogViewModel.Name = name;
+
+            Assert.IsFalse(domainFileStoreDialogViewModel.OkCanExecute);
+            domainFileStoreDialogViewModel.CreatedOn = createdOn;
+
+            Assert.IsFalse(domainFileStoreDialogViewModel.OkCanExecute);
+            domainFileStoreDialogViewModel.SelectedOwner = this.domainOfExpertise;
+
+            Assert.IsTrue(domainFileStoreDialogViewModel.OkCanExecute);
+        }
+    }
+}

--- a/EngineeringModel.Tests/Dialogs/DomainFileStoreDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/DomainFileStoreDialogViewModelTestFixture.cs
@@ -1,9 +1,28 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreDialogViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2020 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
-
+// --------------------------------------------------------------------------------------------------------------------
 namespace CDP4EngineeringModel.Tests.Dialogs
 {
     using System;
@@ -121,7 +140,9 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.domainFileStore.CreatedOn = createdOn;
             this.domainFileStore.Owner = this.domainOfExpertise;
 
-            var domainFileStoreDialogViewModel = new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.iterationClone);
+            var domainFileStoreDialogViewModel = 
+                new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, 
+                    this.thingDialogNavigationService.Object, this.iterationClone);
 
             Assert.AreEqual(name, domainFileStoreDialogViewModel.Name);
             Assert.AreEqual(createdOn, domainFileStoreDialogViewModel.CreatedOn);
@@ -140,7 +161,9 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.domainFileStore.CreatedOn = createdOn;
             this.domainFileStore.Owner = this.domainOfExpertise;
 
-            var domainFileStoreDialogViewModel = new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.iterationClone);
+            var domainFileStoreDialogViewModel = 
+                new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, 
+                    this.thingDialogNavigationService.Object, this.iterationClone);
 
             domainFileStoreDialogViewModel.OkCommand.Execute(null);
 
@@ -153,7 +176,9 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             var name = "name";
             var createdOn = DateTime.UtcNow;
 
-            var domainFileStoreDialogViewModel = new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.iterationClone);
+            var domainFileStoreDialogViewModel = 
+                new DomainFileStoreDialogViewModel(this.domainFileStore, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, 
+                    this.thingDialogNavigationService.Object, this.iterationClone);
 
             Assert.IsFalse(domainFileStoreDialogViewModel.OkCanExecute);
             domainFileStoreDialogViewModel.Name = name;

--- a/EngineeringModel.Tests/Dialogs/FolderDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/FolderDialogViewModelTestFixture.cs
@@ -1,8 +1,28 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FolderDialogViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2020 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.Tests.Dialogs
 {
@@ -125,7 +145,9 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.folder.CreatedOn = createdOn;
             this.folder.Owner = this.domainOfExpertise;
 
-            var folderDialogViewModel = new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.domainFileStoreClone);
+            var folderDialogViewModel = 
+                new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, 
+                    this.thingDialogNavigationService.Object, this.domainFileStoreClone);
 
             Assert.AreEqual(name, folderDialogViewModel.Name);
             Assert.AreEqual(createdOn, folderDialogViewModel.CreatedOn);
@@ -144,7 +166,9 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.folder.CreatedOn = createdOn;
             this.folder.Owner = this.domainOfExpertise;
 
-            var folderDialogViewModel = new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.domainFileStoreClone);
+            var folderDialogViewModel = 
+                new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, 
+                    this.thingDialogNavigationService.Object, this.domainFileStoreClone);
 
             folderDialogViewModel.OkCommand.Execute(null);
 
@@ -157,7 +181,9 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             var name = "name";
             var createdOn = DateTime.UtcNow;
 
-            var folderDialogViewModel = new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.domainFileStoreClone);
+            var folderDialogViewModel = 
+                new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, 
+                    this.thingDialogNavigationService.Object, this.domainFileStoreClone);
 
             Assert.IsFalse(folderDialogViewModel.OkCanExecute);
             folderDialogViewModel.Name = name;

--- a/EngineeringModel.Tests/Dialogs/FolderDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/FolderDialogViewModelTestFixture.cs
@@ -1,0 +1,174 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FolderDialogViewModelTestFixture.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Tests.Dialogs
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive.Concurrency;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.MetaInfo;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+
+    using CDP4Dal;
+    using CDP4Dal.DAL;
+    using CDP4Dal.Operations;
+    using CDP4Dal.Permission;
+
+    using CDP4EngineeringModel.ViewModels;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="FolderDialogViewModel"/>
+    /// </summary>
+    [TestFixture]
+    public class FolderDialogViewModelTestFixture
+    {
+        private Uri uri = new Uri("http://www.rheagroup.com");
+        private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
+        private IThingTransaction thingTransaction;
+        private Mock<ISession> session;
+        private Mock<IPermissionService> permissionService;
+        private Mock<IThingDialogNavigationService> thingDialogNavigationService;
+
+        private EngineeringModel engineeringModel;
+        private DomainOfExpertise domainOfExpertise;
+        private Participant participant;
+
+        private DomainFileStore domainFileStore;
+        private Folder folder;
+        private DomainFileStore domainFileStoreClone;
+
+        [SetUp]
+        public void SetUp()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+
+            this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
+            this.session = new Mock<ISession>();
+            this.permissionService = new Mock<IPermissionService>();
+
+            this.domainOfExpertise = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "system", ShortName = "SYS" };
+
+            this.participant = new Participant(Guid.NewGuid(), this.cache, this.uri);
+            this.participant.Domain.Add(this.domainOfExpertise);
+
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri);
+            engineeringModelSetup.ActiveDomain.Add(this.domainOfExpertise);
+            var srdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri) { Name = "testRDL", ShortName = "test" };
+            var category = new Category(Guid.NewGuid(), this.cache, this.uri) { Name = "test Category", ShortName = "testCategory" };
+            category.PermissibleClass.Add(ClassKind.ElementDefinition);
+            srdl.DefinedCategory.Add(category);
+            var mrdl = new ModelReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri) { RequiredRdl = srdl };
+            engineeringModelSetup.RequiredRdl.Add(mrdl);
+            srdl.DefinedCategory.Add(new Category(Guid.NewGuid(), this.cache, this.uri));
+            this.engineeringModel = new EngineeringModel(Guid.NewGuid(), this.cache, this.uri);
+            this.engineeringModel.EngineeringModelSetup = engineeringModelSetup;
+            var iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri);
+            this.engineeringModel.Iteration.Add(iteration);
+            this.folder = new Folder(Guid.NewGuid(), this.cache, this.uri);
+            this.domainFileStore = new DomainFileStore(Guid.NewGuid(), this.cache, this.uri);
+            this.domainFileStore.Folder.Add(this.folder);
+            iteration.DomainFileStore.Add(this.domainFileStore);
+
+            this.cache.TryAdd(new CacheKey(iteration.Iid, null), new Lazy<Thing>(() => iteration));
+
+            this.domainFileStoreClone = this.domainFileStore.Clone(false);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(this.domainFileStore);
+            this.thingTransaction = new ThingTransaction(transactionContext, this.domainFileStoreClone);
+
+            var dal = new Mock<IDal>();
+            this.session.Setup(x => x.DalVersion).Returns(new Version(1, 1, 0));
+            this.session.Setup(x => x.Dal).Returns(dal.Object);
+
+            var openIterations = new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>();
+            openIterations.Add(iteration, new Tuple<DomainOfExpertise, Participant>(this.domainOfExpertise, this.participant));
+
+            this.session.Setup(x => x.OpenIterations).Returns(openIterations);
+
+            dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());
+        }
+
+        [Test]
+        public void VerifyThatDefaultConstructorIsAvailable()
+        {
+            var folderDialogViewModel = new FolderDialogViewModel();
+            Assert.IsNotNull(folderDialogViewModel);
+        }
+
+        [Test]
+        public void VerifyThatPropertiesAreSet()
+        {
+            var name = "name";
+            var createdOn = DateTime.UtcNow;
+
+            this.folder.Name = name;
+            this.folder.CreatedOn = createdOn;
+            this.folder.Owner = this.domainOfExpertise;
+
+            var folderDialogViewModel = new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.domainFileStoreClone);
+
+            Assert.AreEqual(name, folderDialogViewModel.Name);
+            Assert.AreEqual(createdOn, folderDialogViewModel.CreatedOn);
+            Assert.AreEqual(this.domainOfExpertise, folderDialogViewModel.SelectedOwner);
+            Assert.AreSame(this.domainFileStoreClone, folderDialogViewModel.Container);
+            Assert.IsTrue(folderDialogViewModel.PossibleOwner.Any());
+        }
+
+        [Test]
+        public void VerifyOkExecute()
+        {
+            var name = "name";
+            var createdOn = DateTime.UtcNow;
+
+            this.folder.Name = name;
+            this.folder.CreatedOn = createdOn;
+            this.folder.Owner = this.domainOfExpertise;
+
+            var folderDialogViewModel = new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.domainFileStoreClone);
+
+            folderDialogViewModel.OkCommand.Execute(null);
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()));
+        }
+
+        [Test]
+        public void VerifyCanOkExecute()
+        {
+            var name = "name";
+            var createdOn = DateTime.UtcNow;
+
+            var folderDialogViewModel = new FolderDialogViewModel(this.folder, this.thingTransaction, this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.domainFileStoreClone);
+
+            Assert.IsFalse(folderDialogViewModel.OkCanExecute);
+            folderDialogViewModel.Name = name;
+
+            Assert.IsFalse(folderDialogViewModel.OkCanExecute);
+            folderDialogViewModel.CreatedOn = createdOn;
+
+            Assert.IsFalse(folderDialogViewModel.OkCanExecute);
+            folderDialogViewModel.SelectedOwner = this.domainOfExpertise;
+
+            Assert.IsTrue(folderDialogViewModel.OkCanExecute);
+        }
+    }
+}

--- a/EngineeringModel.Tests/EngineeringModel.Tests.csproj
+++ b/EngineeringModel.Tests/EngineeringModel.Tests.csproj
@@ -165,6 +165,8 @@
     <Compile Include="Dialogs\ActualFiniteStateDialogViewModelTestFixture.cs" />
     <Compile Include="Dialogs\BinaryRelationshipDialogViewModelTestFixture.cs" />
     <Compile Include="Dialogs\BuiltInRuleVerificationDialogViewModelTestFixture.cs" />
+    <Compile Include="Dialogs\FolderDialogViewModelTestFixture.cs" />
+    <Compile Include="Dialogs\DomainFileStoreDialogViewModelTestFixture.cs" />
     <Compile Include="Dialogs\ElementUsageDialogViewModelTestFixture.cs" />
     <Compile Include="Dialogs\ElementDefinitionDialogViewModelTestFixture.cs" />
     <Compile Include="Dialogs\OptionDialogViewModelTestFixture.cs" />
@@ -240,7 +242,9 @@
       <Name>EngineeringModel</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="ViewModels\FileStoreBrowsers\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/EngineeringModel.Tests/ViewModels/DomainFileStoreBrowser/DomainFileStoreBrowserRibbonViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/DomainFileStoreBrowser/DomainFileStoreBrowserRibbonViewModelTestFixture.cs
@@ -1,8 +1,29 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreBrowserRibbonViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2017 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
+
 namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
 {
     using System;
@@ -95,12 +116,15 @@ namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
             this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri) { IterationSetup = this.iterationsetup };
             this.model.Iteration.Add(this.iteration);
 
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.sitedir);
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.DataSourceUri).Returns(this.uri.ToString);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.IsVersionSupported(It.IsAny<Version>())).Returns(true);
             this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>());
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
 
             this.cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
         }

--- a/EngineeringModel.Tests/ViewModels/DomainFileStoreBrowser/DomainFileStoreBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/DomainFileStoreBrowser/DomainFileStoreBrowserViewModelTestFixture.cs
@@ -1,8 +1,29 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreBrowserViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2017 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
+
 namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
 {
     using System;
@@ -127,6 +148,8 @@ namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
                     { this.iteration, new Tuple<DomainOfExpertise, Participant>(this.domain, this.participant) }
                 });
 
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
 
             this.store = new DomainFileStore(Guid.NewGuid(), this.assembler.Cache, this.uri);
@@ -191,11 +214,18 @@ namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
 
             vm.ComputePermission();
 
-            Assert.IsFalse(vm.CanCreateStore);
-            Assert.IsTrue(vm.CanCreateFolder);
+            Assert.IsTrue(vm.CanCreateStore);
+            Assert.IsFalse(vm.CanCreateFolder);
+            Assert.IsFalse(vm.CanUploadFile);
 
             var storeRow = vm.ContainedRows.Single();
             Assert.IsEmpty(storeRow.ContainedRows);
+
+            vm.SelectedThing = storeRow;
+
+            Assert.IsTrue(vm.CanCreateStore);
+            Assert.IsTrue(vm.CanCreateFolder);
+            Assert.IsTrue(vm.CanUploadFile);
 
             this.store.Folder.Add(this.folder1);
             this.store.Folder.Add(this.folder2);
@@ -208,6 +238,12 @@ namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
             Assert.AreEqual(1, storeRow.ContainedRows.Count);
 
             var folder1Row = storeRow.ContainedRows.Single();
+            vm.SelectedThing = folder1Row;
+
+            Assert.IsTrue(vm.CanCreateStore);
+            Assert.IsTrue(vm.CanCreateFolder);
+            Assert.IsTrue(vm.CanUploadFile);
+
             var folder2Row = folder1Row.ContainedRows.Single();
 
             this.store.File.Add(this.file);
@@ -223,6 +259,11 @@ namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
             CDPMessageBus.Current.SendObjectChangeEvent(this.file, EventKind.Updated);
 
             Assert.AreEqual(1, folder2Row.ContainedRows.Count);
+            vm.SelectedThing = folder2Row.ContainedRows.Single();
+
+            Assert.IsTrue(vm.CanCreateStore);
+            Assert.IsFalse(vm.CanCreateFolder);
+            Assert.IsFalse(vm.CanUploadFile);
 
             this.folder2.ContainingFolder = null;
             this.rev.SetValue(this.folder2, 5);
@@ -247,7 +288,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.DomainFileStoreBrowser
             Assert.AreEqual(2, folder2Row.ContainedRows.Count);
         }
 
-        [Test]
+        [Ignore("File upload not implmented yet")]
         public void VerifyUploadFileCommand()
         {
             this.model.Iteration.FirstOrDefault().DomainFileStore.Add(this.store);

--- a/EngineeringModel/EngineeringModel.csproj
+++ b/EngineeringModel/EngineeringModel.csproj
@@ -240,6 +240,7 @@
     <Compile Include="ViewModels\Dialogs\ActualFiniteStateDialogViewModel.cs" />
     <Compile Include="ViewModels\Dialogs\BinaryRelationshipDialogViewModel.cs" />
     <Compile Include="ViewModels\Dialogs\BuiltInRuleVerificationDialogViewModel.cs" />
+    <Compile Include="ViewModels\Dialogs\FolderDialogViewModel.cs" />
     <Compile Include="ViewModels\Dialogs\ElementUsageDialogViewModel.cs" />
     <Compile Include="ViewModels\Dialogs\ElementDefinitionDialogViewModel.cs" />
     <Compile Include="ViewModels\Dialogs\ActualFiniteStateListDialogViewModel.cs" />
@@ -337,6 +338,13 @@
     <Compile Include="Views\Dialogs\BuiltInRuleVerificationDialog.xaml.cs">
       <DependentUpon>BuiltInRuleVerificationDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\Dialogs\FolderDialog.xaml.cs">
+      <DependentUpon>FolderDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Dialogs\DomainFileStoreDialog.xaml.cs">
+      <DependentUpon>DomainFileStoreDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ViewModels\Dialogs\DomainFileStoreDialogViewModel.cs" />
     <Compile Include="Views\Dialogs\ElementDefinitionDialog.xaml.cs">
       <DependentUpon>ElementDefinitionDialog.xaml</DependentUpon>
     </Compile>
@@ -445,6 +453,14 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\Dialogs\BuiltInRuleVerificationDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\Dialogs\FolderDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\Dialogs\DomainFileStoreDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/EngineeringModel/ViewModels/Dialogs/DomainFileStoreDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/DomainFileStoreDialogViewModel.cs
@@ -1,8 +1,28 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreDialogViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2020 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
@@ -72,7 +92,8 @@ namespace CDP4EngineeringModel.ViewModels
         /// <param name="chainOfContainers">
         /// The optional chain of containers that contains the <paramref name="container"/> argument
         /// </param>
-        public DomainFileStoreDialogViewModel(DomainFileStore fileStore, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
+        public DomainFileStoreDialogViewModel(DomainFileStore fileStore, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, 
+            IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
             : base(fileStore, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
         {
         }

--- a/EngineeringModel/ViewModels/Dialogs/DomainFileStoreDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/DomainFileStoreDialogViewModel.cs
@@ -1,0 +1,121 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="DomainFileStoreDialogViewModel.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+
+    using CDP4Dal;
+    using CDP4Dal.Operations;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// The purpose of the <see cref="DomainFileStoreDialogViewModel"/> is to allow a <see cref="DomainFileStore"/> to
+    /// be created or updated.
+    /// </summary>
+    /// <remarks>
+    /// The creation of an <see cref="DomainFileStore"/> will result in an <see cref="DomainFileStore"/> being created by
+    /// the connected data-source
+    /// </remarks>
+    [ThingDialogViewModelExport(ClassKind.DomainFileStore)]
+    public class DomainFileStoreDialogViewModel : CDP4CommonView.DomainFileStoreDialogViewModel, IThingDialogViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainFileStoreDialogViewModel"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The default constructor is required by MEF
+        /// </remarks>
+        public DomainFileStoreDialogViewModel()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainFileStoreDialogViewModel"/> class.
+        /// </summary>
+        /// <param name="fileStore">
+        /// The <see cref="DomainFileStore"/> that is the subject of the current view-model. This is the object
+        /// that will be either created, or edited.
+        /// </param>
+        /// <param name=""></param>
+        /// <param name="transaction">
+        /// The <see cref="ThingTransaction"/> that contains the log of recorded changes.
+        /// </param>
+        /// <param name="session">
+        /// The <see cref="ISession"/> in which the current <see cref="Thing"/> is to be added or updated
+        /// </param>
+        /// <param name="isRoot">
+        /// Assert if this <see cref="DomainFileStoreDialogViewModel"/> is the root of all <see cref="IThingDialogViewModel"/>
+        /// </param>
+        /// <param name="dialogKind">
+        /// The kind of operation this <see cref="DomainFileStoreDialogViewModel"/> performs
+        /// </param>
+        /// <param name="thingDialogNavigationService">
+        /// The <see cref="IThingDialogNavigationService"/>
+        /// </param>
+        /// <param name="container">
+        /// The Container <see cref="Thing"/> of the created <see cref="Thing"/>
+        /// </param>
+        /// <param name="chainOfContainers">
+        /// The optional chain of containers that contains the <paramref name="container"/> argument
+        /// </param>
+        public DomainFileStoreDialogViewModel(DomainFileStore fileStore, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
+            : base(fileStore, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
+        {
+        }
+
+        /// <summary>
+        /// Populate the possible owners
+        /// </summary>
+        protected override void PopulatePossibleOwner()
+        {
+            base.PopulatePossibleOwner();
+
+            var engineeringModel = (EngineeringModel)this.Container.Container;
+            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
+            this.PossibleOwner.AddRange(domains);
+        }
+
+        /// <summary>
+        /// Update the properties
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            base.UpdateProperties();
+
+            this.CreatedOn = this.Thing.CreatedOn.Equals(DateTime.MinValue) ? DateTime.UtcNow : this.Thing.CreatedOn;
+        }
+
+        /// <summary>
+        /// Initialize the <see cref="ICommand"/>s and listeners
+        /// </summary>
+        protected override void InitializeCommands()
+        {
+            base.InitializeCommands();
+            this.WhenAnyValue(x => x.SelectedOwner).Subscribe(_ => this.UpdateOkCanExecute());
+            this.WhenAnyValue(x => x.Name).Subscribe(_ => this.UpdateOkCanExecute());
+        }
+
+        /// <summary>
+        /// Returns whether it is possible to close the current dialog by clicking the OK button
+        /// </summary>
+        protected override void UpdateOkCanExecute()
+        {
+            base.UpdateOkCanExecute();
+            this.OkCanExecute = this.OkCanExecute && this.SelectedOwner != null && !string.IsNullOrWhiteSpace(this.Name);
+        }
+    }
+}

--- a/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
@@ -1,0 +1,132 @@
+﻿// -------------------------------------------------------------------------------------------------
+// <copyright file="FolderDialogViewModel.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// -------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+
+    using CDP4Dal;
+    using CDP4Dal.Operations;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// The purpose of the <see cref="FolderDialogViewModel"/> is to allow a <see cref="Folder"/> to
+    /// be created or updated.
+    /// </summary>
+    /// <remarks>
+    /// The creation of an <see cref="Folder"/> will result in an <see cref="Folder"/> being created by
+    /// the connected data-source
+    /// </remarks>
+    [ThingDialogViewModelExport(ClassKind.Folder)]
+    public class FolderDialogViewModel : CDP4CommonView.FolderDialogViewModel, IThingDialogViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FolderDialogViewModel"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The default constructor is required by MEF
+        /// </remarks>
+        public FolderDialogViewModel()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FolderDialogViewModel"/> class.
+        /// </summary>
+        /// <param name="folder">
+        /// The <see cref="Folder"/> that is the subject of the current view-model. This is the object
+        /// that will be either created, or edited.
+        /// </param>
+        /// <param name=""></param>
+        /// <param name="transaction">
+        /// The <see cref="ThingTransaction"/> that contains the log of recorded changes.
+        /// </param>
+        /// <param name="session">
+        /// The <see cref="ISession"/> in which the current <see cref="Thing"/> is to be added or updated
+        /// </param>
+        /// <param name="isRoot">
+        /// Assert if this <see cref="FolderDialogViewModel"/> is the root of all <see cref="IThingDialogViewModel"/>
+        /// </param>
+        /// <param name="dialogKind">
+        /// The kind of operation this <see cref="FolderDialogViewModel"/> performs
+        /// </param>
+        /// <param name="thingDialogNavigationService">
+        /// The <see cref="IThingDialogNavigationService"/>
+        /// </param>
+        /// <param name="container">
+        /// The Container <see cref="Thing"/> of the created <see cref="Thing"/>
+        /// </param>
+        /// <param name="chainOfContainers">
+        /// The optional chain of containers that contains the <paramref name="container"/> argument
+        /// </param>
+        public FolderDialogViewModel(Folder folder, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
+            : base(folder, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
+        {
+        }
+
+        /// <summary>
+        /// Populate the possible owners
+        /// </summary>
+        protected override void PopulatePossibleOwner()
+        {
+            base.PopulatePossibleOwner();
+
+            var engineeringModel = this.Container.GetContainerOfType<EngineeringModel>();
+            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
+            this.PossibleOwner.AddRange(domains);
+        }
+
+        /// <summary>
+        /// Update the properties
+        /// </summary>
+        protected override void UpdateProperties()
+        {
+            base.UpdateProperties();
+
+            this.CreatedOn = this.Thing.CreatedOn.Equals(DateTime.MinValue) ? DateTime.UtcNow : this.Thing.CreatedOn;
+
+            if (this.SelectedCreator == null)
+            {
+                var iteration = this.Container.GetContainerOfType<Iteration>();
+
+                if (iteration != null)
+                {
+                    this.Session.OpenIterations.TryGetValue(iteration, out var tuple);
+                    this.SelectedCreator = tuple?.Item2;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initialize the <see cref="ICommand"/>s and listeners
+        /// </summary>
+        protected override void InitializeCommands()
+        {
+            base.InitializeCommands();
+            this.WhenAnyValue(x => x.SelectedOwner).Subscribe(_ => this.UpdateOkCanExecute());
+            this.WhenAnyValue(x => x.Name).Subscribe(_ => this.UpdateOkCanExecute());
+        }
+
+        /// <summary>
+        /// Returns whether it is possible to close the current dialog by clicking the OK button
+        /// </summary>
+        protected override void UpdateOkCanExecute()
+        {
+            base.UpdateOkCanExecute();
+            this.OkCanExecute = this.OkCanExecute && this.SelectedOwner != null && !string.IsNullOrWhiteSpace(this.Name);
+        }
+    }
+}

--- a/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
@@ -1,8 +1,28 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FolderDialogViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2020 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
@@ -72,7 +92,8 @@ namespace CDP4EngineeringModel.ViewModels
         /// <param name="chainOfContainers">
         /// The optional chain of containers that contains the <paramref name="container"/> argument
         /// </param>
-        public FolderDialogViewModel(Folder folder, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
+        public FolderDialogViewModel(Folder folder, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, 
+            IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
             : base(folder, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
         {
         }

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreBrowserViewModel.cs
@@ -1,6 +1,26 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreBrowserViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -88,7 +108,8 @@ namespace CDP4EngineeringModel.ViewModels
         /// <param name="dialogNavigationService">
         /// The <see cref="IDialogNavigationService"/>
         /// </param>
-        public DomainFileStoreBrowserViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+        public DomainFileStoreBrowserViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, 
+            IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
             : base(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
         {
             this.Caption = $"{PanelCaption}, iteration_{this.Thing.IterationSetup.IterationNumber}";
@@ -329,7 +350,7 @@ namespace CDP4EngineeringModel.ViewModels
             }
             else
             {
-                this.DomainOfExpertise = (iterationDomainPair.Value == null) || (iterationDomainPair.Value.Item1 == null)
+                this.DomainOfExpertise = iterationDomainPair.Value?.Item1 == null
                     ? "None"
                     : $"{iterationDomainPair.Value.Item1.Name} [{iterationDomainPair.Value.Item1.ShortName}]";
             }

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreBrowserViewModel.cs
@@ -11,18 +11,23 @@ namespace CDP4EngineeringModel.ViewModels
     using System.Linq;
     using System.Reactive.Linq;
     using System.Windows.Controls;
+
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+
     using CDP4Composition;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Mvvm.Types;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
     using CDP4Dal.Events;
+
     using Microsoft.Practices.ServiceLocation;
+
     using ReactiveUI;
 
     /// <summary>
@@ -34,11 +39,6 @@ namespace CDP4EngineeringModel.ViewModels
         /// The Panel Caption
         /// </summary>
         private const string PanelCaption = "Domain File Store";
-
-        /// <summary>
-        /// the <see cref="DomainFileStoreRowViewModel"/>
-        /// </summary>
-        private DomainFileStoreRowViewModel domainFileStoreRow;
 
         /// <summary>
         /// Backing field for <see cref="CurrentModel"/>
@@ -69,7 +69,7 @@ namespace CDP4EngineeringModel.ViewModels
         /// The <see cref="IOpenSaveFileDialogService"/>
         /// </summary>
         private readonly IOpenSaveFileDialogService fileDialogService = ServiceLocator.Current.GetInstance<IOpenSaveFileDialogService>();
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DomainFileStoreBrowserViewModel"/> class.
         /// </summary>
@@ -91,13 +91,13 @@ namespace CDP4EngineeringModel.ViewModels
         public DomainFileStoreBrowserViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
             : base(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
         {
-            this.Caption = string.Format("{0}, iteration_{1}", PanelCaption, this.Thing.IterationSetup.IterationNumber);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", ((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.Caption = $"{PanelCaption}, iteration_{this.Thing.IterationSetup.IterationNumber}";
+            this.ToolTip = $"{((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
             this.ContainedRows = new DisposableReactiveList<IRowViewModelBase<Thing>>();
             this.AddSubscriptions();
             this.UpdateProperties();
         }
-        
+
         /// <summary>
         /// Gets or sets the Contained <see cref="IRowViewModelBase{T}"/>
         /// </summary>
@@ -106,18 +106,15 @@ namespace CDP4EngineeringModel.ViewModels
         /// <summary>
         /// Gets the view model current <see cref="EngineeringModelSetup"/>
         /// </summary>
-        public EngineeringModelSetup CurrentEngineeringModelSetup
-        {
-            get { return (EngineeringModelSetup)this.Thing.IterationSetup.Container; }
-        }
+        public EngineeringModelSetup CurrentEngineeringModelSetup => (EngineeringModelSetup)this.Thing.IterationSetup.Container;
 
         /// <summary>
         /// Gets the current model caption to be displayed in the browser
         /// </summary>
         public string CurrentModel
         {
-            get { return this.currentModel; }
-            private set { this.RaiseAndSetIfChanged(ref this.currentModel, value); }
+            get => this.currentModel;
+            private set => this.RaiseAndSetIfChanged(ref this.currentModel, value);
         }
 
         /// <summary>
@@ -125,8 +122,17 @@ namespace CDP4EngineeringModel.ViewModels
         /// </summary>
         public int CurrentIteration
         {
-            get { return this.currentIteration; }
-            private set { this.RaiseAndSetIfChanged(ref this.currentIteration, value); }
+            get => this.currentIteration;
+            private set => this.RaiseAndSetIfChanged(ref this.currentIteration, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="CreateStoreCommand"/> can be executed
+        /// </summary>
+        public bool CanCreateStore
+        {
+            get => this.canCreateStore;
+            private set => this.RaiseAndSetIfChanged(ref this.canCreateStore, value);
         }
 
         /// <summary>
@@ -134,8 +140,8 @@ namespace CDP4EngineeringModel.ViewModels
         /// </summary>
         public bool CanCreateFolder
         {
-            get { return this.canCreateFolder; }
-            private set { this.RaiseAndSetIfChanged(ref this.canCreateFolder, value); }
+            get => this.canCreateFolder;
+            private set => this.RaiseAndSetIfChanged(ref this.canCreateFolder, value);
         }
 
         /// <summary>
@@ -143,9 +149,14 @@ namespace CDP4EngineeringModel.ViewModels
         /// </summary>
         public bool CanUploadFile
         {
-            get { return this.canUploadFile; }
-            private set { this.RaiseAndSetIfChanged(ref this.canUploadFile, value); }
+            get => this.canUploadFile;
+            private set => this.RaiseAndSetIfChanged(ref this.canUploadFile, value);
         }
+
+        /// <summary>
+        /// Gets the <see cref="ICommand"/> to create a <see cref="DomainFileStore"/>
+        /// </summary>
+        public ReactiveCommand<object> CreateStoreCommand { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ICommand"/> to create a <see cref="Folder"/>
@@ -158,32 +169,18 @@ namespace CDP4EngineeringModel.ViewModels
         public ReactiveCommand<object> UploadFileCommand { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether the <see cref="CreateStoreCommand"/> can be executed
-        /// </summary>
-        public bool CanCreateStore
-        {
-            get { return this.canCreateStore; }
-            private set { this.RaiseAndSetIfChanged(ref this.canCreateStore, value); }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ICommand"/> to create a <see cref="DomainFileStore"/>
-        /// </summary>
-        public ReactiveCommand<object> CreateStoreCommand { get; private set; }
-        
-        /// <summary>
         /// Initializes the <see cref="ICommand"/>s
         /// </summary>
         protected override void InitializeCommands()
         {
             base.InitializeCommands();
             this.CreateFolderCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateFolder));
-            this.CreateFolderCommand.Subscribe(_ => this.ExecuteCreateCommand<Folder>(this.domainFileStoreRow.Thing));
+            this.CreateFolderCommand.Subscribe(_ => this.ExecuteCreateCommand<Folder>(this.SelectedThing.Thing));
 
             this.CreateStoreCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateStore));
-            this.CreateStoreCommand.Subscribe(_ => this.ExecuteCreateCommand<DomainFileStore>(this.Thing.TopContainer));
+            this.CreateStoreCommand.Subscribe(_ => this.ExecuteCreateCommand<DomainFileStore>(this.Thing));
 
-            this.UploadFileCommand = ReactiveCommand.Create();
+            this.UploadFileCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanUploadFile));
             this.UploadFileCommand.Subscribe(_ => this.ExecuteUploadFile());
         }
 
@@ -203,10 +200,12 @@ namespace CDP4EngineeringModel.ViewModels
         public override void ComputePermission()
         {
             base.ComputePermission();
-            this.CanCreateFolder = this.domainFileStoreRow != null &&
-                                   this.PermissionService.CanWrite(ClassKind.Folder, this.domainFileStoreRow.Thing);
 
-            this.CanCreateStore = this.domainFileStoreRow == null;
+            var isContainer = this.SelectedThing?.Thing is DomainFileStore || this.SelectedThing?.Thing is Folder;
+
+            this.CanCreateStore = this.PermissionService.CanWrite(ClassKind.DomainFileStore, this.Thing.Container);
+            this.CanCreateFolder = isContainer && this.PermissionService.CanWrite(ClassKind.Folder, this.SelectedThing.Thing);
+            this.CanUploadFile = isContainer && this.PermissionService.CanWrite(ClassKind.File, this.SelectedThing.Thing);
         }
 
         /// <summary>
@@ -215,7 +214,7 @@ namespace CDP4EngineeringModel.ViewModels
         public override void PopulateContextMenu()
         {
             base.PopulateContextMenu();
-            
+
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Folder", "", this.CreateFolderCommand, MenuItemKind.Create, ClassKind.Folder));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Domain File Store", "", this.CreateStoreCommand, MenuItemKind.Create, ClassKind.DomainFileStore));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Upload a File to the File Store", "", this.UploadFileCommand, MenuItemKind.Create, ClassKind.File));
@@ -230,39 +229,53 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
+
             foreach (var row in this.ContainedRows)
             {
                 row.Dispose();
             }
         }
-        
+
         /// <summary>
         /// Update the <see cref="DomainFileStore"/>
         /// </summary>
         private void UpdateFileStoreRows()
         {
-            var updatedStore = ((Iteration)this.Thing).DomainFileStore.FirstOrDefault();
-            if (updatedStore == null)
-            {
-                if (this.domainFileStoreRow != null)
-                {
-                    this.ContainedRows.RemoveAndDispose(this.domainFileStoreRow);
-                    this.domainFileStoreRow = null;
-                }
+            var currentDomainFileStores = this.ContainedRows.Select(x => x.Thing).OfType<DomainFileStore>().ToList();
+            var newDomainFileStores = this.Thing.DomainFileStore.Except(currentDomainFileStores);
+            var oldDomainFileStores = currentDomainFileStores.Except(this.Thing.DomainFileStore);
 
-                return;
+            foreach (var domainFileStore in oldDomainFileStores)
+            {
+                this.RemoveDomainFileStoreRow(domainFileStore);
             }
 
-            if (this.domainFileStoreRow == null)
+            foreach (var domainFileStore in newDomainFileStores)
             {
-                this.domainFileStoreRow = new DomainFileStoreRowViewModel(updatedStore, this.Session, this);
-                this.ContainedRows.Add(this.domainFileStoreRow);
+                this.AddDomainFileStoreRow(domainFileStore);
             }
-            else if (this.domainFileStoreRow.Thing != updatedStore)
+        }
+
+        /// <summary>
+        /// Add the row of the associated <see cref="DomainFileStore"/>
+        /// </summary>
+        /// <param name="domainFileStore">The <see cref="DomainFileStore"/> to add</param>
+        private void AddDomainFileStoreRow(DomainFileStore domainFileStore)
+        {
+            this.ContainedRows.Add(new DomainFileStoreRowViewModel(domainFileStore, this.Session, this));
+        }
+
+        /// <summary>
+        /// Remove the row of the associated <see cref="DomainFileStore"/>
+        /// </summary>
+        /// <param name="domainFileStore">The <see cref="DomainFileStore"/> to remove</param>
+        private void RemoveDomainFileStoreRow(DomainFileStore domainFileStore)
+        {
+            var row = this.ContainedRows.SingleOrDefault(x => x.Thing == domainFileStore);
+
+            if (row != null)
             {
-                this.domainFileStoreRow.Dispose();
-                this.domainFileStoreRow = new DomainFileStoreRowViewModel(updatedStore, this.Session, this);
-                this.ContainedRows.Add(this.domainFileStoreRow);
+                this.ContainedRows.RemoveAndDispose(row);
             }
         }
 
@@ -272,27 +285,31 @@ namespace CDP4EngineeringModel.ViewModels
         private void AddSubscriptions()
         {
             var engineeringModelSetupSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.CurrentEngineeringModelSetup)
-                .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber)
+                .Where(objectChange => (objectChange.EventKind == EventKind.Updated) && (objectChange.ChangedThing.RevisionNumber > this.RevisionNumber))
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateProperties());
+
             this.Disposables.Add(engineeringModelSetupSubscription);
 
             var domainOfExpertiseSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(typeof(DomainOfExpertise))
-                .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber && objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                .Where(objectChange => (objectChange.EventKind == EventKind.Updated) && (objectChange.ChangedThing.RevisionNumber > this.RevisionNumber) && (objectChange.ChangedThing.Cache == this.Session.Assembler.Cache))
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateProperties());
+
             this.Disposables.Add(domainOfExpertiseSubscription);
 
             var iterationSetupSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.Thing.IterationSetup)
-                .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber)
+                .Where(objectChange => (objectChange.EventKind == EventKind.Updated) && (objectChange.ChangedThing.RevisionNumber > this.RevisionNumber))
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateProperties());
+
             this.Disposables.Add(iterationSetupSubscription);
 
             var modelSubscription = CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.Thing.Container)
-                .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.RevisionNumber > this.RevisionNumber)
+                .Where(objectChange => (objectChange.EventKind == EventKind.Updated) && (objectChange.ChangedThing.RevisionNumber > this.RevisionNumber))
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateProperties());
+
             this.Disposables.Add(modelSubscription);
         }
 
@@ -305,15 +322,16 @@ namespace CDP4EngineeringModel.ViewModels
             this.CurrentIteration = this.Thing.IterationSetup.IterationNumber;
 
             var iterationDomainPair = this.Session.OpenIterations.SingleOrDefault(x => x.Key == this.Thing);
+
             if (iterationDomainPair.Equals(default(KeyValuePair<Iteration, Tuple<DomainOfExpertise, Participant>>)))
             {
                 this.DomainOfExpertise = "None";
             }
             else
             {
-                this.DomainOfExpertise = (iterationDomainPair.Value == null || iterationDomainPair.Value.Item1 == null)
+                this.DomainOfExpertise = (iterationDomainPair.Value == null) || (iterationDomainPair.Value.Item1 == null)
                     ? "None"
-                    : string.Format("{0} [{1}]", iterationDomainPair.Value.Item1.Name, iterationDomainPair.Value.Item1.ShortName);
+                    : $"{iterationDomainPair.Value.Item1.Name} [{iterationDomainPair.Value.Item1.ShortName}]";
             }
 
             this.UpdateFileStoreRows();
@@ -325,18 +343,19 @@ namespace CDP4EngineeringModel.ViewModels
         private void ExecuteUploadFile()
         {
             var result = this.fileDialogService.GetSaveFileDialog(string.Empty, string.Empty, string.Empty, string.Empty, 1);
+
             if (string.IsNullOrEmpty(result))
             {
                 return;
             }
 
             // TODO on Task T1250: Replace the following 3 lines with an actual call to the server to upload the file 
-            var uploadedFile = new File();
-            var participant = new Participant { Person = new Person() };
-            var fileRevision = new FileRevision { Creator = participant };
-            uploadedFile.FileRevision.Add(fileRevision);
-            var uploadedRow = new DomainFileStoreRowViewModel(((Iteration)this.Thing).DomainFileStore.FirstOrDefault(), this.Session, this.domainFileStoreRow);
-            this.ContainedRows.Add(uploadedRow);
+            //var uploadedFile = new File();
+            //var participant = new Participant { Person = new Person() };
+            //var fileRevision = new FileRevision { Creator = participant };
+            //uploadedFile.FileRevision.Add(fileRevision);
+            //var uploadedRow = new DomainFileStoreRowViewModel(((Iteration)this.Thing).DomainFileStore.FirstOrDefault(), this.Session, this.domainFileStoreRow);
+            //this.ContainedRows.Add(uploadedRow);
         }
     }
 }

--- a/EngineeringModel/Views/Dialogs/DomainFileStoreDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/DomainFileStoreDialog.xaml
@@ -1,0 +1,37 @@
+﻿<dx:DXWindow x:Class="CDP4EngineeringModel.Views.Dialogs.DomainFileStoreDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             xmlns:items="clr-namespace:CDP4CommonView.Items;assembly=CDP4CommonView"
+             xmlns:lc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
+             Height="410.405"
+             Width="500"
+             navigation:DialogCloser.DialogResult="{Binding DialogResult}"
+             mc:Ignorable="d">
+    <dx:DXWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/ErrorTemplate.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </dx:DXWindow.Resources>
+    <lc:LayoutGroup Margin="5"
+                    Orientation="Vertical"
+                    ScrollBars="None">
+        <lc:LayoutGroup Margin="-10,-7,-10,-5"
+                        Orientation="Vertical"
+                        View="Tabs"
+                        lc:LayoutControl.AllowHorizontalSizing="True">
+            <lc:LayoutGroup Header="Basic" Orientation="Vertical">
+                <items:NameLayoutItem />
+                <items:OwnerLayoutItem />
+            </lc:LayoutGroup>
+            <items:AdvancedLayoutGroup />
+        </lc:LayoutGroup>
+        <items:UserValidationButtonsLayoutGroup />
+        <items:ErrorMessageLayoutGroup />
+    </lc:LayoutGroup>
+</dx:DXWindow>

--- a/EngineeringModel/Views/Dialogs/DomainFileStoreDialog.xaml.cs
+++ b/EngineeringModel/Views/Dialogs/DomainFileStoreDialog.xaml.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------------------------------------------
+// <copyright file="DomainFileStoreDialog.xaml.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Views.Dialogs
+{
+    using CDP4Common.CommonData;
+
+    using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
+
+    /// <summary>
+    /// Interaction logic for DomainFileStoreDialog
+    /// </summary>
+    [ThingDialogViewExport(ClassKind.DomainFileStore)]
+    public partial class DomainFileStoreDialog : IThingDialogView
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainFileStoreDialog"/> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is used by MEF to instation the view. The view is instantiated to enable navigation using the <see cref="IThingDialogNavigationService"/>
+        /// </remarks>
+        public DomainFileStoreDialog()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainFileStoreDialog"/> class.
+        /// </summary>
+        /// <param name="initializeComponent">
+        /// a value indicating whether the contained Components shall be loaded
+        /// </param>
+        /// <remarks>
+        /// This constructor is called by the <see cref="IThingDialogNavigationService"/>.
+        /// </remarks>
+        public DomainFileStoreDialog(bool initializeComponent)
+        {
+            if (initializeComponent)
+            {
+                this.InitializeComponent();
+            }
+        }
+    }
+}

--- a/EngineeringModel/Views/Dialogs/DomainFileStoreDialog.xaml.cs
+++ b/EngineeringModel/Views/Dialogs/DomainFileStoreDialog.xaml.cs
@@ -1,8 +1,28 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreDialog.xaml.cs" company="RHEA System S.A.">
-//   Copyright (c) 2020 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// ------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.Views.Dialogs
 {

--- a/EngineeringModel/Views/Dialogs/FolderDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/FolderDialog.xaml
@@ -1,0 +1,37 @@
+﻿<dx:DXWindow x:Class="CDP4EngineeringModel.Views.Dialogs.FolderDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             xmlns:items="clr-namespace:CDP4CommonView.Items;assembly=CDP4CommonView"
+             xmlns:lc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
+             Height="410.405"
+             Width="500"
+             navigation:DialogCloser.DialogResult="{Binding DialogResult}"
+             mc:Ignorable="d">
+    <dx:DXWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4CommonView;component/Resources/ErrorTemplate.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </dx:DXWindow.Resources>
+    <lc:LayoutGroup Margin="5"
+                    Orientation="Vertical"
+                    ScrollBars="None">
+        <lc:LayoutGroup Margin="-10,-7,-10,-5"
+                        Orientation="Vertical"
+                        View="Tabs"
+                        lc:LayoutControl.AllowHorizontalSizing="True">
+            <lc:LayoutGroup Header="Basic" Orientation="Vertical">
+                <items:NameLayoutItem />
+                <items:OwnerLayoutItem />
+            </lc:LayoutGroup>
+            <items:AdvancedLayoutGroup />
+        </lc:LayoutGroup>
+        <items:UserValidationButtonsLayoutGroup />
+        <items:ErrorMessageLayoutGroup />
+    </lc:LayoutGroup>
+</dx:DXWindow>

--- a/EngineeringModel/Views/Dialogs/FolderDialog.xaml.cs
+++ b/EngineeringModel/Views/Dialogs/FolderDialog.xaml.cs
@@ -1,8 +1,28 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FolderDialog.xaml.cs" company="RHEA System S.A.">
-//   Copyright (c) 2020 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Merlin Bieze, Naron Phou, Patxi Ozkoidi, Alexander van Delft, Mihail Militaru
+//            Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// ------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.Views.Dialogs
 {

--- a/EngineeringModel/Views/Dialogs/FolderDialog.xaml.cs
+++ b/EngineeringModel/Views/Dialogs/FolderDialog.xaml.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------------------------------------------
+// <copyright file="FolderDialog.xaml.cs" company="RHEA System S.A.">
+//   Copyright (c) 2020 RHEA System S.A.
+// </copyright>
+// ------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Views.Dialogs
+{
+    using CDP4Common.CommonData;
+
+    using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
+
+    /// <summary>
+    /// Interaction logic for DomainFileStoreDialog
+    /// </summary>
+    [ThingDialogViewExport(ClassKind.Folder)]
+    public partial class FolderDialog : IThingDialogView
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FolderDialog"/> class.
+        /// </summary>
+        /// <remarks>
+        /// This constructor is used by MEF to instation the view. The view is instantiated to enable navigation using the <see cref="IThingDialogNavigationService"/>
+        /// </remarks>
+        public FolderDialog()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainFileStoreDialog"/> class.
+        /// </summary>
+        /// <param name="initializeComponent">
+        /// a value indicating whether the contained Components shall be loaded
+        /// </param>
+        /// <remarks>
+        /// This constructor is called by the <see cref="IThingDialogNavigationService"/>.
+        /// </remarks>
+        public FolderDialog(bool initializeComponent)
+        {
+            if (initializeComponent)
+            {
+                this.InitializeComponent();
+            }
+        }
+    }
+}

--- a/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowserRibbon.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/DomainFileStoreBrowserRibbon.xaml
@@ -10,7 +10,7 @@
                                 ContainerRegionName="{x:Static cdp4Composition:RegionNames.ModelRibbonPageRegion}"
                                 MergeOrder="70"
                                 ShowCaptionButton="False"
-                                IsVisible="False">
+                                IsVisible="True">
     <dxr:RibbonPageGroup.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
- DomainFileStore button is visible again in Model tab.
- Add / Edit / Remove DomainFileStore is now possible.
- Add / Remove Folder is now possible, but only for folders directly under DomainFileStore. Not the nested Folders.
- Added unit tests for new files, not for existing (separate issue).