### PR TITLE
#665 Support compound parameters

### DIFF
--- a/CDP4CrossViewEditor.Tests/Assemblers/CrossviewArrayAssemblerTestFixture.cs
+++ b/CDP4CrossViewEditor.Tests/Assemblers/CrossviewArrayAssemblerTestFixture.cs
@@ -115,6 +115,23 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
                 }
             };
 
+            var option1 = new Option(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+            {
+                Name = "Option 1",
+                ShortName = "OPT_1",
+            };
+
+            this.iteration.Option.Add(option1);
+            this.iteration.DefaultOption = option1;
+
+            var option2 = new Option(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+            {
+                Name = "Option 2",
+                ShortName = "OPT_2"
+            };
+
+            this.iteration.Option.Add(option2);
+
             var elementDefinition = new ElementDefinition
             {
                 Iid = Guid.NewGuid(),
@@ -159,12 +176,24 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
 
             var parameterValueset1 = new ParameterValueSet(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
             {
-                Manual = new ValueArray<string>(new List<string> { "Manual" }),
-                Reference = new ValueArray<string>(new List<string> { "Reference" }),
-                Computed = new ValueArray<string>(new List<string> { "Computed" }),
-                Formula = new ValueArray<string>(new List<string> { "Formula" }),
-                Published = new ValueArray<string>(new List<string> { "Published" }),
-                ValueSwitch = ParameterSwitchKind.MANUAL
+                Manual = new ValueArray<string>(new List<string> { "1" }),
+                Reference = new ValueArray<string>(new List<string> { "1.1" }),
+                Computed = new ValueArray<string>(new List<string> { "1.2" }),
+                Formula = new ValueArray<string>(new List<string> { "1.3" }),
+                Published = new ValueArray<string>(new List<string> { "1.4" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                ActualOption = option1
+            };
+
+            var parameterValueset2 = new ParameterValueSet(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+            {
+                Manual = new ValueArray<string>(new List<string> { "1" }),
+                Reference = new ValueArray<string>(new List<string> { "1" }),
+                Computed = new ValueArray<string>(new List<string> { "1" }),
+                Formula = new ValueArray<string>(new List<string> { "1" }),
+                Published = new ValueArray<string>(new List<string> { "1" }),
+                ValueSwitch = ParameterSwitchKind.REFERENCE,
+                ActualOption = option2
             };
 
             var parameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
@@ -177,7 +206,7 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
                 },
                 Owner = this.domain,
                 StateDependence = actualList,
-                ValueSet = { parameterValueset1 },
+                ValueSet = { parameterValueset1, parameterValueset2 }
             };
 
             this.iteration.Element.Add(elementDefinition);

--- a/CDP4CrossViewEditor.Tests/Assemblers/CrossviewArrayAssemblerTestFixture.cs
+++ b/CDP4CrossViewEditor.Tests/Assemblers/CrossviewArrayAssemblerTestFixture.cs
@@ -34,6 +34,7 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
     using CDP4Common.SiteDirectoryData;
 
     using CDP4CrossViewEditor.Assemblers;
+    using CDP4CrossViewEditor.Generator;
     using CDP4CrossViewEditor.RowModels.CrossviewSheet;
 
     using CDP4Dal;
@@ -167,7 +168,7 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
             var contentArray = arrayAssembler.ContentArray;
 
             // The array contains more rows to make a nice header and spacing
-            Assert.AreEqual(this.excelRows.Count, contentArray.GetLength(0) - arrayAssembler.ActualHeaderDepth);
+            Assert.AreEqual(this.excelRows.Count, contentArray.GetLength(0) - CrossviewSheetConstants.HeaderDepth);
         }
 
         [Test]
@@ -181,9 +182,9 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
             var contentArray = arrayAssembler.ContentArray;
 
             // The array contains more rows to make a nice header and spacing
-            Assert.AreEqual(this.excelRows.Count, contentArray.GetLength(0) - arrayAssembler.ActualHeaderDepth);
-            Assert.AreEqual("ElementDefinition_1", contentArray[arrayAssembler.ActualHeaderDepth, 0]);
-            Assert.AreEqual("ED_1", contentArray[arrayAssembler.ActualHeaderDepth, 1]);
+            Assert.AreEqual(this.excelRows.Count, contentArray.GetLength(0) - CrossviewSheetConstants.HeaderDepth);
+            Assert.AreEqual("ElementDefinition_1", contentArray[CrossviewSheetConstants.HeaderDepth, 0]);
+            Assert.AreEqual("ED_1", contentArray[CrossviewSheetConstants.HeaderDepth, 1]);
         }
     }
 }

--- a/CDP4CrossViewEditor.Tests/Assemblers/CrossviewArrayAssemblerTestFixture.cs
+++ b/CDP4CrossViewEditor.Tests/Assemblers/CrossviewArrayAssemblerTestFixture.cs
@@ -196,7 +196,7 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
                 ActualOption = option2
             };
 
