### PR TITLE
Server-returns-internal-exception-when-performing-a-revision-parameter fixes; fixes #106

### DIFF
--- a/CDP4Dashboard/ViewModels/Widget/IterationTrackParameterViewModel.cs
+++ b/CDP4Dashboard/ViewModels/Widget/IterationTrackParameterViewModel.cs
@@ -197,6 +197,11 @@ namespace CDP4Dashboard.ViewModels.Widget
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(async _ => await this.RefreshData()));
 
+            CDPMessageBus.Current.Listen<ObjectChangedEvent>(this.iterationTrackParameter.ParameterOrOverride)
+                .Where(objectChange => objectChange.EventKind == EventKind.Removed)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(async _ => await this.OnDeleteCommand.ExecuteAsyncTask());
+
             this.OnRefreshCommand.Execute(null);
         }
 


### PR DESCRIPTION
…r-no-longer-exists; fixes #106

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
I added listener to the MessageBus, that trigger when parameter change.
<!-- Thanks for contributing to CDP4-IME! -->

