### PR TITLE
The definition class contains the note and example that cannot be ordered on defined things; fixes #385

### DIFF
--- a/CDP4CommonView.Tests/ViewModels/DefinitionDialogViewModelTestFixture.cs
+++ b/CDP4CommonView.Tests/ViewModels/DefinitionDialogViewModelTestFixture.cs
@@ -1,6 +1,25 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="DefinitionDialogViewModelTestFixture.cs" company="RHEA System S.A.">
-//   Copyright (c) 2016 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // ------------------------------------------------------------------------------------------------
 
@@ -149,6 +168,49 @@ namespace CDP4CommonView.Tests
             transaction.CreateOrUpdate(clone);
             
             Assert.DoesNotThrow(() => new DefinitionDialogViewModel(definition, transaction, this.session.Object, true, ThingDialogKind.Create, null, clone, null));
+        }
+
+        [Test]
+        public void VerifyMoveUpAndMoveDownDefinitionDialogViewModel()
+        {
+            var group = new RequirementsGroup(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.assembler.Cache.TryAdd(new CacheKey(group.Iid, null), new Lazy<Thing>(() => group));
+
+            var clone = group.Clone(false);
+            clone.Definition.Add(this.simpleDefinition);
+
+            this.transaction.CreateOrUpdate(clone);
+
+            this.viewmodel = new DefinitionDialogViewModel(this.simpleDefinition, this.transaction, this.session.Object, true, ThingDialogKind.Create, null, clone, null);
+            Assert.IsNotNull(this.viewmodel);
+
+            //Test Note features
+            this.viewmodel.CreateNoteCommand.Execute(null);
+            this.viewmodel.CreateNoteCommand.Execute(null);
+            this.viewmodel.CreateNoteCommand.Execute(null);
+            Assert.AreEqual(this.viewmodel.Note.Count, 4);
+            this.viewmodel.SelectedNote = this.viewmodel.Note[1];
+            Assert.IsTrue(this.viewmodel.SelectedNote.Value.Equals(this.viewmodel.Note[1].Value));
+            this.viewmodel.MoveUpNoteCommand.Execute(null);
+            Assert.IsTrue(this.viewmodel.SelectedNote.Value.Equals(this.viewmodel.Note[0].Value));
+            this.viewmodel.MoveDownNoteCommand.Execute(null);
+            this.viewmodel.MoveDownNoteCommand.Execute(null);
+            Assert.IsTrue(this.viewmodel.SelectedNote.Value.Equals(this.viewmodel.Note[2].Value));
+            this.viewmodel.DeleteNoteCommand.Execute(null);
+            Assert.AreEqual(this.viewmodel.Note.Count, 3);
+
+            //Test Example features
+            this.viewmodel.CreateExampleCommand.Execute(null);
+            this.viewmodel.CreateExampleCommand.Execute(null);
+            Assert.AreEqual(this.viewmodel.Example.Count, 3);
+            this.viewmodel.SelectedExample = this.viewmodel.Example[2];
+            Assert.IsTrue(this.viewmodel.SelectedExample.Value.Equals(this.viewmodel.Example[2].Value));
+            this.viewmodel.MoveUpExampleCommand.Execute(null);
+            Assert.IsTrue(this.viewmodel.SelectedExample.Value.Equals(this.viewmodel.Example[1].Value));
+            this.viewmodel.MoveDownExampleCommand.Execute(null);
+            Assert.IsTrue(this.viewmodel.SelectedExample.Value.Equals(this.viewmodel.Example[2].Value));
+            this.viewmodel.DeleteExampleCommand.Execute(null);
+            Assert.AreEqual(this.viewmodel.Example.Count, 2);
         }
     }
 }

--- a/CDP4CommonView/AutoGenDialogViewModel/DefinitionDialogViewModel.cs
+++ b/CDP4CommonView/AutoGenDialogViewModel/DefinitionDialogViewModel.cs
@@ -238,10 +238,37 @@ namespace CDP4CommonView
             clone.Content = this.Content;
             clone.Note.Clear();
             clone. Note.AddOrderedItems(this.Note.Select(x => new OrderedItem { K = x.Index, V = x.Value }));
