### PR TITLE
[Add] context menu to FiniteStateBrowser to update multiple Parameters and make them state dependent

### DIFF
--- a/EngineeringModel.Tests/Dialogs/CategoryDomainParameterTypeSelectorDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/CategoryDomainParameterTypeSelectorDialogViewModelTestFixture.cs
@@ -2,7 +2,7 @@
 // <copyright file="ParameteterSubscriptionFilterSelectionDialogViewModelTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
@@ -25,12 +25,9 @@
 
 namespace CDP4EngineeringModel.Tests.Dialogs
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
-
+    
     using CDP4Common.SiteDirectoryData;
 
     using CDP4EngineeringModel.ViewModels.Dialogs;
@@ -41,7 +38,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
     /// Suite of tests for the <see cref="CategoryDomainParameterTypeSelectorDialogViewModel"/> class
     /// </summary>
     [TestFixture]
-    public class ParameteterSubscriptionFilterSelectionDialogViewModelTestFixture
+    public class CategoryDomainParameterTypeSelectorDialogViewModelTestFixture
     {
         private List<Category> categories;
         private List<DomainOfExpertise> domains;

--- a/EngineeringModel.Tests/Dialogs/ParameteterSubscriptionFilterSelectionDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/ParameteterSubscriptionFilterSelectionDialogViewModelTestFixture.cs
@@ -38,7 +38,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
     using NUnit.Framework;
 
     /// <summary>
-    /// Suite of tests for the <see cref="ParameterSubscriptionFilterSelectionDialogViewModel"/> class
+    /// Suite of tests for the <see cref="CategoryDomainParameterTypeSelectorDialogViewModel"/> class
     /// </summary>
     [TestFixture]
     public class ParameteterSubscriptionFilterSelectionDialogViewModelTestFixture
@@ -66,7 +66,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         [Test]
         public void Verify_that_constructor_does_expected_setup()
         {
-            var vm = new ParameterSubscriptionFilterSelectionDialogViewModel(this.parameterTypes, this.categories, this.domains);
+            var vm = new CategoryDomainParameterTypeSelectorDialogViewModel(this.parameterTypes, this.categories, this.domains);
 
             CollectionAssert.AreEquivalent(this.categories, vm.PossibleCategories);
             CollectionAssert.AreEquivalent(this.domains, vm.PossibleOwner);
@@ -79,7 +79,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         [Test]
         public void Verify_that_when_a_selection_is_made_canok_can_execute()
         {
-            var vm = new ParameterSubscriptionFilterSelectionDialogViewModel(this.parameterTypes, this.categories, this.domains);
+            var vm = new CategoryDomainParameterTypeSelectorDialogViewModel(this.parameterTypes, this.categories, this.domains);
 
             Assert.That(vm.OkCommand.CanExecute(null), Is.False);
 
@@ -93,7 +93,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         [Test]
         public void Verify_that_when_OkCommand_is_executed_the_Result_is_as_expected()
         {
-            var vm = new ParameterSubscriptionFilterSelectionDialogViewModel(this.parameterTypes, this.categories, this.domains);
+            var vm = new CategoryDomainParameterTypeSelectorDialogViewModel(this.parameterTypes, this.categories, this.domains);
 
             vm.SelectedCategories.Add(this.categories.First());
             vm.SelectedOwners.Add(this.domains.First());
@@ -104,7 +104,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             Assert.That(dialogResult.Result.HasValue, Is.True);
 
-            var subscriptionFilterSelectionResult = dialogResult as ParameterSubscriptionFilterSelectionResult;
+            var subscriptionFilterSelectionResult = dialogResult as CategoryDomainParameterTypeSelectorResult;
 
             CollectionAssert.AreEquivalent(vm.SelectedCategories, subscriptionFilterSelectionResult.Categories);
             CollectionAssert.AreEquivalent(vm.SelectedOwners, subscriptionFilterSelectionResult.DomainOfExpertises);
@@ -114,7 +114,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         [Test]
         public void Verify_that_when_CancelCommand_is_executed_the_Result_is_as_expected()
         {
-            var vm = new ParameterSubscriptionFilterSelectionDialogViewModel(this.parameterTypes, this.categories, this.domains);
+            var vm = new CategoryDomainParameterTypeSelectorDialogViewModel(this.parameterTypes, this.categories, this.domains);
 
             vm.SelectedCategories.Add(this.categories.First());
             vm.SelectedOwners.Add(this.domains.First());

--- a/EngineeringModel.Tests/EngineeringModelModuleTestFixture.cs
+++ b/EngineeringModel.Tests/EngineeringModelModuleTestFixture.cs
@@ -48,6 +48,7 @@ namespace CDP4EngineeringModel.Tests
         private Mock<IFluentRibbonManager> fluentRibbonManager;
         private Mock<IDialogNavigationService> dialogNavigationService;
         private Mock<IParameterSubscriptionBatchService> parameterSubscriptionBatchService;
+        private Mock<IParameterActualFiniteStateListApplicationBatchService> parameterActualFiniteStateListApplicationBatchService;
 
         [SetUp]
         public void SetUp()
@@ -57,18 +58,22 @@ namespace CDP4EngineeringModel.Tests
             this.fluentRibbonManager = new Mock<IFluentRibbonManager>();
             this.dialogNavigationService = new Mock<IDialogNavigationService>();
             this.parameterSubscriptionBatchService = new Mock<IParameterSubscriptionBatchService>();
+            this.parameterActualFiniteStateListApplicationBatchService = new Mock<IParameterActualFiniteStateListApplicationBatchService>();
         }
 
         [Test]
         public void VerifyThatServicesAreSetByConstructor()
         {
             var regionManager = new RegionManager();
-            var module = new EngineeringModelModule(regionManager, this.fluentRibbonManager.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, this.thingDialogNavigationService.Object, null, this.parameterSubscriptionBatchService.Object);
+            var module = new EngineeringModelModule(regionManager, this.fluentRibbonManager.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, this.thingDialogNavigationService.Object, null, this.parameterSubscriptionBatchService.Object, this.parameterActualFiniteStateListApplicationBatchService.Object);
             
             Assert.AreEqual(this.fluentRibbonManager.Object, module.RibbonManager);
             Assert.AreEqual(this.panelNavigationService.Object, module.PanelNavigationService);
             Assert.AreEqual(this.dialogNavigationService.Object, module.DialogNavigationService );
             Assert.AreEqual(this.thingDialogNavigationService.Object, module.ThingDialogNavigationService);
+
+            Assert.That(module.ParameterSubscriptionBatchService, Is.EqualTo(this.parameterSubscriptionBatchService.Object));
+            Assert.That(module.ParameterActualFiniteStateListApplicationBatchService, Is.EqualTo(this.parameterActualFiniteStateListApplicationBatchService.Object));
         }
     }
 }

--- a/EngineeringModel.Tests/OfficeRibbon/EngineeringModelRibbonPartTestFixture.cs
+++ b/EngineeringModel.Tests/OfficeRibbon/EngineeringModelRibbonPartTestFixture.cs
@@ -148,7 +148,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public void VerifyThatTheOrderAndXmlAreLoaded()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null, null);
 
             Assert.AreEqual(this.order, this.ribbonPart.Order);
             Assert.AreEqual(this.amountOfRibbonControls, this.ribbonPart.ControlIdentifiers.Count);
@@ -157,7 +157,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public void VerifyThatIfFluentRibbonIsNotActiveTheSessionEventHasNoEffect()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = false;
@@ -171,7 +171,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public void VerifyThatIfFluentRibbonIsNullTheSessionEventHasNoEffect()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null, null);
 
             var sessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
             CDPMessageBus.Current.SendMessage(sessionEvent);
