### PR TITLE
Sorting fixed not to cause crash in frozen iteration and handling of negative values; fixes #509 and fixes #511

### DIFF
--- a/CDP4Dashboard/ViewModels/Widget/IterationTrackParameterViewModel.cs
+++ b/CDP4Dashboard/ViewModels/Widget/IterationTrackParameterViewModel.cs
@@ -448,7 +448,7 @@ namespace CDP4Dashboard.ViewModels.Widget
                                     RevisionNumber = y.RevisionNumber
                                 }
                             ))
-                    .OrderBy(x => x.ParameterOrOverride)
+                    .OrderBy(x => x.ParameterOrOverride?.UserFriendlyShortName ?? "")
                     .ThenBy(x => x.RevisionNumber)
                     .ThenBy(x => x.Option?.Name ?? "")
                     .ThenBy(x => x.ActualFiniteState?.Name ?? "")
@@ -460,7 +460,7 @@ namespace CDP4Dashboard.ViewModels.Widget
                     x => new Line
                     {
                         RevisionNumber = x.RevisionNumber,
-                        Value = x.Value.First().ToString().Replace("-", "0")
+                        Value = x.Value.First().ToString() == "-" ? "0" : x.Value.First().ToString()
                     },
                     (serie, lines) => new LineSeries
                     {

--- a/CDP4Dashboard/Views/Widget/IterationTrackParameterView.xaml
+++ b/CDP4Dashboard/Views/Widget/IterationTrackParameterView.xaml
@@ -187,8 +187,9 @@
                 </dxch:XYDiagram2D.DefaultPane>
                 <dxch:XYDiagram2D.SeriesItemTemplate>
                     <DataTemplate>
-                        <dxch:LineSeries2D DisplayName="{Binding LineName}"
+                        <dxch:LineStepSeries2D DisplayName="{Binding LineName}"
                                           DataSource="{Binding Lines}"
+                                          
                                           ArgumentDataMember="RevisionNumber"
                                           ValueDataMember="Value"/>
                     </DataTemplate>


### PR DESCRIPTION


### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes crash #511 

Fixes negative values in dashboard #509 

Value graph is not LineStepSeries2D to conform better to the principle of publication.

