### PR TITLE
[Remove] duplicate package reference from CDP4Reporting

### DIFF
--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -220,9 +220,6 @@
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="CommonServiceLocator" Version="1.3">
-	  <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="PresentationCore">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

The CDP4Reporting.csproj file contains a duplicate reference to `CommonServiceLocator` version 1.3, this has been removed.

<!-- Thanks for contributing to COMET-IME! -->

