### PR TITLE
set/unset the top ElementDefinition from the Element Definitions browser context menu; fixes #222

### DIFF
--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -592,7 +592,7 @@ namespace CDP4EngineeringModel.Tests
 
             vm.SelectedThing = defRow;
             vm.PopulateContextMenu();
-            Assert.AreEqual(16, vm.ContextMenu.Count);
+            Assert.AreEqual(17, vm.ContextMenu.Count);
 
             vm.SelectedThing = defRow.ContainedRows[0];
             vm.PopulateContextMenu();
@@ -818,6 +818,62 @@ namespace CDP4EngineeringModel.Tests
             this.dialogNavigationService.Verify(x => x.NavigateModal(It.IsAny<IDialogViewModel>()), Times.Exactly(1));
 
             this.changeOwnershipBatchService.Verify(x => x.Update(this.session.Object, It.IsAny<ElementDefinition>(), this.domain, true, It.IsAny<IEnumerable<ClassKind>>()), Times.Exactly(1));
+        }
+
+        [Test]
+        public void VerifyThatExecuteSetAsTopeElementDefinitionCommandWorks()
+        {
+            var def2 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            
+            this.iteration.Element.Add(this.elementDef);
+            this.iteration.Element.Add(def2);
+
+            this.iteration.TopElement = this.elementDef;
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+
+            var defRow = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == this.elementDef.Iid);
+            var def2Row = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == def2.Iid);
+
+            vm.SelectedThing = null;
+            vm.UnsetAsTopElementDefinitionCommand.Execute(null);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
+
+            vm.SelectedThing = defRow;
+            vm.SetAsTopElementDefinitionCommand.Execute(null);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
+
+            vm.SelectedThing = def2Row;
+            vm.SetAsTopElementDefinitionCommand.Execute(null);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+        }
+
+        [Test]
+        public void VerifyThatExecuteUnsetAsTopeElementDefinitionCommandWorks()
+        {
+            var def2 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            
+            this.iteration.Element.Add(this.elementDef);
+            this.iteration.Element.Add(def2);
+
+            this.iteration.TopElement = this.elementDef;
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+
+            var defRow = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == this.elementDef.Iid);
+            var def2Row = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == def2.Iid);
+
+            vm.SelectedThing = null;
+            vm.UnsetAsTopElementDefinitionCommand.Execute(null);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
+
+            vm.SelectedThing = def2Row;
+            vm.UnsetAsTopElementDefinitionCommand.Execute(null);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
+
+            vm.SelectedThing = defRow;
+            vm.UnsetAsTopElementDefinitionCommand.Execute(null);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
         }
     }
 }

--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -821,7 +821,7 @@ namespace CDP4EngineeringModel.Tests
         }
 
         [Test]
-        public void VerifyThatExecuteSetAsTopeElementDefinitionCommandWorks()
+        public void VerifyThatExecuteSetAsTopElementDefinitionCommandWorks()
         {
             var def2 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri);
             
@@ -832,8 +832,8 @@ namespace CDP4EngineeringModel.Tests
 
             var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
 
-            var defRow = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == this.elementDef.Iid);
-            var def2Row = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == def2.Iid);
+            var defRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == this.elementDef.Iid) as ElementDefinitionRowViewModel;
+            var def2Row = vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == def2.Iid) as ElementDefinitionRowViewModel;
 
             vm.SelectedThing = null;
             vm.UnsetAsTopElementDefinitionCommand.Execute(null);
@@ -849,7 +849,7 @@ namespace CDP4EngineeringModel.Tests
         }
 
         [Test]
-        public void VerifyThatExecuteUnsetAsTopeElementDefinitionCommandWorks()
+        public void VerifyThatExecuteUnsetAsTopElementDefinitionCommandWorks()
         {
             var def2 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri);
             
@@ -860,8 +860,8 @@ namespace CDP4EngineeringModel.Tests
 
             var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
 
-            var defRow = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == this.elementDef.Iid);
-            var def2Row = (ElementDefinitionRowViewModel)vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == def2.Iid);
+            var defRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == this.elementDef.Iid) as ElementDefinitionRowViewModel;
+            var def2Row = vm.ElementDefinitionRowViewModels.Single(x => x.Thing.Iid == def2.Iid) as ElementDefinitionRowViewModel;
 
             vm.SelectedThing = null;
             vm.UnsetAsTopElementDefinitionCommand.Execute(null);

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -39,9 +39,9 @@ namespace CDP4EngineeringModel.ViewModels
 
     using CDP4Common.ReportingData;
     using CDP4Common.SiteDirectoryData;