- 
+            if (!clone.Note.SortedItems.Keys.SequenceEqual(this.Note.Select(x=>x.Index)))
+            {
+                var noteListCount = this.Note.Count;
+                for (var i = 0; i < noteListCount; i++)
+                {
+                    var item = this.Note[i];
+                    var currentIndex = clone.Note.IndexOf(item.Value);
+
+                    if (currentIndex != i)
+                    {
+                        clone.Note.Move(currentIndex, i);
+                    }
+                }
+            }
+
             clone.Example.Clear();
             clone. Example.AddOrderedItems(this.Example.Select(x => new OrderedItem { K = x.Index, V = x.Value }));
- 
+            if (!clone.Example.SortedItems.Keys.SequenceEqual(this.Example.Select(x => x.Index)))
+            {
+                var noteListCount = this.Example.Count;
+                for (var i = 0; i < noteListCount; i++)
+                {
+                    var item = this.Example[i];
+                    var currentIndex = clone.Example.IndexOf(item.Value);
+
+                    if (currentIndex != i)
+                    {
+                        clone.Example.Move(currentIndex, i);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/CDP4CommonView/Items/CitationLayoutGroup.xaml
+++ b/CDP4CommonView/Items/CitationLayoutGroup.xaml
@@ -14,7 +14,7 @@
                   mc:Ignorable="d"
                   VerticalAlignment="Stretch"
                   HorizontalAlignment="Stretch"
-                  Width="500"
+                  Width="525"
                   MaxWidth="1920">
     <dxlc:LayoutGroup.Resources>
         <ResourceDictionary>

--- a/CDP4CommonView/ViewModels/DefinitionDialogViewModel.cs
+++ b/CDP4CommonView/ViewModels/DefinitionDialogViewModel.cs
@@ -1,6 +1,25 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="DefinitionDialogViewModel.cs" company="RHEA S.A.">
-//   Copyright (c) 2015 RHEA S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
 // -------------------------------------------------------------------------------------------------
 
@@ -99,6 +118,16 @@ namespace CDP4CommonView.ViewModels
         public ReactiveCommand<object> DeleteNoteCommand { get; private set; }
 
         /// <summary>
+        /// Gets the move up note command.
+        /// </summary>
+        public ReactiveCommand<object> MoveUpNoteCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the move down note command.
+        /// </summary>
+        public ReactiveCommand<object> MoveDownNoteCommand { get; private set; }
+
+        /// <summary>
         /// Gets the create example command.
         /// </summary>
         public ReactiveCommand<object> CreateExampleCommand { get; private set; }
@@ -107,6 +136,16 @@ namespace CDP4CommonView.ViewModels
         /// Gets the delete example command.
         /// </summary>
         public ReactiveCommand<object> DeleteExampleCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the move up example command.
+        /// </summary>
+        public ReactiveCommand<object> MoveUpExampleCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the move down example command.
+        /// </summary>
+        public ReactiveCommand<object> MoveDownExampleCommand { get; private set; }
 
         /// <summary>
         /// Gets or sets the <see cref="CultureInfo"/> for this definition
@@ -139,11 +178,24 @@ namespace CDP4CommonView.ViewModels
         {
             base.InitializeCommands();
 
+            var canExecuteSelectedMoveNoteCommand = this.WhenAny(vm => vm.SelectedNote, v => v.Value != null && !this.IsReadOnly);
+            var canExecuteSelectedMoveExampleCommand = this.WhenAny(vm => vm.SelectedExample, v => v.Value != null && !this.IsReadOnly);
+
             this.CreateNoteCommand = ReactiveCommand.Create();
             this.CreateNoteCommand.Subscribe(_ => this.ExecuteCreateNoteCommand());
 
             this.DeleteNoteCommand = ReactiveCommand.Create();
             this.DeleteNoteCommand.Subscribe(_ => this.ExecuteDeleteNoteCommand());
+
+            this.MoveUpNoteCommand = ReactiveCommand.Create(canExecuteSelectedMoveNoteCommand);
+            this.MoveUpNoteCommand.Subscribe(_ => this.ExecuteMoveUpCommand(this.Note, this.SelectedNote));
+            this.MoveDownNoteCommand = ReactiveCommand.Create(canExecuteSelectedMoveNoteCommand);
+            this.MoveDownNoteCommand.Subscribe(_ => this.ExecuteMoveDownCommand(this.Note, this.SelectedNote));
+
+            this.MoveUpExampleCommand = ReactiveCommand.Create(canExecuteSelectedMoveExampleCommand);
+            this.MoveUpExampleCommand.Subscribe(_ => this.ExecuteMoveUpCommand(this.Example, this.SelectedExample));
+            this.MoveDownExampleCommand = ReactiveCommand.Create(canExecuteSelectedMoveExampleCommand);
+            this.MoveDownExampleCommand.Subscribe(_ => this.ExecuteMoveDownCommand(this.Example, this.SelectedExample));
 
             this.CreateExampleCommand = ReactiveCommand.Create();
             this.CreateExampleCommand.Subscribe(_ => this.ExecuteCreateExampleCommand());
@@ -300,6 +352,47 @@ namespace CDP4CommonView.ViewModels
             {
                 this.RaiseAndSetIfChanged(ref this.selectedExample, value);
             }
+        }
+
+        /// <summary>
+        /// Execute the "Move Up" Command which puts a selected item one level up
+        /// </summary>
+        /// <param name="orderedList">
+        /// The list of ordered rows
+        /// </param>
+        /// <param name="selectedItem">
+        /// the row to move
+        /// </param>
+        private void ExecuteMoveUpCommand(ReactiveList<PrimitiveRow<string>> orderedList, PrimitiveRow<string> selectedItem)
+        {
+            var selectedIndex = orderedList.IndexOf(selectedItem);
+
+            if (selectedIndex == 0)
+            {
+                return;
+            }
+
+            orderedList.Move(selectedIndex, selectedIndex - 1);
+        }
+
+        /// <summary>
+        /// Execute the "Move Down" Command which puts a selected item one level down
+        /// </summary>
+        /// <param name="orderedList">
+        /// The list of ordered rows
+        /// </param>
+        /// <param name="selectedItem">
+        /// the row to move
+        /// </param>
+        protected void ExecuteMoveDownCommand(ReactiveList<PrimitiveRow<string>> orderedList, PrimitiveRow<string> selectedItem)
+        {
+            var selectedIndex = orderedList.IndexOf(selectedItem);
+            if (selectedIndex == orderedList.Count - 1)
+            {
+                return;
+            }
+
+            orderedList.Move(selectedIndex, selectedIndex + 1);
         }
     }
 }

--- a/CDP4CommonView/Views/DefinitionDialog.xaml
+++ b/CDP4CommonView/Views/DefinitionDialog.xaml
@@ -58,10 +58,17 @@
             </dxlc:LayoutGroup>
 
             <items:CitationLayoutGroup />
-            
-            <dxlc:LayoutGroup Header="Note" Orientation="Vertical">
+
+            <dxlc:LayoutGroup Header="Note" 
+                              Orientation="Vertical" 
+                              Width="Auto"
+                              Height="Auto"
+                              MaxWidth="525"
+                              MaxHeight="350"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch">
                 <dxlc:LayoutItem>
-                    <dxb:ToolBarControl Height="30" Width="480" Background="Transparent">
+                    <dxb:ToolBarControl Height="30" Background="Transparent">
                         <dxb:BarButtonItem x:Name="CreateNoteButton"
                                                Command="{Binding CreateNoteCommand}"
                                                Glyph="{dx:DXImage Image=Add_16x16.png}"
@@ -86,7 +93,7 @@
                 </dxlc:LayoutItem>
 
                 <dxlc:LayoutItem>
-                    <dxg:GridControl Height="250" Width="480"
+                    <dxg:GridControl Height="250" 
                                          AllowLiveDataShaping="False"
                                          ItemsSource="{Binding Note}"
                                          SelectedItem="{Binding SelectedNote,
@@ -117,9 +124,16 @@
                 </dxlc:LayoutItem>
             </dxlc:LayoutGroup>
 
-            <dxlc:LayoutGroup Header="Example" Orientation="Vertical" >
+            <dxlc:LayoutGroup Header="Example" 
+                              Orientation="Vertical" 
+                              Width="Auto"
+                              Height="Auto"
+                              MaxWidth="525"
+                              MaxHeight="350"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch">
                 <dxlc:LayoutItem>
-                    <dxb:ToolBarControl Height="30" Width="480" Background="Transparent">
+                    <dxb:ToolBarControl Height="30" Background="Transparent">
                         <dxb:BarButtonItem x:Name="CreateExampleButton"
                                                Command="{Binding CreateExampleCommand}"
                                                Glyph="{dx:DXImage Image=Add_16x16.png}"
@@ -144,7 +158,7 @@
                 </dxlc:LayoutItem>
 
                 <dxlc:LayoutItem>
-                    <dxg:GridControl Height="250" Width="480"
+                    <dxg:GridControl Height="250" 
                                          AllowLiveDataShaping="False"
                                          ItemsSource="{Binding Example}"
                                          SelectedItem="{Binding SelectedExample,

--- a/CDP4CommonView/Views/DefinitionDialog.xaml
+++ b/CDP4CommonView/Views/DefinitionDialog.xaml
@@ -70,6 +70,14 @@
                                                Command="{Binding DeleteNoteCommand}"
                                                Glyph="{dx:DXImage Image=Delete_16x16.png}"
                                                Hint="Deprecate the note" />
+                        <dxb:BarButtonItem x:Name="MoveUpNoteButton"
+                                           Command="{Binding MoveUpExampleCommand}"
+                                           Glyph="{dx:DXImage Image=MoveUp_16x16.png}"
+                                           Hint="Move the selected note up" />
+                        <dxb:BarButtonItem x:Name="MoveDownNoteButton"
+                                           Command="{Binding MoveDownExampleCommand}"
+                                           Glyph="{dx:DXImage Image=MoveDown_16x16.png}"
+                                           Hint="Move the selected note down" />
                         <dxb:BarButtonItem x:Name="HelpNoteButton"
                                                Command="{Binding HelpNoteValueCommand}"
                                                Glyph="{dx:DXImage Image=Info_16x16.png}"
@@ -120,6 +128,14 @@
                                                Command="{Binding DeleteExampleCommand}"
                                                Glyph="{dx:DXImage Image=Delete_16x16.png}"
                                                Hint="Deprecate the note" />
+                        <dxb:BarButtonItem x:Name="MoveUpExampleButton"
+                                           Command="{Binding MoveUpExampleCommand}"
+                                           Glyph="{dx:DXImage Image=MoveUp_16x16.png}"
+                                           Hint="Move the selected note up" />
+                        <dxb:BarButtonItem x:Name="MoveDownExampleButton"
+                                           Command="{Binding MoveDownExampleCommand}"
+                                           Glyph="{dx:DXImage Image=MoveDown_16x16.png}"
+                                           Hint="Move the selected note down" />
                         <dxb:BarButtonItem x:Name="HelpExampleButton"
                                                Command="{Binding HelpExampleCommand}"
                                                Glyph="{dx:DXImage Image=Info_16x16.png}"

--- a/CDP4CommonView/Views/DefinitionDialog.xaml
+++ b/CDP4CommonView/Views/DefinitionDialog.xaml
@@ -71,11 +71,11 @@
                                                Glyph="{dx:DXImage Image=Delete_16x16.png}"
                                                Hint="Deprecate the note" />
                         <dxb:BarButtonItem x:Name="MoveUpNoteButton"
-                                           Command="{Binding MoveUpExampleCommand}"
+                                           Command="{Binding MoveUpNoteCommand}"
                                            Glyph="{dx:DXImage Image=MoveUp_16x16.png}"
                                            Hint="Move the selected note up" />
                         <dxb:BarButtonItem x:Name="MoveDownNoteButton"
-                                           Command="{Binding MoveDownExampleCommand}"
+                                           Command="{Binding MoveDownNoteCommand}"
                                            Glyph="{dx:DXImage Image=MoveDown_16x16.png}"
                                            Hint="Move the selected note down" />
                         <dxb:BarButtonItem x:Name="HelpNoteButton"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

- [x] I added arrows buttons that allow to re-order (up and down) note and example properties of the Definition class.
- [x] I added UnitTest and IntegrationTest.

<!-- Thanks for contributing to CDP4-IME! -->