-            var parameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+            var parameter1 = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
             {
                 ParameterType = parameterType,
                 Scale = new RatioScale(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
@@ -209,8 +209,42 @@ namespace CDP4CrossViewEditor.Tests.Assemblers
                 ValueSet = { parameterValueset1, parameterValueset2 }
             };
 
+            var compoundParameterType = new CompoundParameterType(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri){
+                Name = "CompoundParameterType_1",
+                ShortName = "CPT_1"
+            };
+
+            compoundParameterType.Component.Add(new ParameterTypeComponent(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+            {
+                ShortName = "a",
+                ParameterType = parameterType
+            });
+
+            compoundParameterType.Component.Add(new ParameterTypeComponent(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+            {
+                ShortName = "b",
+                ParameterType = parameterType
+            });
+
+            this.parameterTypes.Add(compoundParameterType);
+
+            var parameter2 = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+            {
+                ParameterType = compoundParameterType,
+                Owner = this.domain,
+                ValueSet =
+                {
+                    new ParameterValueSet(Guid.NewGuid(), this.assembler.Cache, this.credentials.Uri)
+                    {
+                        Manual = new ValueArray<string>(new List<string> { "a_value", "b_value" }),
+                        ValueSwitch = ParameterSwitchKind.MANUAL
+                    }
+                }
+            };
+
             this.iteration.Element.Add(elementDefinition);
-            this.iteration.Element.FirstOrDefault()?.Parameter.Add(parameter);
+            elementDefinition.Parameter.Add(parameter1);
+            elementDefinition.Parameter.Add(parameter2);
 
             this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>
             {

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -205,7 +205,7 @@ namespace CDP4CrossViewEditor.Assemblers
                         measurementUnitShortName);
 
                     rows[0, columnIndex] = parameterTypeShortName;
-                    rows[1, columnIndex] = measurementUnitShortName;
+                    rows[1, columnIndex] = $"[{measurementUnitShortName}]";
                 }
             }
 

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -314,7 +314,6 @@ namespace CDP4CrossViewEditor.Assemblers
                 {
                     if (parameterOrOverrideBase.ParameterType is CompoundParameterType compoundParameterType)
                     {
-                        // TODO #695: account for recursive CompoundParameterTypes
                         for (var i = 0; i < compoundParameterType.NumberOfValues; ++i)
                         {
                             var component = compoundParameterType.Component[i];

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -64,7 +64,7 @@ namespace CDP4CrossViewEditor.Assemblers
         /// </summary>
         internal readonly
             Dictionary<string,
-                SortedDictionary<string, 
+                SortedDictionary<string,
                     SortedDictionary<string,
                         SortedDictionary<string,
                             SortedDictionary<string,
@@ -295,11 +295,13 @@ namespace CDP4CrossViewEditor.Assemblers
                 case ElementUsage elementUsage:
                     parameters = this.parameterTypes
                         .Select(pt => GetParameterOrOverrideBase(elementUsage, pt));
+
                     break;
 
                 case ElementDefinition elementDefinition:
                     parameters = this.parameterTypes
                         .Select(pt => GetParameterOrOverrideBase(elementDefinition, pt));
+
                     break;
 
                 default:
@@ -376,7 +378,7 @@ namespace CDP4CrossViewEditor.Assemblers
         /// <param name="parameterValueSet">
         /// The given <see cref="ParameterValueSet"/>
         /// </param>
-        private void SetContentColumnIndex(ParameterValueSet parameterValueSet)
+        private void SetContentColumnIndex(ParameterValueSetBase parameterValueSet)
         {
             var parameter = (Parameter)parameterValueSet.Container;
 
@@ -391,7 +393,7 @@ namespace CDP4CrossViewEditor.Assemblers
                             component.Scale?.ShortName ?? "",
                             parameterValueSet.ActualOption?.ShortName ?? "",
                             parameter.StateDependence?.ShortName ?? "",
-                            parameterValueSet.ActualState?.ShortName ?? ""), 
+                            parameterValueSet.ActualState?.ShortName ?? ""),
                         -1);
                 }
             }

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -314,7 +314,7 @@ namespace CDP4CrossViewEditor.Assemblers
                 {
                     if (parameterOrOverrideBase.ParameterType is CompoundParameterType compoundParameterType)
                     {
-                        // TODO account for recursive CompoundParameterTypes
+                        // TODO #695: account for recursive CompoundParameterTypes
                         for (var i = 0; i < compoundParameterType.NumberOfValues; ++i)
                         {
                             var component = compoundParameterType.Component[i];

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -87,11 +87,6 @@ namespace CDP4CrossViewEditor.Assemblers
         public object[,] FormatArray { get; private set; }
 
         /// <summary>
-        /// Gets the array that contains the parameter sheet information
-        /// </summary>
-        private object[,] FormulaArray { get; set; }
-
-        /// <summary>
         /// Gets the array that contains locked cells information
         /// </summary>
         public object[,] LockArray { get; private set; }
@@ -120,7 +115,6 @@ namespace CDP4CrossViewEditor.Assemblers
             this.ContentArray = new object[,] { };
             this.LockArray = new object[,] { };
             this.FormatArray = new object[,] { };
-            this.FormulaArray = new object[,] { };
         }
 
         /// <summary>
@@ -135,7 +129,6 @@ namespace CDP4CrossViewEditor.Assemblers
             this.ContentArray = new object[this.excelRows.Count() + contentHeader.Count, this.numberOfColumns];
             this.LockArray = new object[this.ContentArray.GetLength(0), this.ContentArray.GetLength(1)];
             this.FormatArray = new object[this.ContentArray.GetLength(0), this.ContentArray.GetLength(1)];
-            this.FormulaArray = new object[this.ContentArray.GetLength(0), this.ContentArray.GetLength(1)];
 
             var contentList = new List<object[]>();
 

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -25,6 +25,7 @@
 
 namespace CDP4CrossViewEditor.Assemblers
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
 
@@ -34,6 +35,8 @@ namespace CDP4CrossViewEditor.Assemblers
 
     using CDP4CrossViewEditor.Generator;
     using CDP4CrossViewEditor.RowModels.CrossviewSheet;
+
+    using HeaderColumn = System.ValueTuple<string, string, string, string>;
 
     /// <summary>
     /// The purpose of the <see cref="CrossviewArrayAssembler"/> is to create the arrays that are
@@ -47,13 +50,6 @@ namespace CDP4CrossViewEditor.Assemblers
         private int numberOfColumns = CrossviewSheetConstants.FixedColumns;
 
         /// <summary>
-        /// The actual number of header nested layers.
-        /// This might be lower than <see cref="CrossviewSheetConstants.HeaderDepth"/>
-        /// if all values on a layer are missing.
-        /// </summary>
-        public int ActualHeaderDepth { get; private set; }
-
-        /// <summary>
         /// The <see cref="IExcelRow{T}"/> that are being used to populate the various arrays
         /// </summary>
         private readonly IEnumerable<IExcelRow<Thing>> excelRows;
@@ -64,10 +60,11 @@ namespace CDP4CrossViewEditor.Assemblers
         private IEnumerable<ParameterType> parameterTypes;
 
         /// <summary>
-        /// The header structure mapping parameters to indices
+        /// The header structure mapping parameter layer short names to indices:
+        /// ParamterType -> ActualFiniteStateList -> ActualFiniteState -> MeasurementUnit -> index
         /// </summary>
-        internal readonly Dictionary<string, SortedDictionary<string, int>> headerDictionary
-            = new Dictionary<string, SortedDictionary<string, int>>();
+        internal readonly Dictionary<string, SortedDictionary<string, SortedDictionary<string, SortedDictionary<string, int>>>> headerDictionary
+            = new Dictionary<string, SortedDictionary<string, SortedDictionary<string, SortedDictionary<string, int>>>>();
 
         /// <summary>
         /// Gets the array that contains the parameter sheet information
@@ -125,8 +122,6 @@ namespace CDP4CrossViewEditor.Assemblers
 
             var contentHeader = this.GenerateContentHeader();
 
-            this.ActualHeaderDepth = CrossviewSheetConstants.HeaderDepth;
-
             this.ContentArray = new object[this.excelRows.Count() + contentHeader.Count, this.numberOfColumns];
             this.LockArray = new object[this.ContentArray.GetLength(0), this.ContentArray.GetLength(1)];
             this.FormatArray = new object[this.ContentArray.GetLength(0), this.ContentArray.GetLength(1)];
@@ -148,6 +143,38 @@ namespace CDP4CrossViewEditor.Assemblers
         }
 
         /// <summary>
+        /// Gets all header columns
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IEnumerable{HeaderColumn}"/>
+        /// </returns>
+        private IEnumerable<HeaderColumn> GetHeaderColumns()
+        {
+            foreach (var parameterTypeShortName in this.headerDictionary.Keys.ToList())
+            {
+                var msDictionary = this.headerDictionary[parameterTypeShortName];
+
+                foreach (var measurementScaleShortName in msDictionary.Keys.ToList())
+                {
+                    var afslDictionary = msDictionary[measurementScaleShortName];
+
+                    foreach (var actualFiniteStateListShortName in afslDictionary.Keys.ToList())
+                    {
+                        var afsDictionary = afslDictionary[actualFiniteStateListShortName];
+
+                        foreach (var actualFiniteStateShortName in afsDictionary.Keys.ToList())
+                        {
+                            yield return (parameterTypeShortName,
+                                measurementScaleShortName,
+                                actualFiniteStateListShortName,
+                                actualFiniteStateShortName);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Initializes the header structure mapping parameters to indices
         /// </summary>
         private void InitializeHeaderStructure()
@@ -159,19 +186,16 @@ namespace CDP4CrossViewEditor.Assemblers
                 foreach (var parameter in elementDefinition.Parameter
                     .Where(parameter => this.parameterTypes.Contains(parameter.ParameterType)))
                 {
-                    this.SetContentColumnIndex(parameter);
+                    foreach (var valueSet in parameter.ValueSet)
+                    {
+                        this.SetContentColumnIndex(valueSet);
+                    }
                 }
             }
 
-            foreach (var parameterTypeShortName in this.headerDictionary.Keys.ToList())
+            foreach (var headerColumn in this.GetHeaderColumns())
             {
-                foreach (var measurementUnitShortName in this.headerDictionary[parameterTypeShortName].Keys.ToList())
-                {
-                    this.SetContentColumnIndex(
-                        parameterTypeShortName,
-                        measurementUnitShortName,
-                        this.numberOfColumns++);
-                }
+                this.SetContentColumnIndex(headerColumn, this.numberOfColumns++);
             }
         }
 
@@ -196,17 +220,19 @@ namespace CDP4CrossViewEditor.Assemblers
                 rows[i, 4] = "Category";
             }
 
-            foreach (var parameterTypeShortName in this.headerDictionary.Keys)
+            foreach (var headerColumn in this.GetHeaderColumns())
             {
-                foreach (var measurementUnitShortName in this.headerDictionary[parameterTypeShortName].Keys)
-                {
-                    var columnIndex = this.GetContentColumnIndex(
-                        parameterTypeShortName,
-                        measurementUnitShortName);
+                var columnIndex = this.GetContentColumnIndex(headerColumn);
 
-                    rows[0, columnIndex] = parameterTypeShortName;
-                    rows[1, columnIndex] = $"[{measurementUnitShortName}]";
-                }
+                (
+                    rows[0, columnIndex],
+                    rows[1, columnIndex],
+                    rows[2, columnIndex],
+                    rows[3, columnIndex]
+                    ) = headerColumn;
+
+                // add square brackets to MeasurementScale short name
+                rows[1, columnIndex] = $"[{rows[1, columnIndex]}]";
             }
 
             for (var i = 0; i < CrossviewSheetConstants.HeaderDepth; ++i)
@@ -243,30 +269,29 @@ namespace CDP4CrossViewEditor.Assemblers
             contentRow[3] = excelRow.Owner;
             contentRow[4] = excelRow.Categories;
 
-            IEnumerable<ParameterBase> parameters;
+            IEnumerable<ParameterOrOverrideBase> parameters;
 
             switch (excelRow.Thing)
             {
                 case ElementUsage elementUsage:
                     parameters = this.parameterTypes
-                        .Select(pt => GetParameterBase(elementUsage, pt))
-                        .Where(p => p != null);
+                        .Select(pt => GetParameterOrOverrideBase(elementUsage, pt));
                     break;
 
                 case ElementDefinition elementDefinition:
                     parameters = this.parameterTypes
-                        .Select(pt => GetParameterBase(elementDefinition, pt))
-                        .Where(p => p != null);
+                        .Select(pt => GetParameterOrOverrideBase(elementDefinition, pt));
                     break;
 
                 default:
                     return contentRow;
             }
 
-            foreach (var parameterBase in parameters)
+            foreach (var parameterValueSetBase in parameters
+                .Where(p => p != null)
+                .SelectMany(p => p.ValueSets.Cast<ParameterValueSetBase>()))
             {
-                var valueSet = parameterBase.ValueSets.FirstOrDefault();
-                contentRow[this.GetContentColumnIndex(parameterBase)] = valueSet?.ActualValue.FirstOrDefault();
+                contentRow[this.GetContentColumnIndex(parameterValueSetBase)] = parameterValueSetBase.ActualValue.FirstOrDefault();
             }
 
             return contentRow;
@@ -285,12 +310,12 @@ namespace CDP4CrossViewEditor.Assemblers
         /// The given <see cref="ParameterType"/>
         /// </param>
         /// <returns>
-        /// The <see cref="ParameterBase"/>
+        /// The <see cref="ParameterOrOverrideBase"/>
         /// </returns>
-        private static ParameterBase GetParameterBase(ElementUsage elementUsage, ParameterType parameterType)
+        private static ParameterOrOverrideBase GetParameterOrOverrideBase(ElementUsage elementUsage, ParameterType parameterType)
         {
             return elementUsage.ParameterOverride.FirstOrDefault(po => po.ParameterType == parameterType)
-                   ?? GetParameterBase(elementUsage.ElementDefinition, parameterType);
+                   ?? GetParameterOrOverrideBase(elementUsage.ElementDefinition, parameterType);
         }
 
         /// <summary>
@@ -304,94 +329,113 @@ namespace CDP4CrossViewEditor.Assemblers
         /// The given <see cref="ParameterType"/>
         /// </param>
         /// <returns>
-        /// The <see cref="ParameterBase"/>
+        /// The <see cref="ParameterOrOverrideBase"/>
         /// </returns>
-        private static ParameterBase GetParameterBase(ElementDefinition elementDefinition, ParameterType parameterType)
+        private static ParameterOrOverrideBase GetParameterOrOverrideBase(ElementDefinition elementDefinition, ParameterType parameterType)
         {
             return elementDefinition.Parameter.FirstOrDefault(p => p.ParameterType == parameterType);
         }
 
         /// <summary>
-        /// Sets the column index associated to the given <paramref name="parameterBase"/>
-        /// to the given column <paramref name="index"/>
+        /// Initializes the column index associated to the given <paramref name="parameterValueSet"/>
         /// </summary>
-        /// <param name="parameterBase">
-        /// The given <see cref="ParameterBase"/>
+        /// <param name="parameterValueSet">
+        /// The given <see cref="ParameterValueSet"/>
         /// </param>
-        /// <param name="index">
-        /// The given column index
-        /// </param>
-        private void SetContentColumnIndex(ParameterBase parameterBase, int index = -1)
+        private void SetContentColumnIndex(ParameterValueSet parameterValueSet)
         {
-            this.SetContentColumnIndex(
-                parameterBase.ParameterType.ShortName,
-                parameterBase.Scale?.ShortName ?? "",
-                index);
+            var parameter = (Parameter)parameterValueSet.Container;
+
+            this.SetContentColumnIndex((
+                    parameter.ParameterType.ShortName,
+                    parameter.Scale?.ShortName ?? "",
+                    parameter.StateDependence?.ShortName ?? "",
+                    parameterValueSet.ActualState?.ShortName ?? ""),
+                -1);
         }
 
         /// <summary>
-        /// Sets the column index associated to the given arguments
+        /// Sets the column index associated to the given <paramref name="headerColumn"/>
         /// to the given column <paramref name="index"/>
         /// </summary>
-        /// <param name="parameterTypeShortName">
-        /// The given <see cref="ParameterType"/> short name
-        /// </param>
-        /// <param name="measurementScaleShortName">
-        /// The given <see cref="MeasurementScale"/> short name
+        /// <param name="headerColumn">
+        /// The given <see cref="HeaderColumn"/>
         /// </param>
         /// <param name="index">
         /// The given column index
         /// </param>
-        private void SetContentColumnIndex(
-            string parameterTypeShortName,
-            string measurementScaleShortName,
-            int index)
+        private void SetContentColumnIndex(HeaderColumn headerColumn, int index)
         {
+            var (parameterTypeShortName,
+                measurementScaleShortName,
+                actualFiniteStateListShortName,
+                actualFiniteStateShortName) = headerColumn;
+
             if (!this.headerDictionary.ContainsKey(parameterTypeShortName))
             {
-                this.headerDictionary[parameterTypeShortName] = new SortedDictionary<string, int>();
+                this.headerDictionary[parameterTypeShortName] = new SortedDictionary<string, SortedDictionary<string, SortedDictionary<string, int>>>();
             }
 
-            var scaleDictionary = this.headerDictionary[parameterTypeShortName];
+            var msDictionary = this.headerDictionary[parameterTypeShortName];
 
-            scaleDictionary[measurementScaleShortName] = index;
+            if (!msDictionary.ContainsKey(measurementScaleShortName))
+            {
+                msDictionary[measurementScaleShortName] = new SortedDictionary<string, SortedDictionary<string, int>>();
+            }
+
+            var afslDictionary = msDictionary[measurementScaleShortName];
+
+            if (!afslDictionary.ContainsKey(actualFiniteStateListShortName))
+            {
+                afslDictionary[actualFiniteStateListShortName] = new SortedDictionary<string, int>();
+            }
+
+            var afsDictionary = afslDictionary[actualFiniteStateListShortName];
+
+            afsDictionary[actualFiniteStateShortName] = index;
         }
 
         /// <summary>
-        /// Gets the column index associated to the given <paramref name="parameterBase"/>
+        /// Gets the column index associated to the given <paramref name="parameterValueSetBase"/>
         /// </summary>
-        /// <param name="parameterBase">
-        /// The given <see cref="ParameterBase"/>
+        /// <param name="parameterValueSetBase">
+        /// The given <see cref="ParameterValueSetBase"/>
         /// </param>
         /// <returns>
         /// The column index
         /// </returns>
-        private int GetContentColumnIndex(ParameterBase parameterBase)
+        private int GetContentColumnIndex(ParameterValueSetBase parameterValueSetBase)
         {
-            return this.GetContentColumnIndex(
-                parameterBase.ParameterType.ShortName,
-                parameterBase.Scale?.ShortName ?? "");
+            var parameterOrOverrideBase = (ParameterOrOverrideBase)parameterValueSetBase.Container;
+
+            return this.GetContentColumnIndex((
+                parameterOrOverrideBase.ParameterType.ShortName,
+                parameterOrOverrideBase.Scale?.ShortName ?? "",
+                parameterOrOverrideBase.StateDependence?.ShortName ?? "",
+                parameterValueSetBase.ActualState?.ShortName ?? ""));
         }
 
         /// <summary>
-        /// Gets the column index associated to the given arguments
+        /// Gets the column index associated to the given <paramref name="headerColumn"/>
         /// </summary>
-        /// <param name="parameterTypeShortName">
-        /// The given <see cref="ParameterType"/> short name
-        /// </param>
-        /// <param name="measurementScaleShortName">
-        /// The given <see cref="MeasurementScale"/> short name
+        /// <param name="headerColumn">
+        /// The given <see cref="HeaderColumn"/>
         /// </param>
         /// <returns>
         /// The column index
         /// </returns>
-        private int GetContentColumnIndex(
-            string parameterTypeShortName,
-            string measurementScaleShortName)
+        private int GetContentColumnIndex(HeaderColumn headerColumn)
         {
+            var (parameterTypeShortName,
+                measurementScaleShortName,
+                actualFiniteStateListShortName,
+                actualFiniteStateShortName) = headerColumn;
+
             return this.headerDictionary
                 [parameterTypeShortName]
-                [measurementScaleShortName];
+                [measurementScaleShortName]
+                [actualFiniteStateListShortName]
+                [actualFiniteStateShortName];
         }
 
         /// <summary>

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
@@ -39,7 +39,7 @@ namespace CDP4CrossViewEditor.Generator
 
         /// <summary>
         /// The number of header nested "layers":
-        /// ParamterType -> ActualFiniteStateList -> ActualFiniteState -> MeasurementUnit.
+        /// ParameterType -> MeasurementUnit -> ActualFiniteStateList -> ActualFiniteState.
         /// </summary>
         internal const int HeaderDepth = 4;
 

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
@@ -38,10 +38,10 @@ namespace CDP4CrossViewEditor.Generator
         internal const int FixedColumns = 5;
 
         /// <summary>
-        /// The number of header nested "layers": ParamterType, MeasurementUnit.
-        /// NOTE: There might be fewer actual header rows if all values on a layer are missing.
+        /// The number of header nested "layers":
+        /// ParamterType -> ActualFiniteStateList -> ActualFiniteState -> MeasurementUnit.
         /// </summary>
-        internal const int HeaderDepth = 2;
+        internal const int HeaderDepth = 4;
 
         /// <summary>
         /// The name of the range on the Parameters sheet that contains the header rows.

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
@@ -39,9 +39,9 @@ namespace CDP4CrossViewEditor.Generator
 
         /// <summary>
         /// The number of header nested "layers":
-        /// ParameterType -> MeasurementUnit -> ActualFiniteStateList -> ActualFiniteState.
+        /// ParameterType -> MeasurementScale -> Option -> ActualFiniteStateList -> ActualFiniteState.
         /// </summary>
-        internal const int HeaderDepth = 4;
+        internal const int HeaderDepth = 5;
 
         /// <summary>
         /// The name of the range on the Parameters sheet that contains the header rows.

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetConstants.cs
@@ -39,9 +39,9 @@ namespace CDP4CrossViewEditor.Generator
 
         /// <summary>
         /// The number of header nested "layers":
-        /// ParameterType -> MeasurementScale -> Option -> ActualFiniteStateList -> ActualFiniteState.
+        /// ParameterType -> ParamterTypeComponent -> MeasurementScale -> Option -> ActualFiniteStateList -> ActualFiniteState.
         /// </summary>
-        internal const int HeaderDepth = 5;
+        internal const int HeaderDepth = 6;
 
         /// <summary>
         /// The name of the range on the Parameters sheet that contains the header rows.

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
@@ -303,6 +303,28 @@ namespace CDP4CrossViewEditor.Generator
                         this.crossviewSheet.Cells[dataStartRow, i])
                     .Merge();
             }
+            
+            // collapse empty header rows
+            for (var i = 0; i < CrossviewSheetConstants.HeaderDepth; ++i)
+            {
+                var collapse = true;
+
+                for (var j = CrossviewSheetConstants.FixedColumns; j < numberOfColumns; ++j)
+                {
+                    if ((string)this.crossviewArrayAssember.ContentArray[i, j] == "")
+                    {
+                        continue;
+                    }
+
+                    collapse = false;
+                    break;
+                }
+
+                if (collapse)
+                {
+                    this.crossviewSheet.Cells[numberOfHeaderRows + i + 1, 1].EntireRow.Hidden = true;
+                }
+            }
 
             // group horizontal parameter columns
             var bodyHeaderDictionary = this.crossviewArrayAssember.headerDictionary;

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
@@ -255,7 +255,7 @@ namespace CDP4CrossViewEditor.Generator
             var numberOfBodyRows = this.crossviewArrayAssember.ContentArray.GetLength(0);
             var numberOfColumns = this.crossviewArrayAssember.ContentArray.GetLength(1);
 
-            var dataStartRow = numberOfHeaderRows + this.crossviewArrayAssember.ActualHeaderDepth;
+            var dataStartRow = numberOfHeaderRows + CrossviewSheetConstants.HeaderDepth;
             var dataEndRow = numberOfHeaderRows + numberOfBodyRows;
 
             var parameterRange = this.crossviewSheet.Range(
@@ -278,6 +278,23 @@ namespace CDP4CrossViewEditor.Generator
             formattedRange.Font.Size = 11;
             formattedRange.EntireColumn.AutoFit();
 
+            this.PrettifyBodyHeader();
+
+            this.ApplyCellNames(dataStartRow, CrossviewSheetConstants.FixedColumns + 1, dataEndRow, numberOfColumns);
+
+            this.crossviewSheet.Cells[dataStartRow + 1, 1].Select();
+            this.excelApplication.ActiveWindow.FreezePanes = true;
+        }
+
+        /// <summary>
+        /// Prettify body header
+        /// </summary>
+        private void PrettifyBodyHeader()
+        {
+            var numberOfHeaderRows = this.headerArrayAssembler.HeaderArray.GetLength(0);
+            var numberOfColumns = this.crossviewArrayAssember.ContentArray.GetLength(1);
+            var dataStartRow = numberOfHeaderRows + CrossviewSheetConstants.HeaderDepth;
+
             // format fixed columns
             for (var i = 1; i <= CrossviewSheetConstants.FixedColumns; ++i)
             {
@@ -289,26 +306,66 @@ namespace CDP4CrossViewEditor.Generator
 
             // group horizontal parameter columns
             var bodyHeaderDictionary = this.crossviewArrayAssember.headerDictionary;
-            foreach (var parameterTypeShortName in bodyHeaderDictionary.Keys)
-            {
-                var min = bodyHeaderDictionary[parameterTypeShortName].Values.Min();
-                var max = bodyHeaderDictionary[parameterTypeShortName].Values.Max();
 
-                if (min == max)
+            foreach (var parameterTypeShortName in bodyHeaderDictionary.Keys.ToList())
+            {
+                var msDictionary = bodyHeaderDictionary[parameterTypeShortName];
+
+                var minPt = numberOfColumns;
+                var maxPt = 0;
+
+                foreach (var measurementScaleShortName in msDictionary.Keys.ToList())
+                {
+                    var afslDictionary = msDictionary[measurementScaleShortName];
+
+                    var minMs = numberOfColumns;
+                    var maxMs = 0;
+
+                    foreach (var actualFiniteStateListShortName in afslDictionary.Keys.ToList())
+                    {
+                        var afsDictionary = afslDictionary[actualFiniteStateListShortName];
+
+                        var minAfsl = afsDictionary.Values.Min();
+                        var maxAfsl = afsDictionary.Values.Max();
+
+                        minMs = Math.Min(minMs, minAfsl);
+                        maxMs = Math.Max(maxMs, maxAfsl);
+
+                        minPt = Math.Min(minPt, minAfsl);
+                        maxPt = Math.Max(maxPt, maxAfsl);
+
+                        if (minAfsl == maxAfsl)
+                        {
+                            continue;
+                        }
+
+                        this.crossviewSheet.Range(
+                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, minAfsl + 1],
+                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, maxAfsl + 1])
+                            .Merge();
+                    }
+
+                    if (minMs == maxMs)
+                    {
+                        continue;
+                    }
+
+                    this.crossviewSheet.Range(
+                            this.crossviewSheet.Cells[numberOfHeaderRows + 2, minMs + 1],
+                            this.crossviewSheet.Cells[numberOfHeaderRows + 2, maxMs + 1])
+                        .Merge();
+                }
+
+                if (minPt == maxPt)
                 {
                     continue;
                 }
 
                 this.crossviewSheet.Range(
-                        this.crossviewSheet.Cells[numberOfHeaderRows + 1, min + 1],
-                        this.crossviewSheet.Cells[numberOfHeaderRows + 1, max + 1])
+                        this.crossviewSheet.Cells[numberOfHeaderRows + 1, minPt + 1],
+                        this.crossviewSheet.Cells[numberOfHeaderRows + 1, maxPt + 1])
                     .Merge();
             }
-
-            this.ApplyCellNames(dataStartRow, CrossviewSheetConstants.FixedColumns + 1, dataEndRow, numberOfColumns);
-
-            this.crossviewSheet.Cells[dataStartRow + 1, 1].Select();
-            this.excelApplication.ActiveWindow.FreezePanes = true;
         }
 
         /// <summary>

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
@@ -331,71 +331,92 @@ namespace CDP4CrossViewEditor.Generator
 
             foreach (var parameterTypeShortName in bodyHeaderDictionary.Keys.ToList())
             {
-                var msDictionary = bodyHeaderDictionary[parameterTypeShortName];
+                var ptcDictionary = bodyHeaderDictionary[parameterTypeShortName];
 
                 var minPt = numberOfColumns;
                 var maxPt = 0;
 
-                foreach (var measurementScaleShortName in msDictionary.Keys.ToList())
+                foreach (var parameterTypeComponentShortName in ptcDictionary.Keys.ToList())
                 {
-                    var oDictionary = msDictionary[measurementScaleShortName];
+                    var msDictionary = ptcDictionary[parameterTypeComponentShortName];
 
-                    var minMs = numberOfColumns;
-                    var maxMs = 0;
+                    var minPtc = numberOfColumns;
+                    var maxPtc = 0;
 
-                    foreach (var optionShortName in oDictionary.Keys.ToList())
+                    foreach (var measurementScaleShortName in msDictionary.Keys.ToList())
                     {
-                        var afslDictionary = oDictionary[optionShortName];
+                        var oDictionary = msDictionary[measurementScaleShortName];
 
-                        var minO = numberOfColumns;
-                        var maxO = 0;
+                        var minMs = numberOfColumns;
+                        var maxMs = 0;
 
-                        foreach (var actualFiniteStateListShortName in afslDictionary.Keys.ToList())
+                        foreach (var optionShortName in oDictionary.Keys.ToList())
                         {
-                            var afsDictionary = afslDictionary[actualFiniteStateListShortName];
+                            var afslDictionary = oDictionary[optionShortName];
 
-                            var minAfsl = afsDictionary.Values.Min();
-                            var maxAfsl = afsDictionary.Values.Max();
+                            var minO = numberOfColumns;
+                            var maxO = 0;
 
-                            minO = Math.Min(minO, minAfsl);
-                            maxO = Math.Max(maxO, maxAfsl);
+                            foreach (var actualFiniteStateListShortName in afslDictionary.Keys.ToList())
+                            {
+                                var afsDictionary = afslDictionary[actualFiniteStateListShortName];
 
-                            minMs = Math.Min(minMs, minAfsl);
-                            maxMs = Math.Max(maxMs, maxAfsl);
+                                var minAfsl = afsDictionary.Values.Min();
+                                var maxAfsl = afsDictionary.Values.Max();
 
-                            minPt = Math.Min(minPt, minAfsl);
-                            maxPt = Math.Max(maxPt, maxAfsl);
+                                minO = Math.Min(minO, minAfsl);
+                                maxO = Math.Max(maxO, maxAfsl);
 
-                            if (minAfsl == maxAfsl)
+                                minMs = Math.Min(minMs, minAfsl);
+                                maxMs = Math.Max(maxMs, maxAfsl);
+
+                                minPtc = Math.Min(minPtc, minAfsl);
+                                maxPtc = Math.Max(maxPtc, maxAfsl);
+
+                                minPt = Math.Min(minPt, minAfsl);
+                                maxPt = Math.Max(maxPt, maxAfsl);
+
+                                if (minAfsl == maxAfsl)
+                                {
+                                    continue;
+                                }
+
+                                this.crossviewSheet.Range(
+                                        this.crossviewSheet.Cells[numberOfHeaderRows + 5, minAfsl + 1],
+                                        this.crossviewSheet.Cells[numberOfHeaderRows + 5, maxAfsl + 1])
+                                    .Merge();
+                            }
+
+                            if (minO == maxO)
                             {
                                 continue;
                             }
 
                             this.crossviewSheet.Range(
-                                    this.crossviewSheet.Cells[numberOfHeaderRows + 4, minAfsl + 1],
-                                    this.crossviewSheet.Cells[numberOfHeaderRows + 4, maxAfsl + 1])
+                                    this.crossviewSheet.Cells[numberOfHeaderRows + 4, minO + 1],
+                                    this.crossviewSheet.Cells[numberOfHeaderRows + 4, maxO + 1])
                                 .Merge();
                         }
 
-                        if (minO == maxO)
+                        if (minMs == maxMs)
                         {
                             continue;
                         }
 
                         this.crossviewSheet.Range(
-                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, minO + 1],
-                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, maxO + 1])
+                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, minMs + 1],
+                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, maxMs + 1])
                             .Merge();
                     }
 
