### PR TITLE
Rename dialog title and add ShortName to ParameterToStateMapping

### DIFF
--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -577,7 +577,27 @@ namespace CDP4CrossViewEditor.Assemblers
             {
                 for (var j = this.LockArray.GetLowerBound(1); j <= this.LockArray.GetUpperBound(1); j++)
                 {
-                    this.LockArray[i, j] = i < CrossviewSheetConstants.HeaderDepth || j < CrossviewSheetConstants.FixedColumns;
+                    var locked = false;
+
+                    // lock header
+                    if (i < CrossviewSheetConstants.HeaderDepth)
+                    {
+                        locked = true;
+                    }
+                    
+                    // lock fixed columns
+                    if (j < CrossviewSheetConstants.FixedColumns)
+                    {
+                        locked = true;
+                    }
+                    
+                    // lock cells with no corresponding parameter
+                    if (this.ContentArray[i, j] == null)
+                    {
+                        locked = true;
+                    }
+
+                    this.LockArray[i, j] = locked;
                 }
             }
         }

--- a/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
+++ b/CDP4CrossViewEditor/Assemblers/CrossviewArrayAssembler.cs
@@ -339,14 +339,14 @@ namespace CDP4CrossViewEditor.Assemblers
 
                             var index = this.GetContentColumnIndex(parameterValueSetBase, component);
                             contentRow[index] = value;
-                            namesRow[index] = $"{CrossviewSheetConstants.CrossviewSheetName}_{parameterValueSetBase.ModelCode(i)}";
+                            namesRow[index] = GetCellName(excelRow.Thing, parameterValueSetBase, i);
                         }
                     }
                     else
                     {
                         var index = this.GetContentColumnIndex(parameterValueSetBase);
                         contentRow[index] = parameterValueSetBase.ActualValue.First();
-                        namesRow[index] = $"{CrossviewSheetConstants.CrossviewSheetName}_{parameterValueSetBase.ModelCode()}";
+                        namesRow[index] = GetCellName(excelRow.Thing, parameterValueSetBase);
                     }
                 }
             }
@@ -391,6 +391,33 @@ namespace CDP4CrossViewEditor.Assemblers
         private static ParameterOrOverrideBase GetParameterOrOverrideBase(ElementDefinition elementDefinition, ParameterType parameterType)
         {
             return elementDefinition.Parameter.FirstOrDefault(p => p.ParameterType == parameterType);
+        }
+
+        /// <summary>
+        /// Generate a cell name for the given <paramref name="parameterValueSetBase"/>. Note that non-<see cref="ParameterOverrideValueSet"/>s
+        /// displayed on <see cref="ElementUsage"/> <paramref name="rowThing"/>s will not have a name, as they are not interactible.
+        /// </summary>
+        /// <param name="rowThing">
+        /// The <see cref="Thing"/> of the associated row.
+        /// </param>
+        /// <param name="parameterValueSetBase">
+        ///  The <see cref="ParameterValueSetBase"/> for which to generate the cell name.
+        /// </param>
+        /// <param name="componentIndex">
+        /// Optional, the <see cref="ParameterTypeComponent"/> index.
+        /// </param>
+        /// <returns>
+        /// The cell name.
+        /// </returns>
+        private static string GetCellName(Thing rowThing, ParameterValueSetBase parameterValueSetBase, int? componentIndex = null)
+        {
+            // non-overrides displayed on EUs are not interactible
+            if (rowThing is ElementUsage && parameterValueSetBase is ParameterValueSet)
+            {
+                return null;
+            }
+
+            return $"{CrossviewSheetConstants.CrossviewSheetName}_{parameterValueSetBase.ModelCode(componentIndex)}";
         }
 
         /// <summary>
@@ -577,27 +604,9 @@ namespace CDP4CrossViewEditor.Assemblers
             {
                 for (var j = this.LockArray.GetLowerBound(1); j <= this.LockArray.GetUpperBound(1); j++)
                 {
-                    var locked = false;
-
-                    // lock header
-                    if (i < CrossviewSheetConstants.HeaderDepth)
-                    {
-                        locked = true;
-                    }
-                    
-                    // lock fixed columns
-                    if (j < CrossviewSheetConstants.FixedColumns)
-                    {
-                        locked = true;
-                    }
-                    
-                    // lock cells with no corresponding parameter
-                    if (this.ContentArray[i, j] == null)
-                    {
-                        locked = true;
-                    }
-
-                    this.LockArray[i, j] = locked;
+                    // only named cells can be edited
+                    // this excludes: header, fixed columns, cells with no corresponding parameter
+                    this.LockArray[i, j] = this.NamesArray[i, j] == null;
                 }
             }
         }

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
@@ -29,6 +29,7 @@ namespace CDP4CrossViewEditor.Generator
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Drawing;
     using System.Linq;
 
     using CDP4Common.EngineeringModelData;
