### PR TITLE
[Add] logging orchestration to EngineeringModel and Requirements plugin

### DIFF
--- a/CDP4Composition/Navigation/PanelNavigationService.cs
+++ b/CDP4Composition/Navigation/PanelNavigationService.cs
@@ -203,6 +203,8 @@ namespace CDP4Composition.Navigation
         /// <param name="viewModel">The <see cref="IPanelViewModel"/></param>
         private void Open(IPanelViewModel viewModel)
         {
+            var sw = Stopwatch.StartNew();
+
             var lazyView = this.GetViewType(viewModel);
 
             var parameters = new object[] { true };
@@ -220,7 +222,7 @@ namespace CDP4Composition.Navigation
                 region.Add(view, view.ToString() + Guid.NewGuid());
             }
 
-            logger.Trace("Navigated to Panel {0}", viewModel);
+            logger.Trace("Navigated to Panel {0} in {1} [ms]", viewModel, sw.ElapsedMilliseconds);
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreBrowserRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/FileStoreBrowsers/DomainFileStoreBrowserRibbonViewModel.cs
@@ -1,23 +1,53 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DomainFileStoreBrowserRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2017 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// ------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
+    using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
+    using NLog;
 
     /// <summary>
     /// The view-model for the <see cref="DomainFileStoreBrowserRibbonViewModel"/> view
     /// </summary>
     public class DomainFileStoreBrowserRibbonViewModel : RibbonButtonIterationDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DomainFileStoreBrowserRibbonViewModel"/> class.
         /// </summary>
@@ -48,7 +78,11 @@ namespace CDP4EngineeringModel.ViewModels
         /// </returns>
         public static DomainFileStoreBrowserViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