-                    if (minMs == maxMs)
+                    if (minPtc == maxPtc)
                     {
                         continue;
                     }
 
                     this.crossviewSheet.Range(
-                            this.crossviewSheet.Cells[numberOfHeaderRows + 2, minMs + 1],
-                            this.crossviewSheet.Cells[numberOfHeaderRows + 2, maxMs + 1])
+                            this.crossviewSheet.Cells[numberOfHeaderRows + 2, minPtc + 1],
+                            this.crossviewSheet.Cells[numberOfHeaderRows + 2, maxPtc + 1])
                         .Merge();
                 }
 

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
@@ -338,32 +338,53 @@ namespace CDP4CrossViewEditor.Generator
 
                 foreach (var measurementScaleShortName in msDictionary.Keys.ToList())
                 {
-                    var afslDictionary = msDictionary[measurementScaleShortName];
+                    var oDictionary = msDictionary[measurementScaleShortName];
 
                     var minMs = numberOfColumns;
                     var maxMs = 0;
 
-                    foreach (var actualFiniteStateListShortName in afslDictionary.Keys.ToList())
+                    foreach (var optionShortName in oDictionary.Keys.ToList())
                     {
-                        var afsDictionary = afslDictionary[actualFiniteStateListShortName];
+                        var afslDictionary = oDictionary[optionShortName];
 
-                        var minAfsl = afsDictionary.Values.Min();
-                        var maxAfsl = afsDictionary.Values.Max();
+                        var minO = numberOfColumns;
+                        var maxO = 0;
 
-                        minMs = Math.Min(minMs, minAfsl);
-                        maxMs = Math.Max(maxMs, maxAfsl);
+                        foreach (var actualFiniteStateListShortName in afslDictionary.Keys.ToList())
+                        {
+                            var afsDictionary = afslDictionary[actualFiniteStateListShortName];
 
-                        minPt = Math.Min(minPt, minAfsl);
-                        maxPt = Math.Max(maxPt, maxAfsl);
+                            var minAfsl = afsDictionary.Values.Min();
+                            var maxAfsl = afsDictionary.Values.Max();
 
-                        if (minAfsl == maxAfsl)
+                            minO = Math.Min(minO, minAfsl);
+                            maxO = Math.Max(maxO, maxAfsl);
+
+                            minMs = Math.Min(minMs, minAfsl);
+                            maxMs = Math.Max(maxMs, maxAfsl);
+
+                            minPt = Math.Min(minPt, minAfsl);
+                            maxPt = Math.Max(maxPt, maxAfsl);
+
+                            if (minAfsl == maxAfsl)
+                            {
+                                continue;
+                            }
+
+                            this.crossviewSheet.Range(
+                                    this.crossviewSheet.Cells[numberOfHeaderRows + 4, minAfsl + 1],
+                                    this.crossviewSheet.Cells[numberOfHeaderRows + 4, maxAfsl + 1])
+                                .Merge();
+                        }
+
+                        if (minO == maxO)
                         {
                             continue;
                         }
 
                         this.crossviewSheet.Range(
-                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, minAfsl + 1],
-                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, maxAfsl + 1])
+                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, minO + 1],
+                                this.crossviewSheet.Cells[numberOfHeaderRows + 3, maxO + 1])
                             .Merge();
                     }
 

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
@@ -280,11 +280,10 @@ namespace CDP4CrossViewEditor.Generator
 
             this.PrettifyBodyHeader();
 
