### PR TITLE
#694 UI fixes

### DIFF
--- a/CDP4CrossViewEditor.Tests/ViewModels/CrossViewDialogViewModelTestFixture.cs
+++ b/CDP4CrossViewEditor.Tests/ViewModels/CrossViewDialogViewModelTestFixture.cs
@@ -144,7 +144,7 @@ namespace CDP4CrossViewEditor.Tests.ViewModels
         {
             var viewModel = new CrossViewDialogViewModel(null, this.iteration, this.session.Object);
 
-            Assert.AreEqual("Select equipments and parameters", viewModel.DialogTitle);
+            Assert.AreEqual("Select ElementDefinitions and ParameterTypes", viewModel.DialogTitle);
             Assert.IsInstanceOf<ElementDefinitionSelectorViewModel>(viewModel.ElementSelectorViewModel);
             Assert.IsInstanceOf<ParameterTypeSelectorViewModel>(viewModel.ParameterSelectorViewModel);
         }

--- a/CDP4CrossViewEditor/ViewModels/CrossViewDialogViewModel.cs
+++ b/CDP4CrossViewEditor/ViewModels/CrossViewDialogViewModel.cs
@@ -115,13 +115,14 @@ namespace CDP4CrossViewEditor.ViewModels
         public CrossViewDialogViewModel(Application application, Iteration iteration, ISession session)
         {
             this.Workbooks = new List<WorkbookRowViewModel>();
-            this.DialogTitle = "Select equipments and parameters";
             this.Iteration = iteration;
             this.Session = session;
             this.PopulateWorkbooks(application);
 
             this.ElementSelectorViewModel = new ElementDefinitionSelectorViewModel(this.Iteration, this.Session);
             this.ParameterSelectorViewModel = new ParameterTypeSelectorViewModel(this.Iteration, this.Session);
+
+            this.DialogTitle = $"Select {this.ElementSelectorViewModel.ThingClassKind}s and {this.ParameterSelectorViewModel.ThingClassKind}s";
 
             this.CancelCommand = ReactiveCommand.Create();
             this.CancelCommand.Subscribe(_ => this.ExecuteCancel());

--- a/CDP4CrossViewEditor/ViewModels/ElementDefinitionSelectorViewModel.cs
+++ b/CDP4CrossViewEditor/ViewModels/ElementDefinitionSelectorViewModel.cs
@@ -122,7 +122,7 @@ namespace CDP4CrossViewEditor.ViewModels
         /// <summary>
         /// Move element definition back to source list
         /// </summary>
-        protected override void ExecuteMoveToSource()
+        protected internal override void ExecuteMoveToSource()
         {
             ExecuteMove(this.ElementDefinitionTargetList, this.ElementDefinitionSourceList, this.SelectedTargetList);
         }
@@ -130,7 +130,7 @@ namespace CDP4CrossViewEditor.ViewModels
         /// <summary>
         /// Move element definition back to target list
         /// </summary>
-        protected override void ExecuteMoveToTarget()
+        protected internal override void ExecuteMoveToTarget()
         {
             ExecuteMove(this.ElementDefinitionSourceList, this.ElementDefinitionTargetList, this.SelectedSourceList);
         }

--- a/CDP4CrossViewEditor/ViewModels/ElementDefinitionSelectorViewModel.cs
+++ b/CDP4CrossViewEditor/ViewModels/ElementDefinitionSelectorViewModel.cs
@@ -71,7 +71,8 @@ namespace CDP4CrossViewEditor.ViewModels
         /// </summary>
         /// <param name="iteration">Current opened iteration <see cref="Iteration"/></param>
         /// <param name="session">Current opened session <see cref="ISession"/></param>
-        public ElementDefinitionSelectorViewModel(Iteration iteration, ISession session) : base(iteration, session, ClassKind.ElementBase)
+        public ElementDefinitionSelectorViewModel(Iteration iteration, ISession session)
+            : base(iteration, session, ClassKind.ElementDefinition)
         {
             this.ElementDefinitionSourceList = new ReactiveList<ElementDefinitionRowViewModel>
             {

--- a/CDP4CrossViewEditor/ViewModels/ParameterTypeSelectorViewModel.cs
+++ b/CDP4CrossViewEditor/ViewModels/ParameterTypeSelectorViewModel.cs
@@ -177,9 +177,17 @@ namespace CDP4CrossViewEditor.ViewModels
         /// <summary>
         /// Move parameter types back to source list
         /// </summary>
-        protected override void ExecuteMoveToSource()
+        protected internal override void ExecuteMoveToSource()
         {
             ExecuteMove(this.ParameterTypeTargetList, this.ParameterTypeSourceList, this.SelectedTargetList);
+        }
+
+        /// <summary>
+        /// Move parameter types back to target list
+        /// </summary>
+        protected internal override void ExecuteMoveToTarget()
+        {
+            ExecuteMove(this.ParameterTypeSourceList, this.ParameterTypeTargetList, this.SelectedSourceList);
         }
 
         /// <summary>
@@ -190,14 +198,6 @@ namespace CDP4CrossViewEditor.ViewModels
             this.SelectedTargetList = this.ParameterTypeTargetList;
 
             this.ExecuteMoveToSource();
-        }
-
-        /// <summary>
-        /// Move parameter types back to target list
-        /// </summary>
-        protected override void ExecuteMoveToTarget()
-        {
-            ExecuteMove(this.ParameterTypeSourceList, this.ParameterTypeTargetList, this.SelectedSourceList);
         }
 
         /// <summary>

--- a/CDP4CrossViewEditor/ViewModels/ParameterTypeSelectorViewModel.cs
+++ b/CDP4CrossViewEditor/ViewModels/ParameterTypeSelectorViewModel.cs
@@ -87,7 +87,8 @@ namespace CDP4CrossViewEditor.ViewModels
         /// </summary>
         /// <param name="iteration">Current opened iteration <see cref="Iteration"/></param>
         /// <param name="session">Current opened session <see cref="ISession"/></param>
-        public ParameterTypeSelectorViewModel(Iteration iteration, ISession session) : base(iteration, session, ClassKind.ParameterBase)
+        public ParameterTypeSelectorViewModel(Iteration iteration, ISession session)
+            : base(iteration, session, ClassKind.ParameterType)
         {
             this.ParameterTypeSourceList = new ReactiveList<ParameterTypeRowViewModel>
             {

--- a/CDP4CrossViewEditor/ViewModels/ThingSelectorViewModel.cs
+++ b/CDP4CrossViewEditor/ViewModels/ThingSelectorViewModel.cs
@@ -111,7 +111,7 @@ namespace CDP4CrossViewEditor.ViewModels
         /// Executes move to source command <see cref="MoveItemsToSource"/>
         /// Things will be moved back to selection source
         /// </summary>
-        protected virtual void ExecuteMoveToSource()
+        protected internal virtual void ExecuteMoveToSource()
         {
         }
 
@@ -119,7 +119,7 @@ namespace CDP4CrossViewEditor.ViewModels
         /// Executes move to target command <see cref="MoveItemsToTarget"/>
         /// Things will be selected for Cross View Editor table/report
         /// </summary>
-        protected virtual void ExecuteMoveToTarget()
+        protected internal virtual void ExecuteMoveToTarget()
         {
         }
 
@@ -137,6 +137,7 @@ namespace CDP4CrossViewEditor.ViewModels
         /// <param name="targetList">Target list</param>
         /// <param name="selectedElements">Elements that will be moved beween source and target</param>
         protected static void ExecuteMove<T>(ReactiveList<T> sourceList, ReactiveList<T> targetList, ReactiveList<T> selectedElements)
+            where T : ReactiveObject
         {
             if (selectedElements.Count == 0)
             {
@@ -144,9 +145,8 @@ namespace CDP4CrossViewEditor.ViewModels
             }
 
             targetList.AddRange(selectedElements);
-            var reverseList = selectedElements.Reverse();
 
-            foreach (var element in reverseList)
+            foreach (var element in selectedElements.Reverse())
             {
                 sourceList.Remove(element);
             }

--- a/CDP4CrossViewEditor/ViewModels/ThingSelectorViewModel.cs
+++ b/CDP4CrossViewEditor/ViewModels/ThingSelectorViewModel.cs
@@ -50,10 +50,10 @@ namespace CDP4CrossViewEditor.ViewModels
         /// <summary>
         /// Gets or sets thing type
         /// </summary>
-        private ClassKind ThingClassKind
+        public ClassKind ThingClassKind
         {
             get => this.thingClassKind;
-            set => this.RaiseAndSetIfChanged(ref this.thingClassKind, value);
+            private set => this.RaiseAndSetIfChanged(ref this.thingClassKind, value);
         }
 
         /// <summary>

--- a/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml
+++ b/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml
@@ -33,10 +33,10 @@
                                      SelectedItems="{Binding Path=SelectedSourceList,
                                                              Mode=TwoWay,
                                                              UpdateSourceTrigger=PropertyChanged}"
+                                     ItemsSource="{Binding ElementDefinitionSourceList}"
                                      SelectionMode="Row"
                                      AutoGenerateColumns="None"
-                                     CustomUniqueValues="GridControl_OnCustomUniqueValues"
-                                     ItemsSource="{Binding ElementDefinitionSourceList}">
+                                     CustomUniqueValues="GridControl_OnCustomUniqueValues">
                         <dxg:GridControl.View>
                             <dxg:TableView HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"

--- a/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml
+++ b/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml
@@ -36,7 +36,8 @@
                                      ItemsSource="{Binding ElementDefinitionSourceList}"
                                      SelectionMode="Row"
                                      AutoGenerateColumns="None"
-                                     CustomUniqueValues="GridControl_OnCustomUniqueValues">
+                                     CustomUniqueValues="GridControl_OnCustomUniqueValues"
+                                     MouseDoubleClick="GridControl_OnMouseDoubleClickSource">
                         <dxg:GridControl.View>
                             <dxg:TableView HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"
@@ -79,9 +80,10 @@
                                      SelectedItems="{Binding Path=SelectedTargetList,
                                                              Mode=TwoWay,
                                                              UpdateSourceTrigger=PropertyChanged}"
+                                     ItemsSource="{Binding ElementDefinitionTargetList}"
                                      SelectionMode="Row"
                                      AutoGenerateColumns="None"
-                                     ItemsSource="{Binding ElementDefinitionTargetList}">
+                                     MouseDoubleClick="GridControl_OnMouseDoubleClickTarget">
                         <dxg:GridControl.View>
                             <dxg:TableView HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"

--- a/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml
+++ b/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml
@@ -13,7 +13,11 @@
     <dxlc:LayoutControl Height="Auto"
                         Background="White"
                         Orientation="Vertical">
-        <GroupBox Header="Element" Padding="5" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+        <GroupBox
+            Header="{Binding ThingClassKind}"
+            Padding="5"
+            VerticalAlignment="Stretch"
+            HorizontalAlignment="Stretch">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />

--- a/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml.cs
+++ b/CDP4CrossViewEditor/Views/UserControls/ElementThingSelector.xaml.cs
@@ -27,6 +27,7 @@ namespace CDP4CrossViewEditor.Views.UserControls
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Windows.Input;
 
     using CDP4Common.SiteDirectoryData;
 
@@ -61,6 +62,33 @@ namespace CDP4CrossViewEditor.Views.UserControls
         {
             this.InitializeComponent();
             CreateAndRegisterCustomFunctionOperators();
+        }
+
+        /// <summary>
+        /// Creates and registers the custom functions used to filter the category column
+        /// </summary>
+        private static void CreateAndRegisterCustomFunctionOperators()
+        {
+            var isMemberOfCategoryFunction = CustomFunctionFactory.Create(
+                IsMemberOfCategoryName,
+                (IEnumerable<Category> categories, string categoryName) =>
+                {
+                    return categories?.Any(x => x.Name.ToString().Equals(categoryName) ||
+                                                x.AllSuperCategories().Any(y => y.Name.ToString().Equals(categoryName)))
+                           ?? false;
+                });
+
+            CriteriaOperator.RegisterCustomFunction(isMemberOfCategoryFunction);
+
+            var hasCategoryAppliedFunction = CustomFunctionFactory.Create(
+                HasCategoryApplied,
+                (IEnumerable<Category> categories, string categoryName) =>
+                {
+                    return categories?.Any(x => x.Name.ToString().Equals(categoryName))
+                           ?? false;
+                });
+
+            CriteriaOperator.RegisterCustomFunction(hasCategoryAppliedFunction);
         }
 
         /// <summary>
@@ -122,27 +150,25 @@ namespace CDP4CrossViewEditor.Views.UserControls
         }
 
         /// <summary>
-        /// Creates and registers the custom functions used to filter the category column
+        /// Move elements on double click
         /// </summary>
-        private static void CreateAndRegisterCustomFunctionOperators()
+        /// <param name="sender">Associated control <see cref="GridControl"/></param>
+        /// <param name="e">Associated event <see cref="MouseButtonEventArgs"/></param>
+        private void GridControl_OnMouseDoubleClickSource(object sender, MouseButtonEventArgs e)
         {
-            var isMemberOfCategoryFunction = CustomFunctionFactory.Create(
-                IsMemberOfCategoryName,
-                (IEnumerable<Category> categories, string categoryName) =>
-                {
-                    return categories?.Any(x => x.Name.ToString().Equals(categoryName) || x.AllSuperCategories().Any(y => y.Name.ToString().Equals(categoryName))) ?? false;
-                });
+            (this.DataContext as ElementDefinitionSelectorViewModel)
+                ?.ExecuteMoveToTarget();
+        }
 
-            CriteriaOperator.RegisterCustomFunction(isMemberOfCategoryFunction);
-
-            var hasCategoryAppliedFunction = CustomFunctionFactory.Create(
-                HasCategoryApplied,
-                (IEnumerable<Category> categories, string categoryName) =>
-                {
-                    return categories?.Any(x => x.Name.ToString().Equals(categoryName)) ?? false;
-                });
-
-            CriteriaOperator.RegisterCustomFunction(hasCategoryAppliedFunction);
+        /// <summary>
+        /// Move elements on double click
+        /// </summary>
+        /// <param name="sender">Associated control <see cref="GridControl"/></param>
+        /// <param name="e">Associated event <see cref="MouseButtonEventArgs"/></param>
+        private void GridControl_OnMouseDoubleClickTarget(object sender, MouseButtonEventArgs e)
+        {
+            (this.DataContext as ElementDefinitionSelectorViewModel)
+                ?.ExecuteMoveToSource();
         }
     }
 }