-    
+
     using CDP4CommonView.ViewModels;
-    
+
     using CDP4Composition;
     using CDP4Composition.DragDrop;
     using CDP4Composition.Events;
@@ -50,17 +50,17 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
-    
+
     using CDP4Dal;
     using CDP4Dal.Events;
     using CDP4Dal.Permission;
-    
+
     using CDP4EngineeringModel.Services;
     using CDP4EngineeringModel.Utilities;
     using CDP4EngineeringModel.ViewModels.Dialogs;
 
     using NLog;
-    
+
     using ReactiveUI;
 
     /// <summary>
@@ -152,7 +152,7 @@ namespace CDP4EngineeringModel.ViewModels
             : base(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService)
         {
             this.Caption = "Element Definitions";
-            this.ToolTip = $"{((EngineeringModel) this.Thing.Container).EngineeringModelSetup.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
+            this.ToolTip = $"{((EngineeringModel)this.Thing.Container).EngineeringModelSetup.Name}\n{this.Thing.IDalUri}\n{this.Session.ActivePerson.Name}";
 
             this.parameterSubscriptionBatchService = parameterSubscriptionBatchService;
             this.changeOwnershipBatchService = changeOwnershipBatchService;
@@ -279,6 +279,16 @@ namespace CDP4EngineeringModel.ViewModels
         /// Gets the <see cref="ICommand"/> to change the ownership of an <see cref="IOwnedThing"/> and its contained items
         /// </summary>
         public ReactiveCommand<object> ChangeOwnershipCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> to set an <see cref="ElementDefinition"/> as the top element of the selected iteration
+        /// </summary>
+        public ReactiveCommand<object> SetAsTopElementDefinitionCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> to unset an <see cref="ElementDefinition"/> as the top element of the selected iteration
+        /// </summary>
+        public ReactiveCommand<object> UnsetAsTopElementDefinitionCommand { get; private set; }
 
         /// <summary>
         /// Gets the list of rows representing a <see cref="ElementDefinition"/>
@@ -434,12 +444,18 @@ namespace CDP4EngineeringModel.ViewModels
 
             this.CreateSubscriptionCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateSubscription));
             this.CreateSubscriptionCommand.Subscribe(_ => this.ExecuteCreateSubscriptionCommand());
-            
+
             this.BatchCreateSubscriptionCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.CanCreateBatchSubscriptions));
             this.BatchCreateSubscriptionCommand.Subscribe(_ => this.ExecuteBatchCreateSubscriptionCommand());
 
             this.ChangeOwnershipCommand = ReactiveCommand.Create();
             this.ChangeOwnershipCommand.Subscribe(_ => this.ExecuteChangeOwnershipCommand());
+
+            this.SetAsTopElementDefinitionCommand = ReactiveCommand.Create();
+            this.SetAsTopElementDefinitionCommand.Subscribe(_ => this.ExecuteSetAsTopElementDefinitionCommand());
+
+            this.UnsetAsTopElementDefinitionCommand = ReactiveCommand.Create();
+            this.UnsetAsTopElementDefinitionCommand.Subscribe(_ => this.ExecuteUnsetAsTopElementDefinitionCommand());
 
             this.CreateOverrideCommand = ReactiveCommand.Create(this.WhenAnyValue(vm => vm.CanCreateOverride));
             this.CreateOverrideCommand.Subscribe(_ => this.ExecuteCreateParameterOverride());
@@ -510,7 +526,7 @@ namespace CDP4EngineeringModel.ViewModels
             }
 
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create Multiple Subscriptions", "", this.BatchCreateSubscriptionCommand, MenuItemKind.Create, ClassKind.NotThing));
-            
+
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Change Request", "", this.CreateChangeRequestCommand, MenuItemKind.Create, ClassKind.ChangeRequest));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Request For Deviation", "", this.CreateRequestForDeviationCommand, MenuItemKind.Create, ClassKind.RequestForDeviation));
             this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Request For Waiver", "", this.CreateRequestForWaiverCommand, MenuItemKind.Create, ClassKind.RequestForWaiver));
