### PR TITLE
[Add] GraphExport Plugin

### DIFF
--- a/CDP4-CE.sln
+++ b/CDP4-CE.sln
@@ -118,9 +118,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CDP4Reporting", "CDP4Report
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CDP4Reporting.Tests", "CDP4Reporting.Tests\CDP4Reporting.Tests.csproj", "{04B17D19-509D-4D1C-89FD-8A9213E06117}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CDP4UpdateServerDal", "CDP4UpdateServerDal\CDP4UpdateServerDal.csproj", "{D456404B-B86C-4FE1-960A-6E86C23A6DB0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CDP4UpdateServerDal", "CDP4UpdateServerDal\CDP4UpdateServerDal.csproj", "{D456404B-B86C-4FE1-960A-6E86C23A6DB0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CDP4UpdateServerDal.Tests", "CDP4UpdateServerDal.Tests\CDP4UpdateServerDal.Tests.csproj", "{23F41ACF-BFF8-4D71-8288-1EFB3E7AB7F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CDP4UpdateServerDal.Tests", "CDP4UpdateServerDal.Tests\CDP4UpdateServerDal.Tests.csproj", "{23F41ACF-BFF8-4D71-8288-1EFB3E7AB7F3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CDP4GraphExport", "CDP4GraphExport\CDP4GraphExport.csproj", "{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CDP4GraphExport.Tests", "CDP4GraphExport.Tests\CDP4GraphExport.Tests.csproj", "{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -962,6 +966,38 @@ Global
 		{23F41ACF-BFF8-4D71-8288-1EFB3E7AB7F3}.Release|x64.Build.0 = Release|Any CPU
 		{23F41ACF-BFF8-4D71-8288-1EFB3E7AB7F3}.Release|x86.ActiveCfg = Release|Any CPU
 		{23F41ACF-BFF8-4D71-8288-1EFB3E7AB7F3}.Release|x86.Build.0 = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|x64.Build.0 = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Debug|x86.Build.0 = Debug|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|x64.ActiveCfg = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|x64.Build.0 = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|x86.ActiveCfg = Release|Any CPU
+		{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}.Release|x86.Build.0 = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|x64.Build.0 = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Debug|x86.Build.0 = Debug|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|x64.ActiveCfg = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|x64.Build.0 = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|x86.ActiveCfg = Release|Any CPU
+		{160B09E8-5ADB-4F3F-A9EF-EEE95EA916FA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CDP4GraphExport.Tests/CDP4GraphExport.Tests.csproj
+++ b/CDP4GraphExport.Tests/CDP4GraphExport.Tests.csproj
@@ -1,0 +1,82 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net452</TargetFramework>
+    <AssemblyTitle>CDP4GraphExport.Tests</AssemblyTitle>
+    <Company>RHEA System S.A.</Company>
+    <Product>CDP4GraphExport.Tests</Product>
+    <Description>Grapher Unit Tests</Description>
+    <Copyright>Copyright © RHEA System S.A.</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
+    <PackageReference Include="CDP4Common-CE" Version="6.2.1-2020.9.30.2-pre-release" />
+    <PackageReference Include="CDP4Dal-CE" Version="6.2.0" />
+    <PackageReference Include="CDP4RequirementsVerification-CE" Version="0.4.0" />
+    <PackageReference Include="DevExpress.Charts.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.CodeParser" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Data" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Data.Desktop" Version="20.1.8" />
+    <PackageReference Include="DevExpress.DataAccess" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Mvvm" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Office.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Pdf.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Pdf.Drawing" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Printing.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.RichEdit.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.RichEdit.Export" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Wpf.Charts" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Wpf.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Wpf.DocumentViewer.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Wpf.Grid.Core" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Wpf.Layout" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Wpf.Navigation" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Wpf.Printing" Version="20.1.8" />
+    <PackageReference Include="DevExpress.Xpo" Version="20.1.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.11.0" />
+    <PackageReference Include="NLog" Version="4.6.8" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Prism" Version="5.0.0" />
+    <PackageReference Include="Prism.Composition" Version="5.0.0" />
+    <PackageReference Include="Prism.Interactivity" Version="5.0.0" />
+    <PackageReference Include="Prism.MEFExtensions" Version="5.0.0" />
+    <PackageReference Include="Prism.Mvvm" Version="1.1.1" />
+    <PackageReference Include="Prism.PubSubEvents" Version="1.1.2" />
+    <PackageReference Include="reactiveui-core" Version="6.4.0" />
+    <PackageReference Include="Rx-Core" Version="2.2.5" />
+    <PackageReference Include="Rx-Interfaces" Version="2.2.5" />
+    <PackageReference Include="Rx-Linq" Version="2.2.5" />
+    <PackageReference Include="Rx-Main" Version="2.2.5" />
+    <PackageReference Include="Rx-PlatformServices" Version="2.2.5" />
+    <PackageReference Include="Rx-XAML" Version="2.2.5" />
+    <PackageReference Include="Splat" Version="1.6.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CDP4Composition\CDP4Composition.csproj" />
+    <ProjectReference Include="..\CDP4GraphExport\CDP4GraphExport.csproj" />
+  </ItemGroup>
+</Project>

--- a/CDP4GraphExport.Tests/GraphExportModuleTestFixture.cs
+++ b/CDP4GraphExport.Tests/GraphExportModuleTestFixture.cs
@@ -1,0 +1,84 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GraphExportModuleTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Grapher.Tests
+{
+    using CDP4Composition;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.PluginSettingService;
+
+    using Microsoft.Practices.Prism.Regions;
+    using Microsoft.Practices.ServiceLocation;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="GraphExportModule"/>
+    /// </summary>
+    [TestFixture]
+    public class GraphExportModuleTestFixture
+    {
+        private Mock<IDialogNavigationService> dialogNavigationService;
+        private Mock<IPanelNavigationService> panelNavigationService;
+        private Mock<IPluginSettingsService> pluginSettingService;
+        private Mock<IRegionManager> regionManager;
+        private Mock<IFluentRibbonManager> fluentribbonManager;
+        private Mock<IThingDialogNavigationService> thingDialogNavigationService;
+        private Mock<IServiceLocator> serviceLocator;
+        private Mock<IRegionViewRegistry> regionViewRegistry;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.dialogNavigationService = new Mock<IDialogNavigationService>();
+            this.panelNavigationService = new Mock<IPanelNavigationService>();
+            this.pluginSettingService = new Mock<IPluginSettingsService>();
+            this.fluentribbonManager = new Mock<IFluentRibbonManager>();
+            this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
+            this.regionManager = new Mock<IRegionManager>();
+            this.serviceLocator = new Mock<IServiceLocator>();
+            this.regionViewRegistry = new Mock<IRegionViewRegistry>();
+
+            this.serviceLocator.Setup(x => x.GetInstance<IPanelNavigationService>())
+                .Returns(this.panelNavigationService.Object);
+
+            this.serviceLocator.Setup(x => x.GetInstance<IRegionViewRegistry>())
+                .Returns(this.regionViewRegistry.Object);
+
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+        }
+
+        [Test]
+        public void VerifyInitialize()
+        {
+            var module = new GraphExportModule(this.regionManager.Object, this.fluentribbonManager.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, this.thingDialogNavigationService.Object, this.pluginSettingService.Object);
+            Assert.IsNotNull(module);
+            module.Initialize();
+        }
+    }
+}

--- a/CDP4GraphExport/CDP4GraphExport.csproj
+++ b/CDP4GraphExport/CDP4GraphExport.csproj
@@ -1,0 +1,142 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{00C8F149-2ECA-4922-BA36-4EEA2C4F4AAC}</ProjectGuid>
+    <MinIMEVersion>7.0.0</MinIMEVersion>
+    <TargetFramework>net452</TargetFramework>
+   
+    <LangVersion>latest</LangVersion>
+    <AssemblyTitle>CDP4GraphExport</AssemblyTitle>
+    <Company>RHEA System S.A.</Company>
+    <Product>GraphExport</Product>
+    <Description>CDP4 Graph Export Plugin</Description>
+    <Copyright>Copyright © RHEA System S.A.</Copyright>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <OutputPath>..\CDP4IME\bin\$(Configuration)\$(TargetFramework)\plugins\CDP4GraphExport\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <Import Project="..\Sdk.Plugin.target" /> 
+  <ItemGroup>
+    <PackageReference Include="CDP4Common-CE" Version="6.2.1-2020.9.30.2-pre-release">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="CDP4Dal-CE" Version="6.2.0">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Prism.Composition">
+      <HintPath>..\packages\Prism.Composition.5.0.0\lib\NET45\Microsoft.Practices.Prism.Composition.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Prism.Interactivity">
+      <HintPath>..\packages\Prism.Interactivity.5.0.0\lib\NET45\Microsoft.Practices.Prism.Interactivity.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Prism.Mvvm">
+      <HintPath>..\packages\Prism.Mvvm.1.1.1\lib\net45\Microsoft.Practices.Prism.Mvvm.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Prism.PubSubEvents">
+      <HintPath>..\packages\Prism.PubSubEvents.1.1.2\lib\portable-sl5+windowsphone8+windows8+net40+wpa81\Microsoft.Practices.Prism.PubSubEvents.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="PresentationCore">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="PresentationFramework">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="ReactiveUI">
+      <HintPath>..\packages\reactiveui-core.6.4.0\lib\Net45\ReactiveUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Splat">
+      <HintPath>..\packages\Splat.1.6.0\lib\Net45\Splat.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Configuration">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.ServiceModel">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Transactions">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="System.Xaml">
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="WindowsBase">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CDP4Composition\CDP4Composition.csproj">
+      <Private>false</Private>
+      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.Core">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.Data">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.Drawing">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.IO.Compression.FileSystem">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.Numerics">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.Runtime.Serialization">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.Xml">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Update="System.Xml.Linq">
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+</Project>

--- a/CDP4GraphExport/GraphExportModule.cs
+++ b/CDP4GraphExport/GraphExportModule.cs
@@ -1,0 +1,123 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="GraphExportModule.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//    Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// -------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Grapher
+{
+    using System.ComponentModel.Composition;
+
+    using CDP4Composition;
+    using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation;
+    using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.PluginSettingService;
+
+    using Microsoft.Practices.Prism.Modularity;
+    using Microsoft.Practices.Prism.Regions;
+
+    /// <summary>
+    /// The <see cref="IModule"/> implementation for the <see cref="GraphExportModule"/> Module
+    /// </summary>
+    [ModuleExportName(typeof(GraphExportModule), "Graph Export Module")]
+    public class GraphExportModule : IModule
+    {
+        /// <summary>
+        /// Gets the <see cref="IRegionManager"/> that is used by the <see cref="GraphExportModule"/> to register the regions
+        /// </summary>
+        internal IRegionManager RegionManager { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IFluentRibbonManager"/> that is used by the <see cref="GraphExportModule"/> to register Office Fluent Ribbon XML
+        /// </summary>
+        internal IFluentRibbonManager RibbonManager { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IPanelNavigationService"/> that is used by the <see cref="GraphExportModule"/> to support panel navigation
+        /// </summary>
+        internal IPanelNavigationService PanelNavigationService { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IDialogNavigationService"/> that is used by the <see cref="GraphExportModule"/> to support panel navigation
+        /// </summary>
+        internal IDialogNavigationService DialogNavigationService { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IThingDialogNavigationService"/> that handles navigation to dialogs
+        /// </summary>
+        internal IThingDialogNavigationService ThingDialogNavigationService { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
+        /// </summary>
+        internal IPluginSettingsService PluginSettingsService { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GraphExportModule"/> class.
+        /// </summary>
+        /// <param name="regionManager">
+        /// The (MEF injected) instance of <see cref="IRegionManager"/>
+        /// </param>
+        /// <param name="ribbonManager">
+        /// The (MEF injected) instance of <see cref="IFluentRibbonManager"/>
+        /// </param>
+        /// <param name="panelNavigationService">
+        /// The (MEF injected) instance of <see cref="IPanelNavigationService"/>
+        /// </param>
+        /// <param name="dialogNavigationService">
+        /// The dialog Navigation Service.
+        /// </param>
+        /// <param name="thingDialogNavigationService">
+        /// The (MEF injected) instance of <see cref="IThingDialogNavigationService"/>
+        /// </param>
+        /// <param name="pluginSettingsService">
+        /// The (MEF injected) instance of <see cref="IPluginSettingsService"/>
+        /// </param>
+        [ImportingConstructor]
+        public GraphExportModule(IRegionManager regionManager, IFluentRibbonManager ribbonManager, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IThingDialogNavigationService thingDialogNavigationService, IPluginSettingsService pluginSettingsService)
+        {
+            this.RegionManager = regionManager;
+            this.RibbonManager = ribbonManager;
+            this.PanelNavigationService = panelNavigationService;
+            this.DialogNavigationService = dialogNavigationService;
+            this.ThingDialogNavigationService = thingDialogNavigationService;
+            this.PluginSettingsService = pluginSettingsService;
+        }
+
+        /// <summary>
+        /// Initialize the Module
+        /// </summary>
+        public void Initialize()
+        {
+            this.RegisterRegions();
+        }
+
+        /// <summary>
+        /// Register the view view-models with the <see cref="Region"/>s
+        /// </summary>
+        private void RegisterRegions()
+        {
+            //TODO: register GraphExportRibbon
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
The purpose of this plugin is to export an EngineeringModel to a number of different graph formats such as:

  - GraphML
  - GEXF
  - GraphViz DOT Format

The basis of the exported graph is a NestedElementTree and the relationships between NestedElements on the basis of relationships between ElementDefinitions and ElementUsages. Containment is explicitly exported as well as a directed "contains" relationship from container (source) to containee (target)

<!-- Thanks for contributing to CDP4-IME! -->

