### PR TITLE
1394 fixes team composition   selection items for engineering model are not updated for edited name of engineering model

### DIFF
--- a/CDP4Composition.Tests/Mvvm/MenuItems/RibbonButtonEngineeringModelSetupDependentViewModelTestFixture.cs
+++ b/CDP4Composition.Tests/Mvvm/MenuItems/RibbonButtonEngineeringModelSetupDependentViewModelTestFixture.cs
@@ -57,8 +57,6 @@ namespace CDP4Composition.Tests.Mvvm.MenuItems
         /// The view-model that is being tested
         /// </summary>
         private TestClass viewModel;
-
-        private EngineeringModelSetup engeEngineeringModelSetup;
         private Uri uri;
         private Mock<ISession> session;
 

--- a/CDP4Composition.Tests/Mvvm/MenuItems/RibbonButtonEngineeringModelSetupDependentViewModelTestFixture.cs
+++ b/CDP4Composition.Tests/Mvvm/MenuItems/RibbonButtonEngineeringModelSetupDependentViewModelTestFixture.cs
@@ -169,6 +169,60 @@ namespace CDP4Composition.Tests.Mvvm.MenuItems
             Assert.AreEqual(sortedList, sessionEngineeringModelSetupMenuGroupViewModel.EngineeringModelSetups);
         }
 
+        [Test]
+        public void VerifyThatUpdatedEngineeringModelSetupNameIsReflectedInMenuItemContent()
+        {
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.Open));
+
+            var siteDirectory = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "OldName" };
+            siteDirectory.Model.Add(engineeringModelSetup);
+
+            this.messageBus.SendObjectChangeEvent(engineeringModelSetup, EventKind.Added);
+
+            var group = this.viewModel.EngineeringModelSetups.Single();
+            var menuItem = group.EngineeringModelSetups.Single();
+
+            Assert.AreEqual("OldName", menuItem.MenuItemContent);
+
+            engineeringModelSetup.Name = "NewName";
+            engineeringModelSetup.RevisionNumber = 1;
+
+            this.messageBus.SendObjectChangeEvent(engineeringModelSetup, EventKind.Updated);
+
+            Assert.AreEqual("NewName", menuItem.MenuItemContent);
+        }
+
+        [Test]
+        public void VerifyThatGalleryGroupIsResortedAfterEngineeringModelSetupNameChange()
+        {
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.Open));
+
+            var siteDirectory = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri);
+
+            var setupBeta = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Beta" };
+            siteDirectory.Model.Add(setupBeta);
+
+            var setupAlpha = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Alpha" };
+            siteDirectory.Model.Add(setupAlpha);
+
+            this.messageBus.SendObjectChangeEvent(setupBeta, EventKind.Added);
+            this.messageBus.SendObjectChangeEvent(setupAlpha, EventKind.Added);
+
+            var group = this.viewModel.EngineeringModelSetups.Single();
+
+            Assert.AreEqual("Alpha", group.EngineeringModelSetups[0].MenuItemContent);
+            Assert.AreEqual("Beta", group.EngineeringModelSetups[1].MenuItemContent);
+
+            setupAlpha.Name = "Gamma";
+            setupAlpha.RevisionNumber = 1;
+
+            this.messageBus.SendObjectChangeEvent(setupAlpha, EventKind.Updated);
+
+            Assert.AreEqual("Beta", group.EngineeringModelSetups[0].MenuItemContent);
+            Assert.AreEqual("Gamma", group.EngineeringModelSetups[1].MenuItemContent);
+        }
+
         private class TestClass : RibbonButtonEngineeringModelSetupDependentViewModel
         {
             public TestClass(ICDPMessageBus messageBus) : base(null, messageBus)

--- a/CDP4Composition/Mvvm/MenuItems/RibbonButtonEngineeringModelSetupDependentViewModel.cs
+++ b/CDP4Composition/Mvvm/MenuItems/RibbonButtonEngineeringModelSetupDependentViewModel.cs
@@ -87,6 +87,12 @@ namespace CDP4Composition.Mvvm
                 .Select(x => x.ChangedThing as EngineeringModelSetup)
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(this.EngineeringModelSetupRemovedEventHandler);
+
+            messageBus.Listen<ObjectChangedEvent>(typeof(EngineeringModelSetup))
+                .Where(x => x.EventKind == EventKind.Updated)
+                .Select(x => x.ChangedThing as EngineeringModelSetup)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(this.EngineeringModelSetupUpdatedEventHandler);
         }
 
         /// <summary>
