### PR TITLE
alpha-sort the Owner dropdown box of the FiniteStatesLists dialogs; fixes #638

### DIFF
--- a/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
@@ -264,7 +264,7 @@ namespace CDP4EngineeringModel.ViewModels
             base.PopulatePossibleOwner();
             var iteration = (Iteration)this.Container;
             var model = (EngineeringModel)iteration.Container;
-            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain);
+            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain.OrderBy(d => d.Name));
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/PossibleFiniteStateListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/PossibleFiniteStateListDialogViewModel.cs
@@ -121,7 +121,7 @@ namespace CDP4EngineeringModel.ViewModels
             base.PopulatePossibleOwner();
             var iteration = (Iteration)this.Container;
             var model = (EngineeringModel)iteration.Container;
-            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain);
+            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain.OrderBy(d => d.Name));
         }
 
         /// <summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
   SONARCLOUD_ORGANIZATION: rheagroup
   SONARCLOUD_URL: 'https://sonarcloud.io'
   SONARCLOUD_TOKEN:
-    secure: SusLBtRCNeSFMhatgx83owIfxgme9yjV8PxhORbPZ0Mz/aixNIbXWZlSz4Zxc05u
+    secure: 67KNIhsvMPwHylkTvfGtu39hYkK94X8svR0pxSBeqbm92ffGeViAv7SVDHnC+kbv
 
 skip_branch_with_pr: true
 for:


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
fixes #638 
Update the PopulatePossibleOwner methods of PossibleFiniteStateListDialogViewModel and ActualFiniteStateListDialogViewModel to sort the EngineeringModelSetup.ActiveDomain (Owners) by Name alphabetically.

Please note that we would need to implement this change to any view model making use of the EngineeringModelSetup.ActiveDomain to display in a ComboBoxEdit as that component has no out of the box sorting. Will create another issue to target that.

<!-- Thanks for contributing to CDP4-IME! -->