@@ -181,7 +181,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public void VerifyThatRibbonPartHandlesSessionOpenAndCloseEvent()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = true;
@@ -201,7 +201,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public async Task VerifyThatOnActionSelectModelToOpenWithNegativeResultDoesNotOpenModel()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = true;
@@ -220,7 +220,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public void VerifyThatButtonsAreEnabledAsExpected()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.negativeDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = true;
@@ -277,7 +277,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public async Task VerifyThatOnActionShowElementDefWorks()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = true;
@@ -303,7 +303,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public async Task VerifyThatOnActionShowOptionsWorks()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = true;
@@ -329,7 +329,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public async Task VerifyThatOnActionShowShowFiniteStatesWorks()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = true;
@@ -355,7 +355,7 @@ namespace CDP4EngineeringModel.Tests.OfficeRibbon
         [Test]
         public async Task VerifyThatOnActionShowShowPublicationsWorks()
         {
-            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null);
+            this.ribbonPart = new EngineeringModelRibbonPart(this.order, this.panelNavigationService.Object, this.positiveDialogNavigationService.Object, null, null, null, null);
 
             var fluentRibbonManager = new FluentRibbonManager();
             fluentRibbonManager.IsActive = true;

--- a/EngineeringModel.Tests/Services/ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs
+++ b/EngineeringModel.Tests/Services/ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs
@@ -1,0 +1,121 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Tests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Operations;
+    using CDP4Dal.Permission;
+
+    using CDP4EngineeringModel.Services;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ParameterActualFiniteStateListApplicationBatchService"/> class.
+    /// </summary>
+    [TestFixture]
+    public class ParameterActualFiniteStateListApplicationBatchServiceTestFixture
+    {
+        private ParameterActualFiniteStateListApplicationBatchService parameterActualFiniteStateListApplicationBatchService;
+        private Uri uri;
+        private ConcurrentDictionary<CDP4Common.Types.CacheKey, Lazy<Thing>> cache;
+        private Mock<ISession> session;
+        private Mock<IPermissionService> permissionService;
+        private Iteration iteration;
+        private ActualFiniteStateList actualFiniteStateList;
+        private SiteReferenceDataLibrary siteReferenceDataLibrary;
+        private DomainOfExpertise powerEngineering;
+        private SimpleQuantityKind simpleQuantityKind;
+        private Category equipments;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.uri = new Uri("http://www.rheagroup.com");
+            this.cache = new ConcurrentDictionary<CDP4Common.Types.CacheKey, Lazy<Thing>>();
+
+            this.siteReferenceDataLibrary = new SiteReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri);
+
+            this.powerEngineering = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri);
+            this.simpleQuantityKind = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri);
+            this.equipments = new Category(Guid.NewGuid(), this.cache, this.uri) { ShortName = "EQT", Name = "Equipments" };
+
+            this.siteReferenceDataLibrary.DefinedCategory.Add(this.equipments);
+
+            var engineeringModel = new EngineeringModel(Guid.NewGuid(), this.cache, this.uri);
+            this.iteration = new Iteration(Guid.NewGuid(), this.cache, this.uri);
+            engineeringModel.Iteration.Add(this.iteration);
+            var elementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Owner = this.powerEngineering };
+            elementDefinition.Category.Add(this.equipments);
+            this.iteration.Element.Add(elementDefinition);
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri) { Owner = this.powerEngineering, ParameterType = this.simpleQuantityKind };
+            elementDefinition.Parameter.Add(parameter);
+            this.actualFiniteStateList = new ActualFiniteStateList(Guid.NewGuid(), this.cache, this.uri);
+            this.iteration.ActualFiniteStateList.Add(this.actualFiniteStateList);
+
+            this.session = new Mock<ISession>();
+            this.permissionService = new Mock<IPermissionService>();
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<Parameter>())).Returns(true);
+
+            this.parameterActualFiniteStateListApplicationBatchService = new ParameterActualFiniteStateListApplicationBatchService();
+        }
+
+        [Test]
+        public async Task Verify_that_Create_throws_ArgumentNullExceptions()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(null, null, null, false, null, null, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(this.session.Object, null, null, false, null, null, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(this.session.Object, this.iteration, null,false, null, null, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(this.session.Object, this.iteration, this.actualFiniteStateList, false, null, null, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(this.session.Object, this.iteration, this.actualFiniteStateList, false, new List<Category>(), null, null));
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(this.session.Object, this.iteration, this.actualFiniteStateList,false, new List<Category>(), new List<DomainOfExpertise>(), null));
+        }
+
+        [Test]
+        public async Task Verify_that_Update_Executes()
+        {
+            var categories = new List<Category> { this.equipments };
+            var domains = new List<DomainOfExpertise> { this.powerEngineering };
+            var parameterTypes = new List<ParameterType> { this.simpleQuantityKind };
+
+            await this.parameterActualFiniteStateListApplicationBatchService.Update(this.session.Object, this.iteration, this.actualFiniteStateList, false, categories, domains, parameterTypes);
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Exactly(1));
+        }
+    }
+}

--- a/EngineeringModel.Tests/Services/ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs
+++ b/EngineeringModel.Tests/Services/ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs
@@ -96,7 +96,7 @@ namespace CDP4EngineeringModel.Tests.Services
         }
 
         [Test]
-        public async Task Verify_that_Create_throws_ArgumentNullExceptions()
+        public void Verify_that_Create_throws_ArgumentNullExceptions()
         {
             Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(null, null, null, false, null, null, null));
             Assert.ThrowsAsync<ArgumentNullException>(async () => await this.parameterActualFiniteStateListApplicationBatchService.Update(this.session.Object, null, null, false, null, null, null));

--- a/EngineeringModel.Tests/Services/ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs
+++ b/EngineeringModel.Tests/Services/ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs
@@ -2,7 +2,7 @@
 // <copyright file="ParameterActualFiniteStateListApplicationBatchServiceTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel.Tests/Services/ParameterSubscriptionBatchServiceTestFixture.cs
+++ b/EngineeringModel.Tests/Services/ParameterSubscriptionBatchServiceTestFixture.cs
@@ -2,7 +2,7 @@
 // <copyright file="ParameterSubscriptionBatchServiceTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -51,14 +51,14 @@ namespace CDP4EngineeringModel.Tests
 
     using CDP4EngineeringModel.Services;
     using CDP4EngineeringModel.ViewModels;    
+
     using Moq;
     
     using NUnit.Framework;
     
     using ReactiveUI;
-    
+
     using ElementDefinitionRowViewModel = CDP4EngineeringModel.ViewModels.ElementDefinitionRowViewModel;
-    
     using ElementUsageRowViewModel = CDP4EngineeringModel.ViewModels.ElementUsageRowViewModel;
 
     /// <summary>