@@ -528,7 +544,16 @@ namespace CDP4EngineeringModel.ViewModels
                 this.ContextMenu.Insert(1, new ContextMenuItemViewModel("Create a Parameter Group", "", this.CreateParameterGroup, MenuItemKind.Create, ClassKind.ParameterGroup));
                 this.ContextMenu.Insert(2, new ContextMenuItemViewModel("Copy the Element Definition", "", this.CopyElementDefinitionCommand, MenuItemKind.Copy, ClassKind.ElementDefinition));
                 this.ContextMenu.Insert(3, new ContextMenuItemViewModel("Highlight Element Usages", "", this.HighlightElementUsagesCommand, MenuItemKind.Highlight, ClassKind.ElementUsage));
-                this.ContextMenu.Insert(4, new ContextMenuItemViewModel("Change Ownership", "", this.ChangeOwnershipCommand , MenuItemKind.Edit, ClassKind.NotThing));
+                this.ContextMenu.Insert(4, new ContextMenuItemViewModel("Change Ownership", "", this.ChangeOwnershipCommand, MenuItemKind.Edit, ClassKind.NotThing));
+
+                if (elementDefRow.IsTopElement)
+                {
+                    this.ContextMenu.Insert(5, new ContextMenuItemViewModel("Unset as Top Element", "", this.UnsetAsTopElementDefinitionCommand, MenuItemKind.Delete, ClassKind.NotThing));
+                }
+                else
+                {
+                    this.ContextMenu.Insert(5, new ContextMenuItemViewModel("Set as Top Element", "", this.SetAsTopElementDefinitionCommand, MenuItemKind.Edit, ClassKind.NotThing));
+                }
 
                 return;
             }
@@ -559,7 +584,7 @@ namespace CDP4EngineeringModel.ViewModels
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Change Request", "", this.CreateChangeRequestCommand, MenuItemKind.Create, ClassKind.ChangeRequest));
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Review Item Discrepancy", "", this.CreateReviewItemDiscrepancyCommand, MenuItemKind.Create, ClassKind.ReviewItemDiscrepancy));
 