@@ -294,12 +295,12 @@ namespace CDP4CrossViewEditor.Generator
                     {
                         cellObject.Value = changedValues[cellName];
                         var range = this.crossviewSheet.Range(cellObject, cellObject);
-                        range.Font.Color = System.Drawing.ColorTranslator.ToOle(System.Drawing.Color.Blue);
+                        range.Font.Color = ColorTranslator.ToOle(Color.Blue);
                     }
                 }
             }
 
-            this.crossviewSheet.Cells[dataStartRow + 1, 1].Select();
+            this.crossviewSheet.Cells[dataStartRow + 1, CrossviewSheetConstants.FixedColumns + 1].Select();
             this.excelApplication.ActiveWindow.FreezePanes = true;
         }
 

--- a/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
+++ b/CDP4CrossViewEditor/Generator/CrossviewSheetGenerator.cs
@@ -278,24 +278,31 @@ namespace CDP4CrossViewEditor.Generator
             this.PrettifyBodyHeader();
 
             // add names to parameter value cells
-            for (var i = 0; i < numberOfBodyRows; ++i)
+            for (var i = CrossviewSheetConstants.HeaderDepth; i < numberOfBodyRows; ++i)
             {
-                for (var j = 0; j < numberOfColumns; ++j)
+                for (var j = CrossviewSheetConstants.FixedColumns; j < numberOfColumns; ++j)
                 {
-                    if (this.crossviewArrayAssember.NamesArray[i, j] == null)
+                    var cell = this.crossviewSheet.Cells[numberOfHeaderRows + i + 1, j + 1];
+                    var name = this.crossviewArrayAssember.NamesArray[i, j];
+
+                    if (name == null)
                     {
+                        // non-overrides displayed on EUs are not interactible
+                        if (cell.Value != null)
+                        {
+                            cell.Font.Color = ColorTranslator.ToOle(Color.Gray);
+                        }
+
                         continue;
                     }
 
-                    var cellName = this.crossviewArrayAssember.NamesArray[i, j].ToString();
-                    var cellObject = this.crossviewSheet.Cells[numberOfHeaderRows + i + 1, j + 1];
-                    cellObject.Name = cellName;
+                    cell.Name = name.ToString();
 
-                    if (changedValues.ContainsKey(cellName))
+                    // highlight manually saved values
+                    if (changedValues.ContainsKey(name.ToString()))
                     {
-                        cellObject.Value = changedValues[cellName];
-                        var range = this.crossviewSheet.Range(cellObject, cellObject);
-                        range.Font.Color = ColorTranslator.ToOle(Color.Blue);
+                        cell.Value = changedValues[name.ToString()];
+                        cell.Font.Color = ColorTranslator.ToOle(Color.Blue);
                     }
                 }
             }

--- a/CDP4ReferenceDataMapper.Tests/Managers/DataSourceManagerTestFixture.cs
+++ b/CDP4ReferenceDataMapper.Tests/Managers/DataSourceManagerTestFixture.cs
@@ -358,8 +358,8 @@ namespace CDP4ReferenceDataMapper.Tests.ViewModels.StateToParameterTypeMapper
                 ValueSet = { sourceParameterOverrideValueset1 }
             };
 
-            this.parameterToStateMapping_1 = new ParameterToStateMapping("100", this.sourceParameterType_1, this.actualFinitateSte_on);
-            this.parameterToStateMapping_2 = new ParameterToStateMapping("100", this.sourceParameterType_1, this.actualFinitateSte_off);
+            this.parameterToStateMapping_1 = new ParameterToStateMapping("100", this.sourceParameterType_1, this.actualFinitateSte_on, "");
+            this.parameterToStateMapping_2 = new ParameterToStateMapping("100", this.sourceParameterType_1, this.actualFinitateSte_off, "");
 
             this.parameterToStateMappingList = new[] { this.parameterToStateMapping_1, this.parameterToStateMapping_2 };
 

--- a/CDP4ReferenceDataMapper.Tests/ViewModels/StateToParameterTypeMapperBrowserViewModelTestFixture.cs
+++ b/CDP4ReferenceDataMapper.Tests/ViewModels/StateToParameterTypeMapperBrowserViewModelTestFixture.cs
@@ -258,7 +258,7 @@ namespace CDP4ReferenceDataMapper.Tests.ViewModels.StateToParameterTypeMapper
             this.sourceParameterType_2.Component.Add(
                 new ParameterTypeComponent(Guid.NewGuid(), this.cache, this.uri) 
                 {
-                    ShortName = "Name",
+                    ShortName = "Value",
                     ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri)
                 });
 
