### PR TITLE
Treeview Inline edit while updating fix

### DIFF
--- a/CDP4Composition/Services/GridUpdateService.cs
+++ b/CDP4Composition/Services/GridUpdateService.cs
@@ -1,19 +1,23 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="GridUpdateService.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//   Copyright (c) 2015-2020 RHEA System S.A.
 // </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 
 namespace CDP4Composition.Services
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Windows;
+
     using DevExpress.Xpf.Grid;
+
     using NLog;
 
     /// <summary>
     /// The service used to lock the update of a grid view when update in the view-model are occuring
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class GridUpdateService
     {
         /// <summary>
@@ -30,7 +34,7 @@ namespace CDP4Composition.Services
         /// Sets the <see cref="UpdateStartedProperty"/> property
         /// </summary>
         /// <param name="element">The <see cref="UIElement"/> where the value is set</param>
-        /// <param name="value">The <see cref="Boolean"/> value</param>
+        /// <param name="value">The <see cref="bool"/> value</param>
         public static void SetUpdateStarted(UIElement element, bool? value)
         {
             try
@@ -40,7 +44,7 @@ namespace CDP4Composition.Services
             catch (Exception exception)
             {
                 Logger.Error(exception, $"A problem occurend when SetUpdateStarted was called");
-            }            
+            }
         }
 
         /// <summary>
@@ -61,6 +65,7 @@ namespace CDP4Composition.Services
         private static void UpdateStartedPropertyChanged(DependencyObject source, DependencyPropertyChangedEventArgs e)
         {
             var grid = source as GridDataControlBase;
+
             if (grid == null)
             {
                 throw new InvalidOperationException("The Service can only be used on GridDataControlBase view elements such as GridControl or TreeListControl.");
@@ -75,15 +80,20 @@ namespace CDP4Composition.Services
                 else if ((bool?)e.NewValue == false)
                 {
                     var treeListControl = grid as TreeListControl;
+
                     if (treeListControl != null)
                     {
-                        treeListControl.EndDataUpdate(); 
+                        treeListControl.View.CancelRowEdit();
+                        treeListControl.EndDataUpdate();
                     }
                     else
                     {
                         var gridControl = grid as GridControl;
+
                         if (gridControl != null && gridControl.DataController.IsUpdateLocked)
                         {
+                            // cancel out of any active edit.
+                            gridControl.View.CancelRowEdit();
                             grid.EndDataUpdate();
                         }
                     }

--- a/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementsBrowserViewModel.cs
@@ -510,11 +510,11 @@ namespace CDP4Requirements.ViewModels
             this.CreateRelationshipCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateRelationship));
             this.CreateRelationshipCommand.Subscribe(_ => this.ExecuteCreateCommand<BinaryRelationship>(this.Thing));
 
-            this.CreateRequirementGroupCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateRequirement));
+            this.CreateRequirementGroupCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateRequirementGroup));
             this.CreateRequirementGroupCommand.Subscribe(_ =>
                 this.ExecuteCreateCommand<RequirementsGroup>(this.SelectedThing.Thing));
 
-            this.CreateRequirementCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateRequirementGroup));
+            this.CreateRequirementCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateRequirement));
             this.CreateRequirementCommand.Subscribe(_ => this.ExecuteCreateRequirement());
 
             this.VerifyRequirementsCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanVerifyRequirements));

--- a/Requirements/ViewModels/RequirementBrowser/Rows/RequirementContainerRowViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/Rows/RequirementContainerRowViewModel.cs
@@ -243,9 +243,8 @@ namespace CDP4Requirements.ViewModels
         {
             var row = this.ContainedRows.SingleOrDefault(x => x.Thing == group);
 
-            if (row != null)
+            if (row != null && !row.ContainedRows.Any())
             {
-                this.TopParentRow.GroupCache.Remove(group);
                 this.ContainedRows.RemoveAndDispose(row);
             }
         }


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [ ] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
Grid update service commit should fix the inline edit bug by canceling out before tree data is updated.

The requirement groups still do not function the way they supposed to in case of nested groups. Still needs fixing.