-                this.ContextMenu.Add(new ContextMenuItemViewModel("Navigates to Element Definition", "", this.ChangeFocusCommand, MenuItemKind.Navigate, ClassKind.ElementDefinition));
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Navigate to Element Definition", "", this.ChangeFocusCommand, MenuItemKind.Navigate, ClassKind.ElementDefinition));
 
                 if (this.SelectedThing.ContainedRows.Count > 0)
                 {
@@ -935,6 +960,46 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
+        /// Executes the <see cref="SetAsTopElementDefinitionCommand"/>
+        /// </summary>
+        private async Task ExecuteSetAsTopElementDefinitionCommand()
+        {
+            var elementDefRow = this.SelectedThing as ElementDefinitionRowViewModel;
+            if (elementDefRow?.Thing != null && (this.Thing.TopElement == null || this.Thing.TopElement != elementDefRow.Thing))
+            {
+                var iterationClone = this.Thing.Clone(false);
+                iterationClone.TopElement = elementDefRow.Thing;
+
+                var transactionContext = TransactionContextResolver.ResolveContext(this.Thing);
+                var transaction = new ThingTransaction(transactionContext);
+                transaction.CreateOrUpdate(iterationClone);
+
+                await this.DalWrite(transaction);
+            }
+        }
+
+        /// <summary>
+        /// Executes the <see cref="UnsetAsTopElementDefinitionCommandAsTopElementDefinitionCommand"/>
+        /// </summary>
+        private async Task ExecuteUnsetAsTopElementDefinitionCommand()
+        {
+            var iteration = this.Thing;
+            var elementDefRow = this.SelectedThing as ElementDefinitionRowViewModel;
+
+            if (elementDefRow?.Thing != null && iteration.TopElement == elementDefRow.Thing)
+            {
+                var iterationClone = iteration.Clone(false);
+                iterationClone.TopElement = null;
+
+                var transactionContext = TransactionContextResolver.ResolveContext(iteration);
+                var transaction = new ThingTransaction(transactionContext);
+                transaction.CreateOrUpdate(iterationClone);
+
+                await this.DalWrite(transaction);
+            }
+        }
+
+        /// <summary>
         /// Execute the <see cref="ChangeOwnershipCommand"/>
         /// </summary>
         /// <returns>
@@ -962,7 +1027,7 @@ namespace CDP4EngineeringModel.ViewModels
                     this.SelectedThing.Thing,
                     result.DomainOfExpertise,
                     result.IsContainedItemChangeOwnershipSelected,
-                    new List<ClassKind> { ClassKind.ElementDefinition , ClassKind.Parameter});
+                    new List<ClassKind> { ClassKind.ElementDefinition, ClassKind.Parameter });
             }
             catch (Exception exception)
             {

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -28,6 +28,7 @@ namespace CDP4EngineeringModel.ViewModels
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reactive;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
     using System.Windows;
@@ -283,12 +284,12 @@ namespace CDP4EngineeringModel.ViewModels
         /// <summary>
         /// Gets the <see cref="ReactiveCommand"/> to set an <see cref="ElementDefinition"/> as the top element of the selected iteration
         /// </summary>
-        public ReactiveCommand<object> SetAsTopElementDefinitionCommand { get; private set; }
+        public ReactiveCommand<Unit> SetAsTopElementDefinitionCommand { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ReactiveCommand"/> to unset an <see cref="ElementDefinition"/> as the top element of the selected iteration
         /// </summary>
-        public ReactiveCommand<object> UnsetAsTopElementDefinitionCommand { get; private set; }
+        public ReactiveCommand<Unit> UnsetAsTopElementDefinitionCommand { get; private set; }
 
         /// <summary>
         /// Gets the list of rows representing a <see cref="ElementDefinition"/>
@@ -451,11 +452,9 @@ namespace CDP4EngineeringModel.ViewModels
             this.ChangeOwnershipCommand = ReactiveCommand.Create();
             this.ChangeOwnershipCommand.Subscribe(_ => this.ExecuteChangeOwnershipCommand());
 
-            this.SetAsTopElementDefinitionCommand = ReactiveCommand.Create();
-            this.SetAsTopElementDefinitionCommand.Subscribe(_ => this.ExecuteSetAsTopElementDefinitionCommand());
+            this.SetAsTopElementDefinitionCommand = ReactiveCommand.CreateAsyncTask(_ => this.ExecuteSetAsTopElementDefinitionCommandAsync());
 
-            this.UnsetAsTopElementDefinitionCommand = ReactiveCommand.Create();
-            this.UnsetAsTopElementDefinitionCommand.Subscribe(_ => this.ExecuteUnsetAsTopElementDefinitionCommand());
+            this.UnsetAsTopElementDefinitionCommand = ReactiveCommand.CreateAsyncTask(_ => this.ExecuteUnsetAsTopElementDefinitionCommandAsync());
 
             this.CreateOverrideCommand = ReactiveCommand.Create(this.WhenAnyValue(vm => vm.CanCreateOverride));
             this.CreateOverrideCommand.Subscribe(_ => this.ExecuteCreateParameterOverride());
@@ -548,7 +547,7 @@ namespace CDP4EngineeringModel.ViewModels
 
                 if (elementDefRow.IsTopElement)
                 {
-                    this.ContextMenu.Insert(5, new ContextMenuItemViewModel("Unset as Top Element", "", this.UnsetAsTopElementDefinitionCommand, MenuItemKind.Delete, ClassKind.NotThing));
+                    this.ContextMenu.Insert(5, new ContextMenuItemViewModel("Unset as Top Element", "", this.UnsetAsTopElementDefinitionCommand, MenuItemKind.Edit, ClassKind.NotThing));
                 }
                 else
                 {
@@ -962,7 +961,10 @@ namespace CDP4EngineeringModel.ViewModels
         /// <summary>
         /// Executes the <see cref="SetAsTopElementDefinitionCommand"/>
         /// </summary>
-        private async Task ExecuteSetAsTopElementDefinitionCommand()
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns> 
+        private async Task ExecuteSetAsTopElementDefinitionCommandAsync()
         {
             var elementDefRow = this.SelectedThing as ElementDefinitionRowViewModel;
             if (elementDefRow?.Thing != null && (this.Thing.TopElement == null || this.Thing.TopElement != elementDefRow.Thing))
@@ -979,9 +981,12 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
-        /// Executes the <see cref="UnsetAsTopElementDefinitionCommandAsTopElementDefinitionCommand"/>
+        /// Executes the <see cref="UnsetAsTopElementDefinitionCommand"/>
         /// </summary>
-        private async Task ExecuteUnsetAsTopElementDefinitionCommand()
+        /// <returns>
+        /// an awaitable <see cref="Task"/>
+        /// </returns>
+        private async Task ExecuteUnsetAsTopElementDefinitionCommandAsync()
         {
             var iteration = this.Thing;
             var elementDefRow = this.SelectedThing as ElementDefinitionRowViewModel;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

[Add] 2 commands for settings/unsetting an ElementDefinition as the top element of an iteration. The change is made on an iteration clone which then gets propagated through a Dal iteration transaction, then reflected on all subscribers of the iteration's changes.

<!-- Thanks for contributing to CDP4-IME! -->