--- a/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml
+++ b/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml
@@ -34,7 +34,8 @@
                                                             Mode=TwoWay,
                                                             UpdateSourceTrigger=PropertyChanged}"
                                      ItemsSource="{Binding ParameterTypeSourceList}"
-                                     SelectionMode="Row">
+                                     SelectionMode="Row"
+                                     MouseDoubleClick="GridControl_OnMouseDoubleClickSource">
                         <dxg:GridControl.View>
                             <dxg:TableView HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"
@@ -73,9 +74,10 @@
                                      SelectedItems="{Binding Path=SelectedTargetList,
                                                             Mode=TwoWay,
                                                             UpdateSourceTrigger=PropertyChanged}"
+                                     ItemsSource="{Binding ParameterTypeTargetList}"
                                      SelectionMode="Row"
                                      AutoGenerateColumns="None"
-                                     ItemsSource="{Binding ParameterTypeTargetList}">
+                                     MouseDoubleClick="GridControl_OnMouseDoubleClickTarget">
                         <dxg:GridControl.View>
                             <dxg:TableView HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"

--- a/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml
+++ b/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml
@@ -13,7 +13,11 @@
     <dxlc:LayoutControl Height="Auto"
                         Background="White"
                         Orientation="Vertical">
-        <GroupBox Header="Parameter" Padding="5" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+        <GroupBox
+            Header="{Binding ThingClassKind}"
+            Padding="5"
+            VerticalAlignment="Stretch"
+            HorizontalAlignment="Stretch">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />

--- a/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml
+++ b/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml
@@ -33,7 +33,8 @@
                                      SelectedItems="{Binding Path=SelectedSourceList,
                                                             Mode=TwoWay,
                                                             UpdateSourceTrigger=PropertyChanged}"
-                                     ItemsSource="{Binding ParameterTypeSourceList}">
+                                     ItemsSource="{Binding ParameterTypeSourceList}"
+                                     SelectionMode="Row">
                         <dxg:GridControl.View>
                             <dxg:TableView HorizontalAlignment="Stretch"
                                            VerticalAlignment="Stretch"

--- a/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml.cs
+++ b/CDP4CrossViewEditor/Views/UserControls/ParameterThingSelector.xaml.cs
@@ -25,6 +25,12 @@
 
 namespace CDP4CrossViewEditor.Views.UserControls
 {
+    using System.Windows.Input;
+
+    using CDP4CrossViewEditor.ViewModels;
+
+    using DevExpress.Xpf.Grid;
+
     /// <summary>
     /// Interaction logic for ParameterThingSelector.xaml
     /// </summary>
@@ -36,6 +42,28 @@ namespace CDP4CrossViewEditor.Views.UserControls
         public ParameterThingSelector()
         {
             this.InitializeComponent();
+        }
+
+        /// <summary>
+        /// Move elements on double click
+        /// </summary>
+        /// <param name="sender">Associated control <see cref="GridControl"/></param>
+        /// <param name="e">Associated event <see cref="MouseButtonEventArgs"/></param>
+        private void GridControl_OnMouseDoubleClickSource(object sender, MouseButtonEventArgs e)
+        {
+            (this.DataContext as ParameterTypeSelectorViewModel)
+                ?.ExecuteMoveToTarget();
+        }
+
+        /// <summary>
+        /// Move elements on double click
+        /// </summary>
+        /// <param name="sender">Associated control <see cref="GridControl"/></param>
+        /// <param name="e">Associated event <see cref="MouseButtonEventArgs"/></param>
+        private void GridControl_OnMouseDoubleClickTarget(object sender, MouseButtonEventArgs e)
+        {
+            (this.DataContext as ParameterTypeSelectorViewModel)
+                ?.ExecuteMoveToSource();
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Improvements:
* title: "Select equipments and parameters" -> "Select element definitions and parameter types"
* top panel: "Elements" -> "Element definitions"
* multiple selection and Ctrl+A should work in the bottom parameter grid as well, not just in the top one for elements
* double clicking on an element should add/remove it from the current grid

