### PR TITLE
Fixes #454 Added manifest files to installers

### DIFF
--- a/CDP4-CE.sln
+++ b/CDP4-CE.sln
@@ -502,6 +502,7 @@ Global
 		{2EE90906-5978-4C5A-A9BE-1D8FEB5ADCE9}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{2EE90906-5978-4C5A-A9BE-1D8FEB5ADCE9}.Release|Mixed Platforms.Build.0 = Release|x86
 		{2EE90906-5978-4C5A-A9BE-1D8FEB5ADCE9}.Release|x64.ActiveCfg = Release|x64
+		{2EE90906-5978-4C5A-A9BE-1D8FEB5ADCE9}.Release|x64.Build.0 = Release|x64
 		{2EE90906-5978-4C5A-A9BE-1D8FEB5ADCE9}.Release|x86.ActiveCfg = Release|x86
 		{2EE90906-5978-4C5A-A9BE-1D8FEB5ADCE9}.Release|x86.Build.0 = Release|x86
 		{05B9FB71-DFFD-40BC-BF35-F05A1F3CF217}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/CDP4IME/CDP4IME-CE.csproj
+++ b/CDP4IME/CDP4IME-CE.csproj
@@ -12,8 +12,8 @@
     <Product>CDP4IME</Product>
     <Description>The CDP4 Integrated Modelling Environment</Description>
     <Copyright>Copyright © RHEA System S.A</Copyright>
-    <AssemblyVersion>6.0.0.2</AssemblyVersion>
-    <FileVersion>6.0.0.2</FileVersion>
+    <AssemblyVersion>6.0.0.3</AssemblyVersion>
+    <FileVersion>6.0.0.3</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>

--- a/CDP4IMEInstaller/BasicRDLPlugin.wxs
+++ b/CDP4IMEInstaller/BasicRDLPlugin.wxs
@@ -5,9 +5,15 @@
 
 	<Fragment>
     <ComponentGroup Id="BASICRDL_CG" Directory="BASICRDL">
+
       <Component Id="comp_BasicRdl" Guid="{DE37D6B6-D60F-4B4C-B8A5-537A9FCBDF02}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_BasicRdl"  Vital="yes" Source="$(var.BasicRdl.TargetPath)" KeyPath="yes"></File>
        </Component>
+
+      <Component Id="comp_Manifest_CDP4BasicRdl" Guid="{E9116DD9-A23B-4AA8-A681-5E2473622282}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4BasicRdl"  Vital="yes" Source="$(var.BasicRdl.TargetDir)CDP4BasicRdl.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
 	</Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4Budget.wxs
+++ b/CDP4IMEInstaller/CDP4Budget.wxs
@@ -5,9 +5,15 @@
 
   <Fragment>
     <ComponentGroup Id="BUDGET_CG" Directory="BUDGET">
+
       <Component Id="comp_Budget" Guid="{22399B02-D4D4-4726-8869-5D8BB9E81722}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_Budget"  Vital="yes" Source="$(var.CDP4Budget.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4BudgetViewer" Guid="{707EEFAA-4B88-40AF-B6C2-69D1708628A2}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4BudgetViewer"  Vital="yes" Source="$(var.CDP4Budget.TargetDir)CDP4BudgetViewer.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
 	</Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4BuiltInRules.wxs
+++ b/CDP4IMEInstaller/CDP4BuiltInRules.wxs
@@ -5,9 +5,15 @@
 
   <Fragment>
     <ComponentGroup Id="BUILTINRULES_CG" Directory="BUILTINRULES">
+
       <Component Id="comp_BUILTINRULES" Guid="{B659E6A2-2BB3-48EC-BCC5-A4386413EA8E}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_BUILTINRULES"  Vital="yes" Source="$(var.CDP4BuiltInRules.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4BuiltInRules" Guid="{8979D499-C709-47A5-9F4F-844835EBB86A}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4BuiltInRules"  Vital="yes" Source="$(var.CDP4BuiltInRules.TargetDir)CDP4BuiltInRules.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4Dashboard.wxs