-            this.ApplyCellNames(
-                dataStartRow + 1,
-                CrossviewSheetConstants.FixedColumns + 1,
-                dataEndRow,
-                numberOfColumns);
+            this.crossviewSheet.Range(
+                    this.crossviewSheet.Cells[dataStartRow + 1, CrossviewSheetConstants.FixedColumns + 1],
+                    this.crossviewSheet.Cells[dataEndRow, numberOfColumns])
+                .CreateNames(top: false, left: false, bottom: false, right: true);
 
             this.crossviewSheet.Cells[dataStartRow + 1, 1].Select();
             this.excelApplication.ActiveWindow.FreezePanes = true;
@@ -434,29 +433,6 @@ namespace CDP4CrossViewEditor.Generator
                         this.crossviewSheet.Cells[numberOfHeaderRows + 1, maxPt + 1])
                     .Merge();
             }
-        }
-
-        /// <summary>
-        /// Apply cell names to the actual value column
-        /// </summary>
-        /// <param name="beginRow">
-        /// The row at which the range begins
-        /// </param>
-        /// <param name="beginColumn">
-        /// The column at which the range begins
-        /// </param>
-        /// <param name="endRow">
-        /// The row at which the range ends
-        /// </param>
-        /// <param name="endColumn">
-        /// The column at which the range ends
-        /// </param>
-        private void ApplyCellNames(int beginRow, int beginColumn, int endRow, int endColumn)
-        {
-            this.crossviewSheet.Range(
-                    this.crossviewSheet.Cells[beginRow, beginColumn],
-                    this.crossviewSheet.Cells[endRow, endColumn])
-                .CreateNames(top: false, left: false, bottom: false, right: true);
         }
     }
 }


### PR DESCRIPTION
Add Crossview support for single layer compound parameters.

Nested compound parameter types need additional work, but CDP4 doesn't let you create them even though according to 10-25 they are valid.