@@ -785,7 +785,7 @@ namespace CDP4EngineeringModel.Tests
         [Test]
         public async Task Verify_that_ExecuteBatchCreateSubscriptionCommand_works_as_expected()
         {
-            var dialogResult = new CDP4EngineeringModel.ViewModels.Dialogs.ParameterSubscriptionFilterSelectionResult(true, false, Enumerable.Empty<ParameterType>(), Enumerable.Empty<Category>(), Enumerable.Empty<DomainOfExpertise>());
+            var dialogResult = new CDP4EngineeringModel.ViewModels.Dialogs.CategoryDomainParameterTypeSelectorResult(true, false, Enumerable.Empty<ParameterType>(), Enumerable.Empty<Category>(), Enumerable.Empty<DomainOfExpertise>());
             this.dialogNavigationService.Setup(x => x.NavigateModal(It.IsAny<IDialogViewModel>())).Returns(dialogResult);
 
             var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, this.dialogNavigationService.Object, null, this.parameterSubscriptionBatchService.Object);

--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -2,7 +2,7 @@
 // <copyright file="ElementDefinitionBrowserViewModelTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel.Tests/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModelTestFixture.cs
@@ -2,7 +2,7 @@
 // <copyright file="FiniteStateBrowserViewModelTestFixture.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/EngineeringModel.csproj
+++ b/EngineeringModel/EngineeringModel.csproj
@@ -252,8 +252,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="Views\Dialogs\ParameterSubscriptionFilterSelectionDialog.xaml.cs">
-      <DependentUpon>ParameterSubscriptionFilterSelectionDialog.xaml</DependentUpon>
+    <Compile Update="Views\Dialogs\CategoryDomainParameterTypeSelectorDialog.xaml.cs">
+      <DependentUpon>CategoryDomainParameterTypeSelectorDialog.xaml</DependentUpon>
     </Compile>
     <Compile Update="Views\Dialogs\ActualFiniteStateDialog.xaml.cs">
       <DependentUpon>ActualFiniteStateDialog.xaml</DependentUpon>
@@ -371,7 +371,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <Page Include="Views\Dialogs\ParameterSubscriptionFilterSelectionDialog.xaml">
+    <Page Include="Views\Dialogs\CategoryDomainParameterTypeSelectorDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/EngineeringModel/EngineeringModelModule.cs
+++ b/EngineeringModel/EngineeringModelModule.cs
@@ -76,8 +76,11 @@ namespace CDP4EngineeringModel
         /// <param name="parameterSubscriptionBatchService">
         /// The (MEF injected) instance of <see cref="IParameterSubscriptionBatchService"/>
         /// </param>
+        /// <param name="parameterActualFiniteStateListApplicationBatchService">
+        /// The (MEF injected) instance of <see cref="IParameterActualFiniteStateListApplicationBatchService"/>
+        /// </param>
         [ImportingConstructor]
-        public EngineeringModelModule(IRegionManager regionManager, IFluentRibbonManager ribbonManager, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IThingDialogNavigationService thingDialogNavigationService, IPluginSettingsService pluginSettingsService, IParameterSubscriptionBatchService parameterSubscriptionBatchService)
+        public EngineeringModelModule(IRegionManager regionManager, IFluentRibbonManager ribbonManager, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IThingDialogNavigationService thingDialogNavigationService, IPluginSettingsService pluginSettingsService, IParameterSubscriptionBatchService parameterSubscriptionBatchService, IParameterActualFiniteStateListApplicationBatchService parameterActualFiniteStateListApplicationBatchService)
         {
             this.regionManager = regionManager;
             this.RibbonManager = ribbonManager;
@@ -86,6 +89,7 @@ namespace CDP4EngineeringModel
             this.ThingDialogNavigationService = thingDialogNavigationService;
             this.PluginSettingsService = pluginSettingsService;
             this.ParameterSubscriptionBatchService = parameterSubscriptionBatchService;
+            this.ParameterActualFiniteStateListApplicationBatchService = parameterActualFiniteStateListApplicationBatchService;
         }
 
         /// <summary>
@@ -120,6 +124,12 @@ namespace CDP4EngineeringModel
         internal IParameterSubscriptionBatchService ParameterSubscriptionBatchService { get; private set; }
 
         /// <summary>
+        /// Gets the <see cref="IParameterActualFiniteStateListApplicationBatchService"/> used to update multiple <see cref="Parameter"/>s state dependency
+        /// in a batch operation
+        /// </summary>
+        internal IParameterActualFiniteStateListApplicationBatchService ParameterActualFiniteStateListApplicationBatchService { get; private set; }
+
+        /// <summary>
         /// Initialize the <see cref="EngineeringModelModule"/> by registering the <see cref="Region"/>s and the <see cref="RibbonPart"/>s
         /// </summary>
         public void Initialize()
@@ -148,7 +158,7 @@ namespace CDP4EngineeringModel
         /// </summary>
         private void RegisterRibbonParts()
         {
-            var rdlRibbonPart = new EngineeringModelRibbonPart(10, this.PanelNavigationService, this.DialogNavigationService, this.ThingDialogNavigationService, this.PluginSettingsService, this.ParameterSubscriptionBatchService);
+            var rdlRibbonPart = new EngineeringModelRibbonPart(10, this.PanelNavigationService, this.DialogNavigationService, this.ThingDialogNavigationService, this.PluginSettingsService, this.ParameterSubscriptionBatchService, this.ParameterActualFiniteStateListApplicationBatchService);
             this.RibbonManager.RegisterRibbonPart(rdlRibbonPart);
         }
     }

--- a/EngineeringModel/OfficeRibbon/EngineeringModelRibbonPart.cs
+++ b/EngineeringModel/OfficeRibbon/EngineeringModelRibbonPart.cs
@@ -2,7 +2,7 @@
 // <copyright file="EngineeringModelRibbonPart.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/Services/IParameterActualFiniteStateListApplicationBatchService.cs
+++ b/EngineeringModel/Services/IParameterActualFiniteStateListApplicationBatchService.cs
@@ -2,7 +2,7 @@
 // <copyright file="IParameterActualFiniteStateListApplicationBatchService.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/Services/IParameterActualFiniteStateListApplicationBatchService.cs
+++ b/EngineeringModel/Services/IParameterActualFiniteStateListApplicationBatchService.cs
@@ -1,0 +1,75 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IParameterActualFiniteStateListApplicationBatchService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Services
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    /// <summary>
+    /// The purpose of the <see cref="IParameterActualFiniteStateListApplicationBatchService"/> is to apply a <see cref="ActualFiniteStateList"/> to
+    /// a multiple <see cref="Parameters"/> as a batch operation. The <see cref="Parameter"/>s that are to be updated are selected based on provided
+    /// <see cref="ParameterType"/>s, <see cref="Category"/>s and owning <see cref="DomainOfExpertise"/>
+    /// </summary>
+    public interface IParameterActualFiniteStateListApplicationBatchService
+    {
+        /// <summary>
+        /// Updates multiple Parameters with <see cref="ActualFiniteStateList"/> application in one batch operation
+        /// </summary>
+        /// <param name="session">
+        /// The <see cref="ISession"/> that is used to communicate with the selected data source
+        /// </param>
+        /// <param name="iteration">
+        /// The container <see cref="Iteration"/> in which the parameteres are to be updated
+        /// </param>
+        /// <param name="actualFiniteStateList">
+        /// The <see cref="ActualFiniteStateList"/> that needs to be applied to the <see cref="Parameter"/>s
+        /// </param>
+        /// <param name="isUncategorizedIncluded">
+        /// A value indication whether <see cref="Parameter"/>s contained by <see cref="ElementDefinition"/>s that are
+        /// not a member of a <see cref="Category"/> shall be included or not
+        /// </param>
+        /// <param name="categories">
+        /// An <see cref="IEnumerable{Category}"/> that is a selection criteria to select the <see cref="Parameter"/>s that need
+        /// to be updated with the <see cref="ActualFiniteStateList"/>
+        /// </param>
+        /// <param name="domainOfExpertises"></param>
+        /// An <see cref="IEnumerable{DomainOfExpertise}"/> that is a selection criteria to select the <see cref="Parameter"/>s that need
+        /// to be updated with the <see cref="ActualFiniteStateList"/>
+        /// <param name="parameterTypes">
+        /// An <see cref="IEnumerable{ParameterType}"/> that is a selection criteria to select the <see cref="Parameter"/>s that need
+        /// to be updated with the <see cref="ActualFiniteStateList"/>
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        Task Update(ISession session, Iteration iteration, ActualFiniteStateList actualFiniteStateList, bool isUncategorizedIncluded, IEnumerable<Category> categories, IEnumerable<DomainOfExpertise> domainOfExpertises, IEnumerable<ParameterType> parameterTypes);
+    }
+}