+++ b/CDP4IMEInstaller/CDP4Dashboard.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_CDP4Dashboard"  Vital="yes" Source="$(var.CDP4Dashboard.TargetPath)" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4Dashboard" Guid="{200B1D2F-8818-4E63-A4DD-3069F37D3F84}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4Dashboard"  Vital="yes" Source="$(var.CDP4Dashboard.TargetDir)CDP4Dashboard.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4JsonFileDalPlugin.wxs
+++ b/CDP4IMEInstaller/CDP4JsonFileDalPlugin.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_CDP4JsonFileDal"  Vital="yes" Source="$(var.CDP4JsonFileDal.TargetDir)CDP4JsonFileDal.dll" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4JsonFileDal" Guid="{B392D068-7870-427E-A186-468731AAF7CC}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4JsonFileDal"  Vital="yes" Source="$(var.CDP4JsonFileDal.TargetDir)CDP4JsonFileDalPlugin.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
       <Component Id="comp_ionicZip" Guid="{B3614A66-1BFF-47D9-A8E4-1B440172D18E}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_IonicZip" Vital="yes" Source="$(var.CDP4JsonFileDal.TargetDir)DotNetZip.dll" KeyPath="yes" />
       </Component>

--- a/CDP4IMEInstaller/CDP4LogInfoPlugin.wxs
+++ b/CDP4IMEInstaller/CDP4LogInfoPlugin.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_CDP4LogInfo"  Vital="yes" Source="$(var.CDP4LogInfo.TargetPath)" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4LogInfo" Guid="{489E1F02-1627-489C-8CBF-A8D199CA523E}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4LogInfo"  Vital="yes" Source="$(var.CDP4LogInfo.TargetDir)CDP4LogInfo.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
       <Component Id="comp_CDP4LogInfo_csvhelper" Guid="{873A7341-472F-4FA5-AC53-FA7EC8C2F102}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_CDP4LogInfo_csvhelper" Vital="yes" Source="$(var.CDP4LogInfo.TargetDir)CsvHelper.dll" KeyPath="yes" />
       </Component>

--- a/CDP4IMEInstaller/CDP4ObjectBrowserPlugin.wxs
+++ b/CDP4IMEInstaller/CDP4ObjectBrowserPlugin.wxs
@@ -5,9 +5,15 @@
 
   <Fragment>
     <ComponentGroup Id="OBJECTBROWSER_CG" Directory="OBJECTBROWSER">
+
       <Component Id="comp_ObjectBrowser" Guid="{719F4DCB-3ED3-4E6D-99FC-3FAC87742536}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_ObjectBrowser"  Vital="yes" Source="$(var.CDP4ObjectBrowser.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4ObjectBrowser" Guid="{54F6E002-F46C-4378-BD3D-C5B59F95E2E1}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4ObjectBrowser"  Vital="yes" Source="$(var.CDP4ObjectBrowser.TargetDir)CDP4ObjectBrowser.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4PropertyGridPlugin.wxs
+++ b/CDP4IMEInstaller/CDP4PropertyGridPlugin.wxs
@@ -5,9 +5,15 @@
   
   <Fragment>
     <ComponentGroup Id="PROPERTYGRID_CG" Directory="PROPERTYGRID">
+
       <Component Id="comp_CDP4PropertyGrid" Guid="{527C1073-3EFD-495F-A2F5-2AAD7BFDDC8D}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_CDP4PropertyGrid"  Vital="yes" Source="$(var.CDP4PropertyGrid.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4PropertyGrid" Guid="{7391CC18-EA96-4542-846F-295A565529B2}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4PropertyGrid"  Vital="yes" Source="$(var.CDP4PropertyGrid.TargetDir)CDP4PropertyGrid.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4RelationshipEditor.wxs
+++ b/CDP4IMEInstaller/CDP4RelationshipEditor.wxs
@@ -5,9 +5,15 @@
 
   <Fragment>
     <ComponentGroup Id="RELATIONSHIPEDITOR_CG" Directory="RELATIONSHIPEDITOR">