@@ -156,6 +162,22 @@ namespace CDP4Composition.Mvvm
             }
 
             ((ICommand)menuItemToRemove.ClosePanelsCommand).Execute(default);
+        }
+
+        /// <summary>
+        /// The event-handler that is invoked by the subscription that listens for <see cref="EngineeringModelSetup"/>s updated
+        /// </summary>
+        /// <param name="engineeringModelSetup">the engineering model setup</param>
+        protected virtual void EngineeringModelSetupUpdatedEventHandler(EngineeringModelSetup engineeringModelSetup)
+        {
+            var group = this.EngineeringModelSetups.SingleOrDefault(x => x.Thing == engineeringModelSetup.Container);
+
+            if (group == null)
+            {
+                return;
+            }
+
+            group.EngineeringModelSetups.Sort((x, y) => x.MenuItemContent.CompareTo(y.MenuItemContent));
         }
 
         /// <summary>

--- a/CDP4Composition/Mvvm/MenuItems/RibbonMenuItemEngineeringModelSetupDependentViewModel.cs
+++ b/CDP4Composition/Mvvm/MenuItems/RibbonMenuItemEngineeringModelSetupDependentViewModel.cs
@@ -82,6 +82,7 @@ namespace CDP4Composition.Mvvm
         private void SetProperties()
         {
             this.RevisionNumber = this.EngineeringModelSetup.RevisionNumber;
+            this.UpdateStaticMenuItemContent(this.EngineeringModelSetup.Name);
         }
 
         /// <summary>

--- a/CDP4Composition/Mvvm/MenuItems/RibbonMenuItemViewModelBase.cs
+++ b/CDP4Composition/Mvvm/MenuItems/RibbonMenuItemViewModelBase.cs
@@ -97,7 +97,7 @@ namespace CDP4Composition.Mvvm
         /// <summary>
         /// Static part of the MenuItemCentent
         /// </summary>
-        private readonly string staticMenuItemContent;
+        private string staticMenuItemContent;
 
         /// <summary>
         /// Backing field for <see cref="IsChecked"/> 
@@ -151,6 +151,17 @@ namespace CDP4Composition.Mvvm
                 prefix = $"({panelCount}) ";
             }
 
+            this.MenuItemContent = $"{prefix}{this.staticMenuItemContent}";
+        }
+
+        /// <summary>
+        /// Updates the static part of the menu item content and recomputes <see cref="MenuItemContent"/> preserving the open-panel count prefix.
+        /// </summary>
+        /// <param name="newContent">The new static content (e.g. an updated name)</param>
+        protected void UpdateStaticMenuItemContent(string newContent)
+        {
+            this.staticMenuItemContent = newContent;
+            var prefix = this.PanelViewModels.Count > 0 ? $"({this.PanelViewModels.Count}) " : string.Empty;
             this.MenuItemContent = $"{prefix}{this.staticMenuItemContent}";
         }
 

--- a/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionDisconnectViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/TeamComposition/TeamCompositionDisconnectViewModelTestFixture.cs
@@ -63,7 +63,6 @@ namespace CDP4SiteDirectory.Tests
         private Mock<IPermissionService> permissionService;
         private Mock<ISession> session;
         private Uri uri = new Uri("https://www.stariongroup.eu");
-        private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
         private Person person;
         private CDPMessageBus messageBus;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

- Selection items in ribbon are now updated when editing the name of an engineering model.
- Fixed two stumbled upon sonar issue. (field not used)