@@ -566,7 +566,7 @@ namespace CDP4ReferenceDataMapper.Tests.ViewModels.StateToParameterTypeMapper
                 this.dialogNavigationService.Object,
                 this.pluginSettingsService.Object);
 
-            Assert.That(this.stateToParameterTypeMapperBrowserViewModel.Caption, Is.EqualTo("Actual Finite State to ParameterType mapping, iteration_1"));
+            Assert.That(this.stateToParameterTypeMapperBrowserViewModel.Caption, Is.EqualTo("Parameter to Actual Finite State Mapping, iteration_1"));
             Assert.That(this.stateToParameterTypeMapperBrowserViewModel.ToolTip, Is.EqualTo("Test\nhttp://www.rheagroup.com/\nJohn Doe"));
 
             Assert.That(this.stateToParameterTypeMapperBrowserViewModel.PossibleElementDefinitionCategory.Count, Is.EqualTo(2));
@@ -881,6 +881,14 @@ namespace CDP4ReferenceDataMapper.Tests.ViewModels.StateToParameterTypeMapper
                     .ActualValue[1];
 
             Assert.AreEqual(newValueValue, dataView[0][columnName].ToString());
+
+            var newShortName = 
+                newMapping
+                    .ValueSet
+                    .First()
+                    .ActualValue[0];
+
+            Assert.AreEqual(newShortName, dataView[0][this.stateToParameterTypeMapperBrowserViewModel.DataSourceManager.GetShortNameColumnName(columnName)].ToString());
         }
 
         [Test]

--- a/CDP4ReferenceDataMapper/Data/ParameterToStateMapping.cs
+++ b/CDP4ReferenceDataMapper/Data/ParameterToStateMapping.cs
@@ -73,6 +73,11 @@ namespace CDP4ReferenceDataMapper.Data
         public string Value { get; set; }
 
         /// <summary>
+        /// Gets or sets the <see cref="Parameter"/>'s shortname that was mapped in case the source was a <see cref="CompoundParameterType"/>.
+        /// </summary>
+        public string ShortName { get; set; }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="ParameterToStateMapping"/> class
         /// </summary>
         [JsonConstructor]
@@ -87,7 +92,8 @@ namespace CDP4ReferenceDataMapper.Data
         /// <param name="value">The value</param>
         /// <param name="parameterType">The <see cref="ParameterType"/> that was mapped</param>
         /// <param name="actualFiniteState">The <see cref="ActualFiniteState"/></param>
-        public ParameterToStateMapping(string value, ParameterType parameterType, ActualFiniteState actualFiniteState)
+        /// <param name="shortName">ShortName to add to the mapping</param>
+        public ParameterToStateMapping(string value, ParameterType parameterType, ActualFiniteState actualFiniteState, string shortName)
         {
             this.ParameterTypeIid = parameterType.Iid;
             this.ParameterTypeName = parameterType.Name;
@@ -98,6 +104,7 @@ namespace CDP4ReferenceDataMapper.Data
             this.ActualFiniteStateName = actualFiniteState.Name;
 
             this.Value = value;
+            this.ShortName = shortName;
         }
     }
 }

--- a/CDP4ReferenceDataMapper/ViewModels/StateToParameterTypeMapperBrowserViewModel.cs
+++ b/CDP4ReferenceDataMapper/ViewModels/StateToParameterTypeMapperBrowserViewModel.cs
@@ -119,7 +119,7 @@ namespace CDP4ReferenceDataMapper.ViewModels
         /// <summary>
         /// The Panel Caption
         /// </summary>
-        private const string PanelCaption = "Actual Finite State to ParameterType mapping";
+        private const string PanelCaption = "Parameter to Actual Finite State Mapping";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StateToParameterTypeMapperBrowserViewModel"/> class
@@ -430,6 +430,13 @@ namespace CDP4ReferenceDataMapper.ViewModels
                         : this.DataSourceManager.GetElementDefinitionParameterValueForDataRow(row.Row, new Guid(parameterTypeIid));
 
                 this.DataSourceManager.SetValue(property, valueRow, newPropertyValue);
+
+                var newPropertyCustomName =
+                    string.IsNullOrWhiteSpace(parameterTypeIid)
+                        ? null
+                        : this.DataSourceManager.GetElementDefinitionParameterCustomNameForDataRow(row.Row, new Guid(parameterTypeIid));
+
+                this.DataSourceManager.SetValue(this.DataSourceManager.GetShortNameColumnName(property), valueRow, newPropertyCustomName);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
- Rename dialog title to "Parameter to Actual Finite State Mapping"
- Add ShortName property to ParameterToStateMapping (serializes to JSON TextParameter) for use in reports