+
       <Component Id="comp_RELATIONSHIPEDITOR" Guid="{513166CE-2407-4201-B02E-78201A247741}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_RELATIONSHIPEDITOR"  Vital="yes" Source="$(var.CDP4RelationshipEditor.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4RelationshipEditor" Guid="{F04E06AB-A1C5-4B8B-BCE6-6137C04148FF}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4RelationshipEditor"  Vital="yes" Source="$(var.CDP4RelationshipEditor.TargetDir)CDP4RelationshipEditor.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4RelationshipMatrix.wxs
+++ b/CDP4IMEInstaller/CDP4RelationshipMatrix.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_RelationshipMatrix"  Vital="yes" Source="$(var.CDP4RelationshipMatrix.TargetPath)" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4RelationshipMatrix" Guid="{0651E705-556A-4BCE-9327-1B1B50D78A0F}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4RelationshipMatrix"  Vital="yes" Source="$(var.CDP4RelationshipMatrix.TargetDir)CDP4RelationshipMatrix.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
       <Component Id="comp_RelationshipMatrix_csvhelper" Guid="{27D4ACFF-E6FF-48C7-B7A0-6C3D4160AA13}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_RelationshipMatrix_csvhelper" Vital="yes" Source="$(var.CDP4RelationshipMatrix.TargetDir)CsvHelper.dll" KeyPath="yes" />
       </Component>

--- a/CDP4IMEInstaller/CDP4Scripting.wxs
+++ b/CDP4IMEInstaller/CDP4Scripting.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_CDP4Scripting"  Vital="yes" Source="$(var.CDP4Scripting.TargetPath)" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4Scripting" Guid="{6BEB2F67-845B-473C-9DCA-9796CC1E33B8}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4Scripting"  Vital="yes" Source="$(var.CDP4Scripting.TargetDir)CDP4Scripting.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
       <Component Id="comp_avalonedit" Guid="{93A09AF1-FF5D-4413-A039-610711F2216D}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_avalonedit" Vital="yes" Source="$(var.CDP4Scripting.TargetDir)ICSharpCode.AvalonEdit.dll" KeyPath="yes" />
       </Component>

--- a/CDP4IMEInstaller/CDP4ServicesDal.wxs
+++ b/CDP4IMEInstaller/CDP4ServicesDal.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_CDP4ServicesDal"  Vital="yes" Source="$(var.CDP4ServicesDal.TargetDir)CDP4ServicesDal.dll" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4ServicesDal" Guid="{6F6CACE5-8D5E-4791-91A3-F587AAE5DA58}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4ServicesDal"  Vital="yes" Source="$(var.CDP4ServicesDal.TargetDir)CDP4ServicesDalPlugin.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4SiteDirectoryPlugin.wxs
+++ b/CDP4IMEInstaller/CDP4SiteDirectoryPlugin.wxs
@@ -5,9 +5,15 @@
 
   <Fragment>
     <ComponentGroup Id="SITEDIRECTORY_CG" Directory="SITEDIRECTORY">
+
       <Component Id="comp_SiteDirectory" Guid="{AD413BF5-39B6-47F2-A61D-D3C7F7A673BA}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_SiteDirectory"  Vital="yes" Source="$(var.CDP4SiteDirectory.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4SiteDirectory" Guid="{550CCEC3-E0B2-4D50-BA4E-63F5454593F6}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4SiteDirectory"  Vital="yes" Source="$(var.CDP4SiteDirectory.TargetDir)CDP4SiteDirectory.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/CDP4WspDalPlugin.wxs
+++ b/CDP4IMEInstaller/CDP4WspDalPlugin.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_CDP4WspDal"  Vital="yes" Source="$(var.CDP4WspDal.TargetDir)CDP4WspDal.dll" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4WspDal" Guid="{C85AD485-3992-4662-9213-1A85821471B2}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4WspDal"  Vital="yes" Source="$(var.CDP4WspDal.TargetDir)CDP4WspDalPlugin.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/EngineeringModelPlugin.wxs
+++ b/CDP4IMEInstaller/EngineeringModelPlugin.wxs
@@ -5,9 +5,15 @@
 
   <Fragment>
     <ComponentGroup Id="ENGINEERINGMODEL_CG" Directory="ENGINEERINGMODEL">