--- a/EngineeringModel/Services/IParameterSubscriptionBatchService .cs
+++ b/EngineeringModel/Services/IParameterSubscriptionBatchService .cs
@@ -2,7 +2,7 @@
 // <copyright file="IParameterSubscriptionBatchService.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/Services/ParameterActualFiniteStateListApplicationBatchService.cs
+++ b/EngineeringModel/Services/ParameterActualFiniteStateListApplicationBatchService.cs
@@ -186,7 +186,7 @@ namespace CDP4EngineeringModel.Services
 
                     if (domainOfExpertises.Contains(parameter.Owner) &&
                         parameterTypes.Contains(parameter.ParameterType) &&
-                        (isCategorized | isUncategorizedIncluded))
+                        (isCategorized || isUncategorizedIncluded))
                     {
                         parameters.Add(parameter);
                     }

--- a/EngineeringModel/Services/ParameterActualFiniteStateListApplicationBatchService.cs
+++ b/EngineeringModel/Services/ParameterActualFiniteStateListApplicationBatchService.cs
@@ -1,0 +1,223 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParameterActualFiniteStateListApplicationBatchService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.ComponentModel.Composition;
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Operations;
+
+    /// <summary>
+    /// The purpose of the <see cref="ParameterSubscriptionBatchService"/> is to create multiple <see cref="ParameterSubscription"/>s
+    /// as part of one batch operation. The <see cref="Parameter"/>s that are subscribed to are selected based on provided
+    /// <see cref="ParameterType"/>s, <see cref="Category"/>s and owning <see cref="DomainOfExpertise"/>
+    /// </summary>
+    [Export(typeof(IParameterActualFiniteStateListApplicationBatchService))]
+    [PartCreationPolicy(CreationPolicy.Shared)]
+    public class ParameterActualFiniteStateListApplicationBatchService : IParameterActualFiniteStateListApplicationBatchService
+    {
+        /// <summary>
+        /// Updates multiple <see cref="Parameter"/>s with <see cref="ActualFiniteStateList"/> application in one batch operation
+        /// </summary>
+        /// <param name="session">
+        /// The <see cref="ISession"/> that is used to communicate with the selected data source
+        /// </param>
+        /// <param name="iteration">
+        /// The container <see cref="Iteration"/> in which the parameteres are to be updated
+        /// </param>
+        /// <param name="actualFiniteStateList">
+        /// The <see cref="ActualFiniteStateList"/> that needs to be applied to the <see cref="Parameter"/>s
+        /// </param>
+        /// <param name="isUncategorizedIncluded">
+        /// A value indication whether <see cref="Parameter"/>s contained by <see cref="ElementDefinition"/>s that are
+        /// not a member of a <see cref="Category"/> shall be included or not
+        /// </param>
+        /// <param name="categories">
+        /// An <see cref="IEnumerable{Category}"/> that is a selection criteria to select the <see cref="Parameter"/>s that need
+        /// to be updated with the <see cref="ActualFiniteStateList"/>
+        /// </param>
+        /// <param name="domainOfExpertises"></param>
+        /// An <see cref="IEnumerable{DomainOfExpertise}"/> that is a selection criteria to select the <see cref="Parameter"/>s that need
+        /// to be updated with the <see cref="ActualFiniteStateList"/>
+        /// <param name="parameterTypes">
+        /// An <see cref="IEnumerable{ParameterType}"/> that is a selection criteria to select the <see cref="Parameter"/>s that need
+        /// to be updated with the <see cref="ActualFiniteStateList"/>
+        /// </param>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        public async Task Update(ISession session, Iteration iteration, ActualFiniteStateList actualFiniteStateList, bool isUncategorizedIncluded, IEnumerable<Category> categories, IEnumerable<DomainOfExpertise> domainOfExpertises, IEnumerable<ParameterType> parameterTypes)
+        {
+            if (session == null)
+            {
+                throw new ArgumentNullException(nameof(session), $"The {nameof(session)} may not be null");
+            }
+
+            if (iteration == null)
+            {
+                throw new ArgumentNullException(nameof(iteration), $"The {nameof(iteration)} may not be null");
+            }
+
+            if (actualFiniteStateList == null)
+            {
+                throw new ArgumentNullException(nameof(actualFiniteStateList), $"The {nameof(actualFiniteStateList)} may not be null");
+            }
+
+            if (categories == null)
+            {
+                throw new ArgumentNullException(nameof(categories), $"The {nameof(categories)} may not be null");
+            }
+
+            if (domainOfExpertises == null)
+            {
+                throw new ArgumentNullException(nameof(domainOfExpertises), $"The {nameof(domainOfExpertises)} may not be null");
+            }
+
+            if (parameterTypes == null)
+            {
+                throw new ArgumentNullException(nameof(parameterTypes), $"The {nameof(parameterTypes)} may not be null");
+            }
+
+            var parameters = this.QueryParameters(session, iteration, actualFiniteStateList, isUncategorizedIncluded, categories, domainOfExpertises, parameterTypes);
+
+            if (!parameters.Any())
+            {
+                return;
+            }
+
+            var transactionContext = TransactionContextResolver.ResolveContext(iteration);
+            var transaction = new ThingTransaction(transactionContext);
+
+            this.UpdateTransactionWithUpdatedParameters(transaction, actualFiniteStateList, parameters);
+
+            var updateOperationContainer = transaction.FinalizeTransaction();
+            await session.Write(updateOperationContainer);
+        }
+
+        /// <summary>
+        /// Iterates through the <see cref="ElementDefinition"/>s of the <see cref="Iteration"/> to find all the <see cref="Parameter"/>s
+        /// that satisfy the selection criteratia
+        /// </summary>
+        /// <param name="session">
+        /// The <see cref="ISession"/> that is used to communicate with the selected data source
+        /// </param>
+        /// <param name="iteration">
+        /// The container <see cref="Iteration"/> to query the <see cref="Parameter"/>s from
+        /// </param>
+        /// <param name="owner">
+        /// The <see cref="DomainOfExpertise"/> that is be the owner of the created <see cref="ParameterSubscription"/>s and should therefore
+        /// not be the owner of the <see cref="Parameter"/>s or <see cref="ParameterOverride"/>s that are subscribed to
+        /// </param>
+        /// <param name="isUncategorizedIncluded">
+        /// A value indication whether <see cref="Parameter"/>s contained by <see cref="ElementDefinition"/>s that are
+        /// not a member of a <see cref="Category"/> shall be included or not
+        /// </param>
+        /// <param name="categories">
+        /// An <see cref="IEnumerable{Category}"/> that is a selection criteria to select the <see cref="Parameter"/>s
+        /// </param>
+        /// <param name="domainOfExpertises">
+        /// An <see cref="IEnumerable{DomainOfExpertise}"/> that is a selection criteria to select the <see cref="Parameter"/>s
+        /// </param>
+        /// <param name="parameterTypes">
+        /// An <see cref="IEnumerable{ParameterType}"/> that is a selection criteria to select the <see cref="Parameter"/>s
+        /// </param>
+        /// <returns>
+        /// An <see cref="IEnumerable{Parameter}"/>
+        /// </returns>
+        private IEnumerable<Parameter> QueryParameters(ISession session, Iteration iteration, ActualFiniteStateList actualFiniteStateList, bool isUncategorizedIncluded, IEnumerable<Category> categories, IEnumerable<DomainOfExpertise> domainOfExpertises, IEnumerable<ParameterType> parameterTypes)
+        {
+            var parameters = new List<Parameter>();
+
+            foreach (var elementDefinition in iteration.Element)
+            {
+                var isCategorized = false;
+
+                foreach (var parameter in elementDefinition.Parameter)
+                {
+                    if (!session.PermissionService.CanWrite(parameter))
+                    {
+                        break;
+                    }
+
+                    if (parameter.StateDependence == actualFiniteStateList)
+                    {
+                        break;
+                    }
+
+                    foreach (var category in categories)
+                    {
+                        isCategorized = elementDefinition.IsMemberOfCategory(category);
+
+                        if (isCategorized)
+                        {
+                            break;
+                        }
+                    }
+
+                    if (domainOfExpertises.Contains(parameter.Owner) &&
+                        parameterTypes.Contains(parameter.ParameterType) &&
+                        (isCategorized | isUncategorizedIncluded))
+                    {
+                        parameters.Add(parameter);
+                    }
+                }
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
+        /// Update the <see cref="ThingTransaction"/> with new <see cref="ParameterSubscription"/>s
+        /// </summary>
+        /// <param name="transaction">
+        ///  The subject <see cref="IThingTransaction"/> that is to be updated
+        /// </param>
+        /// <param name="owner">
+        /// The <see cref="DomainOfExpertise"/> that is be the owner of the created <see cref="ParameterSubscription"/>s and should therefore
+        /// not be the owner of the <see cref="Parameter"/>s or <see cref="ParameterOverride"/>s that are subscribed to
+        /// </param>
+        /// <param name="parameterOrOverrides">
+        /// An <see cref="IEnumerable{ParameterOrOverrideBase}"/> for which new <see cref="ParameterSubscription"/>s will be created.
+        /// </param>
+        private void UpdateTransactionWithUpdatedParameters(IThingTransaction transaction, ActualFiniteStateList actualFiniteStateList, IEnumerable<Parameter> parameters)
+        {
+            foreach (var parameter in parameters)
+            {
+                var clone = parameter.Clone(false);
+                clone.StateDependence = actualFiniteStateList;
+
+                transaction.CreateOrUpdate(clone);
+            }
+        }
+    }
+}

--- a/EngineeringModel/Services/ParameterActualFiniteStateListApplicationBatchService.cs
+++ b/EngineeringModel/Services/ParameterActualFiniteStateListApplicationBatchService.cs
@@ -2,7 +2,7 @@
 // <copyright file="ParameterActualFiniteStateListApplicationBatchService.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/Services/ParameterSubscriptionBatchService.cs
+++ b/EngineeringModel/Services/ParameterSubscriptionBatchService.cs
@@ -171,7 +171,7 @@ namespace CDP4EngineeringModel.Services
                     
                     if (domainOfExpertises.Contains(parameter.Owner) && 
                         parameterTypes.Contains(parameter.ParameterType) && 
-                        (isCategorized | isUncategorizedIncluded))
+                        (isCategorized || isUncategorizedIncluded))
                     {
                         parameters.Add(parameter);
                     }

