### PR TITLE
Product tree tooltip missing ED category; fixes #318

### DIFF
--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementUsageRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ElementUsageRowViewModel.cs
@@ -248,6 +248,7 @@ namespace CDP4EngineeringModel.ViewModels
         {
             this.PopulateParameterGroups();
             this.PopulateParameters();
+            this.UpdateTooltip();
         }
 
         /// <summary>

--- a/ProductTree/ViewModels/ProductTreeRows/ElementUsageRowViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeRows/ElementUsageRowViewModel.cs
@@ -303,7 +303,7 @@ namespace CDP4ProductTree.ViewModels
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.HighlightEventHandler());
 
-            this.Disposables.Add(highlightSubscription);
+            this.Disposables.Add(highlightUsageSubscription);
         }
 
         /// <summary>
@@ -334,6 +334,10 @@ namespace CDP4ProductTree.ViewModels
 
             var categories = this.Thing.Category.Any() ? string.Join(" ", this.Thing.Category.OrderBy(x => x.ShortName).Select(x => x.ShortName)) : "-";
             sb.AppendLine($"Category: {categories}");
+
+            var elementDefCategories = this.Thing.ElementDefinition.Category.OrderBy(x => x.ShortName).Select(x => x.ShortName);
+            var elementDefCategoriesText = this.Thing.ElementDefinition.Category.Any() ? string.Join(" ", elementDefCategories) : "-";
+            sb.AppendLine($"ED Category: {elementDefCategoriesText }");
 
             sb.AppendLine($"Model Code: {this.Path()}");
 
@@ -440,6 +444,7 @@ namespace CDP4ProductTree.ViewModels
             this.PopulateElementUsages();
             this.PopulateParameterGroups();
             this.PopulateParameterOrOverride();
+            this.UpdateTooltip();
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
fixes #318
- Added the missing ED category to the tooltip
- Updated the Product Tree and Element Definition browsers' ElementUsageRowViewModels to refresh the tooltips on ED updates

<!-- Thanks for contributing to CDP4-IME! -->