+      
       <Component Id="comp_EngineeringModel" Guid="{6FBD347F-FE92-4A1C-9FCD-5AF3900F60E7}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_EngineeringModel"  Vital="yes" Source="$(var.EngineeringModel.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4EngineeringModel" Guid="{AB268318-CCFD-4EAD-BEBD-DF648752AAF9}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4EngineeringModel"  Vital="yes" Source="$(var.EngineeringModel.TargetDir)CDP4EngineeringModel.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/ParameterSheetGeneratorPlugin.wxs
+++ b/CDP4IMEInstaller/ParameterSheetGeneratorPlugin.wxs
@@ -8,6 +8,11 @@
       <Component Id="comp_ParameterSheetGenerator" Guid="{6D18C516-993E-4C05-A9FF-045FDA734439}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_ParameterSheetGenerator"  Vital="yes" Source="$(var.CDP4ParameterSheetGenerator.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4ParameterSheetGenerator" Guid="{B6DAAA51-1A21-497A-98ED-F15F7DEDA09D}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4ParameterSheetGenerator"  Vital="yes" Source="$(var.CDP4ParameterSheetGenerator.TargetDir)CDP4ParameterSheetGenerator.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/ProductTreePlugin.wxs
+++ b/CDP4IMEInstaller/ProductTreePlugin.wxs
@@ -5,9 +5,15 @@
 
   <Fragment>
     <ComponentGroup Id="PRODUCTTREE_CG" Directory="PRODUCTTREE">
+      
       <Component Id="comp_ProductTree" Guid="{CC2CF0B6-28B8-455F-B155-FF19898E6BB5}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_ProductTree"  Vital="yes" Source="$(var.ProductTree.TargetPath)" KeyPath="yes"></File>
       </Component>
+
+      <Component Id="comp_Manifest_CDP4ProductTree" Guid="{F05EDC78-E8B2-4B2A-A0EB-7D3B5B996D4F}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4ProductTree"  Vital="yes" Source="$(var.ProductTree.TargetDir)CDP4ProductTree.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/CDP4IMEInstaller/RequirementsPlugin.wxs
+++ b/CDP4IMEInstaller/RequirementsPlugin.wxs
@@ -10,6 +10,10 @@
         <File Id="fil_Requirements"  Vital="yes" Source="$(var.Requirements.TargetPath)" KeyPath="yes"></File>
       </Component>
 
+      <Component Id="comp_Manifest_CDP4Requirements" Guid="{4E2B0309-63C7-48BD-A402-922AE0230B96}" Location="local" Win64="$(var.Win64)">
+        <File Id="fil_Manifest_CDP4Requirements"  Vital="yes" Source="$(var.Requirements.TargetDir)CDP4Requirements.plugin.manifest" KeyPath="yes"></File>
+      </Component>
+
       <Component Id="comp_reqif" Guid="{A628AC1E-6361-4294-93DB-068A674EBF40}" Location="local" Win64="$(var.Win64)">
         <File Id="fil_reqif" Vital="yes" Source="$(var.Requirements.TargetDir)ReqIFSharp.dll" KeyPath="yes" />
       </Component>

--- a/CDP4ObjectBrowser/CDP4ObjectBrowser.csproj
+++ b/CDP4ObjectBrowser/CDP4ObjectBrowser.csproj
@@ -32,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <Import Project="..\Plugin.target" />
+  <Import Project="..\Sdk.Plugin.target" />
   <ItemGroup>
     <PackageReference Include="CDP4Common-CE" Version="6.1.1">
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/CDP4PluginPackager.Tests/SdkPluginPackagerTestFixture.cs
+++ b/CDP4PluginPackager.Tests/SdkPluginPackagerTestFixture.cs
@@ -54,8 +54,19 @@ namespace CDP4PluginPackager.Tests
             var testDirectory = Path.Combine(prefix, TargetProject);
             Directory.SetCurrentDirectory(testDirectory);
 