-            return new DomainFileStoreBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var stopWatch = Stopwatch.StartNew();
+            var viewModel = new DomainFileStoreBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            stopWatch.Stop();
+            Logger.Info("Open DomainFileStoreBrowserViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }

--- a/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/FiniteStateBrowser/FiniteStateBrowserRibbonViewModel.cs
@@ -1,6 +1,6 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="FiniteStateBrowserRibbonViewModel.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Naron Phou, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
 //

--- a/EngineeringModel/ViewModels/OptionBrowser/OptionBrowserRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/OptionBrowser/OptionBrowserRibbonViewModel.cs
@@ -1,23 +1,53 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="OptionBrowserRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
+    using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
+    using NLog;
 
     /// <summary>
     /// The view-model for the <see cref="OptionBrowserRibbon"/> view
     /// </summary>
     public class OptionBrowserRibbonViewModel : RibbonButtonIterationDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="OptionBrowserRibbonViewModel"/> class
         /// </summary>
@@ -38,7 +68,12 @@ namespace CDP4EngineeringModel.ViewModels
         /// <returns>An instance of <see cref="OptionBrowserViewModel"/></returns>
         public static OptionBrowserViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
-            return new OptionBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var stopWatch = Stopwatch.StartNew();
+
+            var viewModel = new OptionBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            stopWatch.Stop();
+            Logger.Info("Open OptionBrowserViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }

--- a/EngineeringModel/ViewModels/PublicationBrowser/PublicationBrowserRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/PublicationBrowser/PublicationBrowserRibbonViewModel.cs
@@ -1,23 +1,53 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="PublicationBrowserRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
+    using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
+    using NLog;
 
     /// <summary>
     /// The view-model for the <see cref="PublicationBrowserRibbon"/> view
     /// </summary>
     public class PublicationBrowserRibbonViewModel : RibbonButtonIterationDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PublicationBrowserRibbonViewModel"/> class
         /// </summary>
@@ -39,7 +69,12 @@ namespace CDP4EngineeringModel.ViewModels
         /// <returns>An instance of <see cref="PublicationBrowserViewModel"/></returns>
         public static PublicationBrowserViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
-            return new PublicationBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var stopWatch = Stopwatch.StartNew();
+
+            var viewModel = new PublicationBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            stopWatch.Stop();
+            Logger.Info("Open PublicationBrowserViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }

--- a/EngineeringModel/ViewModels/RelationshipBrowser/RelationshipBrowserRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/RelationshipBrowser/RelationshipBrowserRibbonViewModel.cs
@@ -1,23 +1,53 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RelationshipBrowserRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
+    using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
+    using NLog;
 
     /// <summary>
     /// The view-model for the <see cref="RelationshipBrowserRibbon"/> view
     /// </summary>
     public class RelationshipBrowserRibbonViewModel : RibbonButtonIterationDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RelationshipBrowserRibbonViewModel"/> class
         /// </summary>
@@ -40,7 +70,12 @@ namespace CDP4EngineeringModel.ViewModels
         /// <returns>An instance of <see cref="RelationshipBrowserViewModel"/></returns>
         public static RelationshipBrowserViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
-            return new RelationshipBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var stopWatch = Stopwatch.StartNew();
+
+            var viewModel = new RelationshipBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            stopWatch.Stop();
+            Logger.Info("Open RelationshipBrowserViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListRibbonViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListRibbonViewModel.cs
@@ -1,24 +1,54 @@
-﻿// -------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="RuleVerificationListRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4EngineeringModel.ViewModels
 {
     using System;
+    using System.Diagnostics;
+    
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
+    using NLog;
 
     /// <summary>
     /// The view-model for <see cref="RuleVerificationListRibbonView"/> containing the controls in the "View" Page for this module
     /// </summary>
     public class RuleVerificationListRibbonViewModel : RibbonButtonIterationDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RuleVerificationListRibbonViewModel"/> class.
         /// </summary>
@@ -52,6 +82,8 @@ namespace CDP4EngineeringModel.ViewModels
         /// </returns>
         public static RuleVerificationListBrowserViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
+            var stopWatch = Stopwatch.StartNew();
+
             var model = iteration.Container as EngineeringModel;
             if (model == null)
             {
@@ -64,7 +96,10 @@ namespace CDP4EngineeringModel.ViewModels
                 throw new InvalidOperationException("The Participant in an engineering model cannot be null");
             }
 
-            return new RuleVerificationListBrowserViewModel(iteration, participant, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var viewModel = new RuleVerificationListBrowserViewModel(iteration, participant, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            stopWatch.Stop();
+            Logger.Info("Open RuleVerificationListBrowserViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }

--- a/ProductTree/ViewModels/ProductTreeRibbonViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeRibbonViewModel.cs
@@ -1,23 +1,53 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ProductTreeRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -----------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4ProductTree.ViewModels
 {
+    using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
+    using NLog;
 
     /// <summary>
     /// The view-model for the product-tree ribbon controls
     /// </summary>
     public class ProductTreeRibbonViewModel : RibbonButtonOptionDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RibbonButtonIterationDependentViewModel"/> class
         /// </summary>
@@ -40,7 +70,12 @@ namespace CDP4ProductTree.ViewModels
         /// <returns>An instance of <see cref="ProductTreeViewModel"/></returns>
         public static ProductTreeViewModel InstantiatePanelViewModel(Option option, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
-            return new ProductTreeViewModel(option, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var stopWatch = Stopwatch.StartNew();
+
+            var viewModel = new ProductTreeViewModel(option, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            stopWatch.Stop();
+            Logger.Info("Open ProductTreeViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }

--- a/Requirements/ViewModels/RequirementBrowser/RequirementRibbonViewModel.cs
+++ b/Requirements/ViewModels/RequirementBrowser/RequirementRibbonViewModel.cs
@@ -1,25 +1,56 @@
-﻿// -------------------------------------------------------------------------------------------------
-// <copyright file="RequirementViewRibbonViewModel.cs" company="RHEA System S.A.">
-//   Copyright (c) 2015 RHEA System S.A.
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RequirementRibbonViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2015-2021 RHEA System S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+//
+//    This file is part of CDP4-IME Community Edition. 
+//    The CDP4-IME Community Edition is the RHEA Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // </copyright>
-// -------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 namespace CDP4Requirements.ViewModels
 {
     using System;
+    using System.Diagnostics;
+
     using CDP4Common.EngineeringModelData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.PluginSettingService;
+
     using CDP4Dal;
+
     using CDP4Requirements.Views;
+
+    using NLog;
 
     /// <summary>
     /// The view model for the ribbon control <see cref="RequirementBrowserRibbon"/>
     /// </summary>
     public class RequirementRibbonViewModel : RibbonButtonIterationDependentViewModel
     {
+        /// <summary>
+        /// The logger for the current class
+        /// </summary>
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RequirementRibbonViewModel"/> class
         /// </summary>
@@ -39,13 +70,18 @@ namespace CDP4Requirements.ViewModels
         /// <returns>An instance of <see cref="RequirementsBrowserViewModel"/></returns>
         public static RequirementsBrowserViewModel InstantiatePanelViewModel(Iteration iteration, ISession session, IThingDialogNavigationService thingDialogNavigationService, IPanelNavigationService panelNavigationService, IDialogNavigationService dialogNavigationService, IPluginSettingsService pluginSettingsService)
         {
+            var stopWatch = Stopwatch.StartNew();
+
             var model = iteration.Container as EngineeringModel;
             if (model == null)
             {
                 throw new InvalidOperationException("The container of an Iteration cannot be anything else than an Engineering Model.");
             }
 
-            return new RequirementsBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            var viewModel = new RequirementsBrowserViewModel(iteration, session, thingDialogNavigationService, panelNavigationService, dialogNavigationService, pluginSettingsService);
+            stopWatch.Stop();
+            Logger.Info("Open RequirementsBrowserViewModel took {0}", stopWatch.Elapsed);
+            return viewModel;
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the CDP4-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
[Add] logging orchestration to EngineeringModel and Requirements plugin ribbon viewmodels to measure the duration of creating and opening the browsers in these plugins (productree, requirements tree, etc.)

<!-- Thanks for contributing to CDP4-IME! -->