--- a/EngineeringModel/Services/ParameterSubscriptionBatchService.cs
+++ b/EngineeringModel/Services/ParameterSubscriptionBatchService.cs
@@ -2,7 +2,7 @@
 // <copyright file="ParameterSubscriptionBatchService.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorDialogViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ParameterSubscriptionFilterSelectionDialogViewModel.cs" company="RHEA System S.A.">
+// <copyright file="CategoryDomainParameterTypeSelectorDialogViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
@@ -36,10 +36,11 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
     using ReactiveUI;
 
     /// <summary>
-    /// The purpose of the <see cref="ParameterSubscriptionFilterSelectionDialogViewModel"/> is to provide selection criteria
-    /// to select Parameters for which <see cref="ParameterSubscription"/>s need to be created
+    /// The purpose of the <see cref="CategoryDomainParameterTypeSelectorDialogViewModel"/> is to provide selection criteria
+    /// for <see cref="Thing"/>s that may need to be filtered on selected <see cref="Category"/>, <see cref="DomainOfExpertise"/>
+    /// and <see cref="ParameterType"/>
     /// </summary>
-    public class ParameterSubscriptionFilterSelectionDialogViewModel : DialogViewModelBase
+    public class CategoryDomainParameterTypeSelectorDialogViewModel : DialogViewModelBase
     {
         /// <summary>
         /// Backing field for <see cref="SelectedCategories"/> property
@@ -62,12 +63,12 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
         private bool isUncategorizedIncluded;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ParameterSubscriptionFilterSelectionDialogViewModel"/> class
+        /// Initializes a new instance of the <see cref="CategoryDomainParameterTypeSelectorDialogViewModel"/> class
         /// </summary>
         /// <param name="parameterTypes"></param>
         /// <param name="categories"></param>
         /// <param name="domainOfExpertises"></param>
-        public ParameterSubscriptionFilterSelectionDialogViewModel(IEnumerable<ParameterType> parameterTypes, IEnumerable<Category> categories, IEnumerable<DomainOfExpertise> domainOfExpertises)
+        public CategoryDomainParameterTypeSelectorDialogViewModel(IEnumerable<ParameterType> parameterTypes, IEnumerable<Category> categories, IEnumerable<DomainOfExpertise> domainOfExpertises)
         {
             this.PossibleParameterTypes = parameterTypes.OrderBy(x => x.Name);
             this.PossibleCategories = categories.OrderBy(x => x.Name);
@@ -174,7 +175,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
         /// </summary>
         private void ExecuteOk()
         {
-            this.DialogResult = new ParameterSubscriptionFilterSelectionResult(true, this.IsUncategorizedIncluded, this.selectedParameterTypes, this.selectedCategories, this.selectedOwners);
+            this.DialogResult = new CategoryDomainParameterTypeSelectorResult(true, this.IsUncategorizedIncluded, this.selectedParameterTypes, this.selectedCategories, this.selectedOwners);
         }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorDialogViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="CategoryDomainParameterTypeSelectorDialogViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorResult.cs
+++ b/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorResult.cs
@@ -2,7 +2,7 @@
 // <copyright file="CategoryDomainParameterTypeSelectorResult.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorResult.cs
+++ b/EngineeringModel/ViewModels/Dialogs/CategoryDomainParameterTypeSelectorResult.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ParameterSubscriptionFilterSelectionResult.cs" company="RHEA System S.A.">
+// <copyright file="CategoryDomainParameterTypeSelectorResult.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
@@ -32,9 +32,9 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
     using CDP4Composition.Navigation;
 
     /// <summary>
-    /// The <see cref="IDialogResult"/> for the <see cref="ParameterSubscriptionFilterSelectionResult"/> dialog
+    /// The <see cref="IDialogResult"/> for the <see cref="CategoryDomainParameterTypeSelectorResult"/> dialog
     /// </summary>
-    public class ParameterSubscriptionFilterSelectionResult : BaseDialogResult
+    public class CategoryDomainParameterTypeSelectorResult : BaseDialogResult
     {
         /// <summary>
         /// Initializes an instance of the <see cref="ParameteterSubscriptionFilterSelectionResult"/> class
@@ -55,7 +55,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
         /// <param name="domainOfExpertises">
         /// The selected instances of <see cref="DomainOfExpertise"/>
         /// </param>
-        public ParameterSubscriptionFilterSelectionResult(bool? messageBoxResult, bool isUncategorizedIncluded, IEnumerable<ParameterType> parameterTypes, IEnumerable<Category> categories, IEnumerable<DomainOfExpertise> domainOfExpertises) : base(messageBoxResult)
+        public CategoryDomainParameterTypeSelectorResult(bool? messageBoxResult, bool isUncategorizedIncluded, IEnumerable<ParameterType> parameterTypes, IEnumerable<Category> categories, IEnumerable<DomainOfExpertise> domainOfExpertises) : base(messageBoxResult)
         {
             this.IsUncategorizedIncluded = isUncategorizedIncluded;
             this.ParameterTypes = parameterTypes;

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="ElementDefinitionsBrowserViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="ElementDefinitionsBrowserViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
@@ -109,7 +109,7 @@ namespace CDP4EngineeringModel.ViewModels
         private bool canCreateSubscription;
 
         /// <summary>
-        /// Backing field for <see cref="canCreateBatchSubscriptions"/>
+        /// Backing field for <see cref="CanCreateBatchSubscriptions"/>
         /// </summary>
         private bool canCreateBatchSubscriptions;
 
@@ -261,7 +261,7 @@ namespace CDP4EngineeringModel.ViewModels
         public ReactiveCommand<object> CreateSubscriptionCommand { get; private set; }
 
         /// <summary>
-        /// Gets the <see cref="ICommand"/> to create multiple <see cref="ParameterSubscription"/> in batch operation mode
+        /// Gets the <see cref="ICommand"/> to create multiple <see cref="ParameterSubscription"/>s in batch operation mode
         /// </summary>
         public ReactiveCommand<object> BatchCreateSubscriptionCommand { get; private set; }
 
@@ -492,7 +492,7 @@ namespace CDP4EngineeringModel.ViewModels
             }
 
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create Multiple Subscriptions", "", this.BatchCreateSubscriptionCommand, MenuItemKind.Create, ClassKind.NotThing));
-
+            
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Change Request", "", this.CreateChangeRequestCommand, MenuItemKind.Create, ClassKind.ChangeRequest));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Request For Deviation", "", this.CreateRequestForDeviationCommand, MenuItemKind.Create, ClassKind.RequestForDeviation));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Request For Waiver", "", this.CreateRequestForWaiverCommand, MenuItemKind.Create, ClassKind.RequestForWaiver));
@@ -890,8 +890,8 @@ namespace CDP4EngineeringModel.ViewModels
             var allowedCategories = requiredRls.SelectMany(rdl => rdl.DefinedCategory).Where(c => c.PermissibleClass.Contains(ClassKind.ElementDefinition));
             var allowedParameterTypes = requiredRls.SelectMany(rdl => rdl.ParameterType);
 
-            var parameteterSubscriptionFilterSelectionDialogViewModel = new ParameterSubscriptionFilterSelectionDialogViewModel(allowedParameterTypes, allowedCategories, allowedDomainOfExpertises);
-            var result = this.DialogNavigationService.NavigateModal(parameteterSubscriptionFilterSelectionDialogViewModel) as ParameterSubscriptionFilterSelectionResult;
+            var categoryDomainParameterTypeSelectorDialogViewModel = new CategoryDomainParameterTypeSelectorDialogViewModel(allowedParameterTypes, allowedCategories, allowedDomainOfExpertises);
+            var result = this.DialogNavigationService.NavigateModal(categoryDomainParameterTypeSelectorDialogViewModel) as CategoryDomainParameterTypeSelectorResult;
 
             if (result == null || !result.Result.HasValue || !result.Result.Value)
             {

--- a/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserRibbonViewModel.cs
@@ -1,23 +1,58 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FiniteStateBrowserRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
+    using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
+    using CDP4EngineeringModel.Services;
+    using CDP4EngineeringModel.Views;
+
+    using Microsoft.Practices.ServiceLocation;
+
+    using NLog;
 
     /// <summary>
     /// The view-model for the <see cref="FiniteStateBrowserRibbon"/> view
     /// </summary>
     public class FiniteStateBrowserRibbonViewModel : RibbonButtonIterationDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="FiniteStateBrowserRibbonViewModel"/> class
         /// </summary>
@@ -39,7 +74,14 @@ namespace CDP4EngineeringModel.ViewModels
         /// <returns>An instance of <see cref="OptionBrowserViewModel"/></returns>
         public static FiniteStateBrowserViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
-            return new FiniteStateBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var stopWatch = Stopwatch.StartNew();
+
+            var parameterActualFiniteStateListApplicationBatchService = ServiceLocator.Current.GetInstance<IParameterActualFiniteStateListApplicationBatchService>();
+
+            var viewModel = new FiniteStateBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService, parameterActualFiniteStateListApplicationBatchService);
+            stopWatch.Stop();
+            Logger.Info("Open FiniteStateBrowserViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }

--- a/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserRibbonViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="FiniteStateBrowserRibbonViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModel.cs
@@ -30,6 +30,7 @@ namespace CDP4EngineeringModel.ViewModels
     using System.Reactive.Linq;
     using System.Threading.Tasks;
     using System.Windows;
+    using System.Windows.Controls;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
@@ -47,6 +48,8 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Dal.Events;
     using CDP4Dal.Operations;
 
+    using CDP4EngineeringModel.Services;
+    using CDP4EngineeringModel.ViewModels.Dialogs;
     using CDP4EngineeringModel.Views;
 
     using ReactiveUI;
@@ -97,6 +100,11 @@ namespace CDP4EngineeringModel.ViewModels
         private bool canExecuteCreateActualFiniteStateListCommand;
 
         /// <summary>
+        /// Backing field for <see cref="CanUpdateBatchParameters"/>
+        /// </summary>
+        private bool canUpdateBatchParameters;
+
+        /// <summary>
         /// Backing field for <see cref="CanSetAsDefault"/>
         /// </summary>
         private bool canSetAsDefault;
@@ -110,6 +118,11 @@ namespace CDP4EngineeringModel.ViewModels
         /// Backing field for <see cref="CurrentIteration"/>
         /// </summary>
         private int currentIteration;
+
+        /// <summary>
+        /// The <see cref="IParameterActualFiniteStateListApplicationBatchService"/> used to update multiple <see cref="Parameter"/>s to set the <see cref="ActualFiniteStateList"/> in a batch operation
+        /// </summary>
+        private readonly IParameterActualFiniteStateListApplicationBatchService parameterActualFiniteStateListApplicationBatchService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FiniteStateBrowserViewModel"/> class
@@ -132,11 +145,16 @@ namespace CDP4EngineeringModel.ViewModels
         /// <param name="pluginSettingsService">
         /// The <see cref="IPluginSettingsService"/> used to read and write plugin setting files.
         /// </param>
-        public FiniteStateBrowserViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
+        /// <param name="parameterActualFiniteStateListApplicationBatchService">
+        /// The <see cref="IParameterActualFiniteStateListApplicationBatchService"/> used to update multiple <see cref="Parameter"/>s to set the <see cref="ActualFiniteStateList"/> in a batch operation
+        /// </param>
+        public FiniteStateBrowserViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService, IParameterActualFiniteStateListApplicationBatchService parameterActualFiniteStateListApplicationBatchService)
             : base(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
         {
-            this.Caption = string.Format("{0}, iteration_{1}", PanelCaption, this.Thing.IterationSetup.IterationNumber);
-            this.ToolTip = string.Format("{0}\n{1}\n{2}", ((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name, this.Thing.IDalUri, this.Session.ActivePerson.Name);
+            this.Caption = $"{PanelCaption}, iteration_{this.Thing.IterationSetup.IterationNumber}";
+            this.ToolTip = $"{((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
+
+            this.parameterActualFiniteStateListApplicationBatchService = parameterActualFiniteStateListApplicationBatchService;
 
             this.UpdatePossibleFiniteStatesList();
             this.UpdateActualFiniteStatesList();
@@ -212,6 +230,15 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
+        /// Gets a value indicating whether the batch update parameters command shall be enabled
+        /// </summary>
+        public bool CanUpdateBatchParameters
+        {
+            get { return this.canUpdateBatchParameters; }
+            private set { this.RaiseAndSetIfChanged(ref this.canUpdateBatchParameters, value); }
+        }
+
+        /// <summary>
         /// Gets the <see cref="ICommand"/> to create a <see cref="PossibleFiniteStateList"/>
         /// </summary>
         public ReactiveCommand<object> CreatePossibleFiniteStateListCommand { get; private set; }
@@ -229,8 +256,13 @@ namespace CDP4EngineeringModel.ViewModels
         /// <summary>
         /// Gets the <see cref="ICommand"/> to create a <see cref="PossibleFiniteState"/> 
         /// </summary>
-        public ReactiveCommand<object> CreatePossibleStateCommand { get; private set; } 
-        
+        public ReactiveCommand<object> CreatePossibleStateCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ICommand"/> to update multiple <see cref="Parameter"/>s in batch operation mode
+        /// </summary>
+        public ReactiveCommand<object> BatchUpdateParameterCommand { get; private set; }
+
         /// <summary>
         /// Initializes the browser
         /// </summary>
@@ -262,8 +294,10 @@ namespace CDP4EngineeringModel.ViewModels
             this.SetDefaultStateCommand.Subscribe(_ => this.ExecuteSetDefaultCommand());
 
             this.CreatePossibleStateCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreatePossibleState));
-            this.CreatePossibleStateCommand.Subscribe(
-                _ => this.ExecuteCreateCommand<PossibleFiniteState>(this.SelectedThing.Thing.GetContainerOfType<PossibleFiniteStateList>()));
+            this.CreatePossibleStateCommand.Subscribe(_ => this.ExecuteCreateCommand<PossibleFiniteState>(this.SelectedThing.Thing.GetContainerOfType<PossibleFiniteStateList>()));
+
+            this.BatchUpdateParameterCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanUpdateBatchParameters));
+            this.BatchUpdateParameterCommand.Subscribe(_ => this.ExecuteBatchUpdateParameterCommand());
         }
 
         /// <summary>