-            this.sdkPluginPackager = new SdkPluginPackager(testDirectory, true, "Debug", "net452");
+            this.sdkPluginPackager = new SdkPluginPackager(testDirectory, true, "Debug", "net452", "AnyCPU");
             this.sdkPluginPackager.Start();
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            var file = Path.Combine(this.sdkPluginPackager.OutputPath, $"{this.sdkPluginPackager.Manifest.Name}.cdp4ck");
+
+            if (File.Exists(file))
+            {
+                File.Delete(file);
+            }
         }
 
         [Test]

--- a/CDP4PluginPackager/BasePluginPackager.cs
+++ b/CDP4PluginPackager/BasePluginPackager.cs
@@ -63,6 +63,11 @@ namespace CDP4PluginPackager
         protected string BuildTargetFramework;
 
         /// <summary>
+        /// The build platform (AnyCpu/x64)
+        /// </summary>
+        protected readonly string BuildPlatform;
+
+        /// <summary>
         /// Contains the plugin name
         /// </summary>
         protected string PluginName;
@@ -89,12 +94,14 @@ namespace CDP4PluginPackager
         /// <param name="shouldPluginGetPacked">state if a plugin needs to be packed in a zip</param>
         /// <param name="buildConfiguration">the current build configuration (Debug/Release)</param>
         /// <param name="buildTargetFramework">The target framework version (net452)</param>
-        protected BasePluginPackager(string path, bool shouldPluginGetPacked, string buildConfiguration = "", string buildTargetFramework = "")
+        /// <param name="buildPlatform">The build platform (AnyCpu/x64)</param>
+        protected BasePluginPackager(string path, bool shouldPluginGetPacked, string buildConfiguration = "", string buildTargetFramework = "", string buildPlatform = "")
         {
             this.Path = path;
             this.ShouldPluginGetPacked = shouldPluginGetPacked;
             this.BuildConfiguration = buildConfiguration;
             this.BuildTargetFramework = buildTargetFramework;
+            this.BuildPlatform = buildPlatform;
         }
 
         /// <summary>

--- a/CDP4PluginPackager/Models/Sdk/PropertyGroup.cs
+++ b/CDP4PluginPackager/Models/Sdk/PropertyGroup.cs
@@ -35,6 +35,12 @@ namespace CDP4PluginPackager.Models.Sdk
     public class PropertyGroup
     {
         /// <summary>
+        /// Gets or Sets the Condition
+        /// </summary>
+        [XmlAttribute(AttributeName = "Condition")]
+        public string Condition { get; set; }
+
+        /// <summary>
         /// Gets or Sets the Project Guid
         /// </summary>
         [XmlElement(ElementName = "ProjectGuid")]

--- a/CDP4PluginPackager/Program.cs
+++ b/CDP4PluginPackager/Program.cs
@@ -57,7 +57,9 @@ namespace CDP4PluginPackager
 
                 var targetFramework = GetTargetFrameworkFromArgs(args);
 
-                var plugingPacker = new SdkPluginPackager(path, shouldPluginGetPacked, buildConfiguration, targetFramework);
+                var buildPlatform = GetBuildPlatformFromArgs(args);
+
+                var plugingPacker = new SdkPluginPackager(path, shouldPluginGetPacked, buildConfiguration, targetFramework, buildPlatform);
 
                 plugingPacker.Start();
             }
@@ -95,6 +97,21 @@ namespace CDP4PluginPackager
             return 
                 targetFrameworkParameterPosition >= 0 
                     ? args[targetFrameworkParameterPosition].Split(new[] { ':' }, StringSplitOptions.None)[1] 
