### PR TITLE
#507 Return data source result as a DataTable

### DIFF
--- a/CDP4Composition/Reporting/ReportingDataSourceClass.cs
+++ b/CDP4Composition/Reporting/ReportingDataSourceClass.cs
@@ -27,7 +27,6 @@ namespace CDP4Composition.Reporting
 {
     using CDP4Common.EngineeringModelData;
 
-    using System.Collections.Generic;
     using System.Data;
 
     /// <summary>
@@ -38,6 +37,9 @@ namespace CDP4Composition.Reporting
     /// </typeparam>
     public class ReportingDataSourceClass<T> where T : ReportingDataSourceRow, new()
     {
+        /// <summary>
+        /// The <see cref="CategoryHierarchy"/> used for filtering the considered <see cref="ElementBase"/> items.
+        /// </summary>
         private readonly CategoryHierarchy categoryHierarchy;
 
         /// <summary>
@@ -62,16 +64,11 @@ namespace CDP4Composition.Reporting
         }
 
         /// <summary>
-        /// Gets a tabular representation of the hierarhical tree upon which the data source is based.
+        /// Gets a <see cref="DataTable"/> representation of the hierarhical tree upon which the data source is based.
         /// </summary>
         /// <returns>
-        /// The tabular representation.
+        /// The <see cref="DataTable"/>.
         /// </returns>
-        public List<T> GetTabularRepresentation()
-        {
-            return this.topNode.GetTabularRepresentation();
-        }
-
         public DataTable GetTable()
         {
             var table = ReportingDataSourceNode<T>.GetTable(this.categoryHierarchy);

--- a/CDP4Composition/Reporting/ReportingDataSourceClass.cs
+++ b/CDP4Composition/Reporting/ReportingDataSourceClass.cs
@@ -74,17 +74,7 @@ namespace CDP4Composition.Reporting
 
         public DataTable GetTable()
         {
-            var table = new DataTable();
-
-            for (var hierarchy = this.categoryHierarchy; hierarchy != null; hierarchy = hierarchy.Child)
-            {
-                table.Columns.Add(hierarchy.Category.Name, typeof(string));
-            }
-
-            foreach (var publicGetter in ReportingDataSourceNode<T>.PublicGetters)
-            {
-                table.Columns.Add(publicGetter.Name, publicGetter.GetMethod.ReturnType);
-            }
+            var table = ReportingDataSourceNode<T>.GetTable(this.categoryHierarchy);
 
             this.topNode.AddDataRows(table);
 

--- a/CDP4Composition/Reporting/ReportingDataSourceNode.cs
+++ b/CDP4Composition/Reporting/ReportingDataSourceNode.cs
@@ -83,19 +83,19 @@ namespace CDP4Composition.Reporting
             this.ElementBase as ElementUsage;
 
         /// <summary>
-        /// The fully qualified (to the tree root) name of this <see cref="elementBase"/>.
+        /// The fully qualified (to the tree root) name of this <see cref="ElementBase"/>.
         /// </summary>
         private string FullyQualifiedName => (this.parent != null)
             ? this.parent.FullyQualifiedName + "." + this.ElementUsage.ShortName
             : this.ElementDefinition.ShortName;
 
         /// <summary>
-        /// The filtering <see cref="Category"/> that must be matched on the current <see cref="elementBase"/>.
+        /// The filtering <see cref="Category"/> that must be matched on the current <see cref="ElementBase"/>.
         /// </summary>
         private readonly Category filterCategory;
 
         /// <summary>
-        /// Boolean flag indicating whether the current <see cref="elementBase"/> matches the <see cref="filterCategory"/>.
+        /// Boolean flag indicating whether the current <see cref="ElementBase"/> matches the <see cref="filterCategory"/>.
         /// </summary>
         private bool IsVisible =>
             this.ElementBase.Category.Contains(this.filterCategory);

--- a/CDP4Composition/Reporting/ReportingDataSourceNode.cs
+++ b/CDP4Composition/Reporting/ReportingDataSourceNode.cs
@@ -74,7 +74,7 @@ namespace CDP4Composition.Reporting
 
             for (var hierarchy = categoryHierarchy; hierarchy != null; hierarchy = hierarchy.Child)
             {
-                table.Columns.Add(hierarchy.Category.Name, typeof(string));
+                table.Columns.Add(hierarchy.Category.ShortName, typeof(string));
             }
 
             foreach (var publicGetter in PublicGetters)
@@ -274,7 +274,7 @@ namespace CDP4Composition.Reporting
         {
             this.parent?.InitializeCategoryColumns(row);
 
-            row[this.filterCategory.Name] = this.ElementBase.Name;
+            row[this.filterCategory.ShortName] = this.ElementBase.Name;
         }
     }
 }

--- a/CDP4Composition/Reporting/ReportingDataSourceNode.cs
+++ b/CDP4Composition/Reporting/ReportingDataSourceNode.cs
@@ -130,26 +130,7 @@ namespace CDP4Composition.Reporting
 
             this.ElementBase = elementBase;
 
-            this.rowRepresentation = new T
-            {
-                ElementBase = this.ElementBase,
-                ElementName = this.FullyQualifiedName,
-                IsVisible = this.IsVisible
-            };
-
-            if (this.IsVisible)
-            {
-                foreach (var rowField in RowFields)
-                {
-                    var column = rowField.Key
-                        .GetConstructor(Type.EmptyTypes)
-                        .Invoke(new object[] { }) as ReportingDataSourceColumn<T>;
-
-                    column.Initialize(this);
-
-                    rowField.Value.SetValue(this.rowRepresentation, column);
-                }
-            }
+            this.rowRepresentation = this.GetRowRepresentation();
 
             if (categoryHierarchy.Child == null)
             {
@@ -200,6 +181,40 @@ namespace CDP4Composition.Reporting
             }
 
             return tabularRepresentation;
+        }
+
+        /// <summary>
+        /// Gets the tabular representation of this node.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="ReportingDataSourceRow"/>.
+        /// </returns>
+        private T GetRowRepresentation()
+        {
+            var row = new T
+            {
+                ElementBase = this.ElementBase,
+                ElementName = this.FullyQualifiedName,
+                IsVisible = this.IsVisible
+            };
+
+            if (!this.IsVisible)
+            {
+                return row;
+            }
+
+            foreach (var rowField in RowFields)
+            {
+                var column = rowField.Key
+                    .GetConstructor(Type.EmptyTypes)
+                    .Invoke(new object[] { }) as ReportingDataSourceColumn<T>;
+
+                column.Initialize(this);
+
+                rowField.Value.SetValue(row, column);
+            }
+
+            return row;
         }
     }
 }

--- a/CDP4Composition/Reporting/ReportingDataSourceRow.cs
+++ b/CDP4Composition/Reporting/ReportingDataSourceRow.cs
@@ -39,11 +39,6 @@ namespace CDP4Composition.Reporting
         protected internal ElementBase ElementBase { get; internal set; }
 
         /// <summary>
-        /// The Element name, fully qualified with the path to the top element.
-        /// </summary>
-        public string ElementName { get; internal set; }
-
-        /// <summary>
         /// Flag indicating whether the row matches the filtered criteria defined in <see cref="CategoryHierarchy"/>.
         /// Note that when this is false, all values will be null on the row.
         /// </summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
* Return data source result as a DataTable
* Add a column for each category in the filtering hierarchy, the value being the ElementBase name