@@ -303,6 +337,12 @@ namespace CDP4EngineeringModel.ViewModels
                 this.CanCreatePossibleState = this.PermissionService.CanWrite(possibleList);
             }
 
+            var actualFiniteStateListRowViewModel = this.SelectedThing as ActualFiniteStateListRowViewModel;
+            if (actualFiniteStateListRowViewModel != null)
+            {
+                this.CanUpdateBatchParameters = this.PermissionService.CanWrite(ClassKind.Parameter, this.Thing);
+            }
+
             this.CanSetAsDefault = false;
         }
 
@@ -338,6 +378,12 @@ namespace CDP4EngineeringModel.ViewModels
             if (possibleListRow != null)
             {
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Possible Finite State", "", this.CreatePossibleStateCommand, MenuItemKind.Create, ClassKind.PossibleFiniteState));
+            }
+
+            var actualFiniteStateListRowViewModel = this.SelectedThing as ActualFiniteStateListRowViewModel;
+            if (actualFiniteStateListRowViewModel != null)
+            {
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Apply Actual Finite State List to multiple Parameters", "", this.BatchUpdateParameterCommand, MenuItemKind.Edit, ClassKind.NotThing));
             }
         }
 
@@ -430,6 +476,54 @@ namespace CDP4EngineeringModel.ViewModels
 
             transaction.CreateOrUpdate(clone);
             await this.DalWrite(transaction);