+                    : null;
+        }
+
+        /// <summary>
+        /// Gets the Build Platform (AnyCpu, x86, x64, enz...) from the command line arguments
+        /// </summary>
+        /// <param name="args">The array of command line arguments</param>
+        /// <returns>Build Platform when found in arguments, otherwise null</returns>
+        private static string GetBuildPlatformFromArgs(string[] args)
+        {
+            var buildPlatformParameterPosition = Array.FindIndex(args, x => x.StartsWith("platform:"));
+
+            return
+                buildPlatformParameterPosition >= 0
+                    ? args[buildPlatformParameterPosition].Split(new[] { ':' }, StringSplitOptions.None)[1]
                     : null;
         }
     }

--- a/CDP4PluginPackager/Program.cs
+++ b/CDP4PluginPackager/Program.cs
@@ -27,9 +27,11 @@
 namespace CDP4PluginPackager
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
 
+    [ExcludeFromCodeCoverage]
     internal class Program
     {
         /// <summary>

--- a/CDP4PluginPackager/SdkPluginPackager.cs
+++ b/CDP4PluginPackager/SdkPluginPackager.cs
@@ -29,6 +29,7 @@ namespace CDP4PluginPackager
     using System;
     using System.IO;
     using System.Linq;
+    using System.Windows;
 
     using CDP4PluginPackager.Models.Sdk;
 
@@ -44,7 +45,8 @@ namespace CDP4PluginPackager
         /// <param name="shouldPluginGetPacked">state if a plugin needs to be packed in a zip</param>
         /// <param name="buildConfiguration">the current build configuration (Debug/Release)</param>
         /// <param name="buildTargetFramework">The target framework version (net452)</param>
-        public SdkPluginPackager(string path, bool shouldPluginGetPacked, string buildConfiguration, string buildTargetFramework) : base(path, shouldPluginGetPacked, buildConfiguration, buildTargetFramework)
+        /// <param name="buildPlatform">The build platform (AnyCpu/x64)</param>
+        public SdkPluginPackager(string path, bool shouldPluginGetPacked, string buildConfiguration, string buildTargetFramework, string buildPlatform) : base(path, shouldPluginGetPacked, buildConfiguration, buildTargetFramework, buildPlatform)
         {
         }
 
@@ -58,10 +60,15 @@ namespace CDP4PluginPackager
             this.OutputPath =
                 System.IO.Path.Combine(
                     this.Csproj.PropertyGroup
-                        .First(d => !string.IsNullOrWhiteSpace(d.OutputPath))
+                        .First(d => d.Condition?.Contains($"{this.BuildConfiguration}|{this.BuildPlatform}") ?? false)
                         .OutputPath
                         .Replace("$(Configuration)", this.BuildConfiguration)
                         .Replace("$(TargetFramework)", this.BuildTargetFramework));
+
+            if (this.BuildConfiguration == "Release")
+            {
+                this.OutputPath = System.IO.Path.Combine(this.OutputPath, this.BuildTargetFramework);
+            }
 
             if (!Directory.Exists(this.OutputPath))
             {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,7 @@ test_script:
       -hideskipped:All
       -output:"%TEST_COVERAGE%"
       -filter:"+[CDP4*]* -[*.Tests*]* -[*.Views]*"
+      -excludebyattribute:*.ExcludeFromCodeCoverageAttribute
 after_test:
     - ps: SonarScanner.MSBuild.exe end /d:"sonar.login=$env:SONARCLOUD_TOKEN"
 notifications:

--- a/cdp4ime-tests.nunit
+++ b/cdp4ime-tests.nunit
@@ -23,5 +23,6 @@
     <assembly path="ProductTree.Tests/bin/Debug/net452/ProductTree.Tests.dll" />
     <assembly path="RelationshipMatrix.Tests/bin/Debug/net452/CDP4RelationshipMatrix.Tests.dll" />
     <assembly path="Requirements.Tests/bin/Debug/net452/CDP4Requirements.Tests.dll" />
+    <assembly path="CDP4PluginPackager.Tests/bin/Debug/net452/CDP4Requirements.Tests.dll" />
   </Config>
 </NUnitProject>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Installers contain the manifest now for plugins.