+        }
+
+        /// <summary>
+        /// Execute the <see cref="BatchUpdateParameterCommand"/>
+        /// </summary>
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task ExecuteBatchUpdateParameterCommand()
+        {
+            var actualFiniteStateListRowViewModel = this.SelectedThing as ActualFiniteStateListRowViewModel;
+            if (actualFiniteStateListRowViewModel == null)
+            {
+                return;
+            }
+
+            var actualFiniteStateList = (ActualFiniteStateList)actualFiniteStateListRowViewModel.Thing;
+
+            var currentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(this.Thing);
+            var model = (EngineeringModel)this.Thing.Container;
+            var allowedDomainOfExpertises = model.EngineeringModelSetup.ActiveDomain.Where(x => x != currentDomainOfExpertise);
+
+            var requiredRls = model.RequiredRdls;
+            var allowedCategories = requiredRls.SelectMany(rdl => rdl.DefinedCategory).Where(c => c.PermissibleClass.Contains(ClassKind.ElementDefinition));
+            var allowedParameterTypes = requiredRls.SelectMany(rdl => rdl.ParameterType);
+
+            var categoryDomainParameterTypeSelectorDialogViewModel = new CategoryDomainParameterTypeSelectorDialogViewModel(allowedParameterTypes, allowedCategories, allowedDomainOfExpertises);
+            var result = this.DialogNavigationService.NavigateModal(categoryDomainParameterTypeSelectorDialogViewModel) as CategoryDomainParameterTypeSelectorResult;
+
+            if (result == null || !result.Result.HasValue || !result.Result.Value)
+            {
+                return;
+            }
+
+            try
+            {
+                this.IsBusy = true;
+
+                await this.parameterActualFiniteStateListApplicationBatchService.Update(this.Session, this.Thing, actualFiniteStateList, result.IsUncategorizedIncluded, result.Categories, result.DomainOfExpertises, result.ParameterTypes);
+            }
+            catch (Exception exception)
+            {
+                logger.Error(exception, "An error occured when applying an ActualFiniteState to multiple Parameters in a batch operation");
+            }
+            finally
+            {
+                this.IsBusy = false;
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserViewModel.cs
@@ -487,22 +487,19 @@ namespace CDP4EngineeringModel.ViewModels
         private async Task ExecuteBatchUpdateParameterCommand()
         {
             var actualFiniteStateListRowViewModel = this.SelectedThing as ActualFiniteStateListRowViewModel;
+
             if (actualFiniteStateListRowViewModel == null)
             {
                 return;
             }
 
-            var actualFiniteStateList = (ActualFiniteStateList)actualFiniteStateListRowViewModel.Thing;
-
-            var currentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(this.Thing);
             var model = (EngineeringModel)this.Thing.Container;
-            var allowedDomainOfExpertises = model.EngineeringModelSetup.ActiveDomain.Where(x => x != currentDomainOfExpertise);
-
+            
             var requiredRls = model.RequiredRdls;
             var allowedCategories = requiredRls.SelectMany(rdl => rdl.DefinedCategory).Where(c => c.PermissibleClass.Contains(ClassKind.ElementDefinition));
             var allowedParameterTypes = requiredRls.SelectMany(rdl => rdl.ParameterType);
 
-            var categoryDomainParameterTypeSelectorDialogViewModel = new CategoryDomainParameterTypeSelectorDialogViewModel(allowedParameterTypes, allowedCategories, allowedDomainOfExpertises);
+            var categoryDomainParameterTypeSelectorDialogViewModel = new CategoryDomainParameterTypeSelectorDialogViewModel(allowedParameterTypes, allowedCategories, model.EngineeringModelSetup.ActiveDomain);
             var result = this.DialogNavigationService.NavigateModal(categoryDomainParameterTypeSelectorDialogViewModel) as CategoryDomainParameterTypeSelectorResult;
 
             if (result == null || !result.Result.HasValue || !result.Result.Value)
@@ -514,7 +511,7 @@ namespace CDP4EngineeringModel.ViewModels
             {
                 this.IsBusy = true;
 
-                await this.parameterActualFiniteStateListApplicationBatchService.Update(this.Session, this.Thing, actualFiniteStateList, result.IsUncategorizedIncluded, result.Categories, result.DomainOfExpertises, result.ParameterTypes);
+                await this.parameterActualFiniteStateListApplicationBatchService.Update(this.Session, this.Thing, actualFiniteStateListRowViewModel.Thing, result.IsUncategorizedIncluded, result.Categories, result.DomainOfExpertises, result.ParameterTypes);
             }
             catch (Exception exception)
             {

--- a/EngineeringModel/ViewModels/Ribbon Controls/ElementDefinitionRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/Ribbon Controls/ElementDefinitionRibbonViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="ElementDefinitionRibbonViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/ViewModels/Ribbon Controls/ElementDefinitionRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/Ribbon Controls/ElementDefinitionRibbonViewModel.cs
@@ -1,17 +1,39 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ElementDefinitionRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2020 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
     using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
 
     using CDP4EngineeringModel.Services;
@@ -28,7 +50,7 @@ namespace CDP4EngineeringModel.ViewModels
         /// <summary>
         /// The logger for the current class
         /// </summary>
-        private static Logger logger = LogManager.GetCurrentClassLogger();
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ElementDefinitionRibbonViewModel"/> class
@@ -50,10 +72,10 @@ namespace CDP4EngineeringModel.ViewModels
             var stopWatch = Stopwatch.StartNew();
 
             var parameterSubscriptionBatchService = ServiceLocator.Current.GetInstance<IParameterSubscriptionBatchService>();
-
+            
             var viewModel = new ElementDefinitionsBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService, parameterSubscriptionBatchService);
             stopWatch.Stop();
-            logger.Info("Open ElementDefinitionsBrowserViewModel took {0}", stopWatch.Elapsed);
+            Logger.Info("Open ElementDefinitionsBrowserViewModel took {0}", stopWatch.Elapsed);
             return viewModel;
         }
     }

--- a/EngineeringModel/Views/Dialogs/CategoryDomainParameterTypeSelectorDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/CategoryDomainParameterTypeSelectorDialog.xaml
@@ -1,4 +1,4 @@
-﻿<dx:DXWindow x:Class="CDP4EngineeringModel.Views.Dialogs.ParameterSubscriptionFilterSelectionDialog"
+﻿<dx:DXWindow x:Class="CDP4EngineeringModel.Views.Dialogs.CategoryDomainParameterTypeSelectorDialog"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/EngineeringModel/Views/Dialogs/CategoryDomainParameterTypeSelectorDialog.xaml.cs
+++ b/EngineeringModel/Views/Dialogs/CategoryDomainParameterTypeSelectorDialog.xaml.cs
@@ -2,7 +2,7 @@
 // <copyright file="CategoryDomainParameterTypeSelectorDialog.xaml.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
+//    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //
 //    This file is part of CDP4-IME Community Edition. 
 //    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration

--- a/EngineeringModel/Views/Dialogs/CategoryDomainParameterTypeSelectorDialog.xaml.cs
+++ b/EngineeringModel/Views/Dialogs/CategoryDomainParameterTypeSelectorDialog.xaml.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ParameterSubscriptionFilterSelectionDialog.xaml.cs" company="RHEA System S.A.">
+// <copyright file="CategoryDomainParameterTypeSelectorDialog.xaml.cs" company="RHEA System S.A.">
 //    Copyright (c) 2015-2020 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Ahmed
@@ -33,13 +33,13 @@ namespace CDP4EngineeringModel.Views.Dialogs
     /// <summary>
     /// Interaction logic for ParameteterSubscriptionFilterSelectionDialog.xaml
     /// </summary>
-    [DialogViewExport("ParameterSubscriptionFilterSelectionDialog", "The Engineering Model Setup Iteration Selection")]
-    public partial class ParameterSubscriptionFilterSelectionDialog : DXWindow, IDialogView
+    [DialogViewExport("CategoryDomainParameterTypeSelectorDialog", "Category, DomainOfExpertise and ParameterType Selector")]
+    public partial class CategoryDomainParameterTypeSelectorDialog : DXWindow, IDialogView
     {
         // <summary>
         /// Initializes a new instance of the <see cref="ParameterSubscriptionFilterSelectionDialog"/> class
         /// </summary>
-        public ParameterSubscriptionFilterSelectionDialog()
+        public CategoryDomainParameterTypeSelectorDialog()
         {
         }
 
@@ -52,7 +52,7 @@ namespace CDP4EngineeringModel.Views.Dialogs
         /// <remarks>
         /// This constructor is called by the navigation service
         /// </remarks>
-        public ParameterSubscriptionFilterSelectionDialog(bool initializeComponent)
+        public CategoryDomainParameterTypeSelectorDialog(bool initializeComponent)
         {
             if (initializeComponent)
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[Add] IParameterActualFiniteStateListApplicationBatchService and ParameterActualFiniteStateListApplicationBatchService

[Add] IParameterActualFiniteStateListApplicationBatchService to EngineeringModelModule, EngineeringModelRibbonPart, ElementDefinitionsBrowserViewModel, ElementDefinitionRibbonViewModel

[Rename] ParameterSubscriptionFilterSelectionDialog to CategoryDomainParameterTypeSelectorDialog

[Rename]  ParameterSubscriptionFilterSelectionDialogViewModel to CategoryDomainParameterTypeSelectorDialogViewModel

[Rename] ParameterSubscriptionFilterSelectionResult to CategoryDomainParameterTypeSelectorResult

[Update] FiniteStateBrowserViewModel to include context menu item to apply ActualFiniteStateList to multiple Parameters

<!-- Thanks for contributing to CDP4-IME! -->

