### PR TITLE
Bugifx: Cache the first batch of already loaded assemblies and reuse in consecutive compile actions

### DIFF
--- a/BasicRdl/BasicRdl.csproj
+++ b/BasicRdl/BasicRdl.csproj
@@ -10,8 +10,8 @@
 	<Product>BasicRdl</Product>
 	<Description>CDP4-COMET Basic Reference Data Library Plugin</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4Addin/CDP4Addin.csproj
+++ b/CDP4Addin/CDP4Addin.csproj
@@ -10,8 +10,8 @@
     <Product>CDP4AddinCE</Product>
     <Description>CDP4-COMET-CE Office Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
     <RegisterForComInterop>true</RegisterForComInterop>
     <PlatformTarget>anycpu</PlatformTarget>
   </PropertyGroup>

--- a/CDP4BudgetViewer/CDP4Budget.csproj
+++ b/CDP4BudgetViewer/CDP4Budget.csproj
@@ -8,8 +8,8 @@
 	<Product>CDP4BudgetViewer</Product>
 	<Description>CDP4-COMET Budget Computation and Viewer Plugin</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4BuiltInRules/CDP4BuiltInRules.csproj
+++ b/CDP4BuiltInRules/CDP4BuiltInRules.csproj
@@ -10,8 +10,8 @@
 	  <Product>CDP4BuiltInRules</Product>
 	  <Description>CDP4-COMET Built-In rules Plugin</Description>
 	  <Copyright>Copyright © Starion Group S.A.</Copyright>
-	  <AssemblyVersion>11.0.0.10</AssemblyVersion>
-	  <FileVersion>11.0.0.10</FileVersion>
+	  <AssemblyVersion>11.0.0.11</AssemblyVersion>
+	  <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4Composition/CDP4Composition.csproj
+++ b/CDP4Composition/CDP4Composition.csproj
@@ -7,8 +7,8 @@
 	<Product>CDP4Composition</Product>
 	<Description>CDP4-COMET Composition and Infrastructure library</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
 	<OutputPath>bin\$(Configuration)\</OutputPath>
 	<LangVersion>latest</LangVersion>
 	<UseWPF>true</UseWPF>

--- a/CDP4CrossViewEditor/CDP4CrossViewEditor.csproj
+++ b/CDP4CrossViewEditor/CDP4CrossViewEditor.csproj
@@ -9,8 +9,8 @@
     <Product>CDP4CrossViewEditor</Product>
     <Description>CDP4-COMET Excel Addin CrossView Editor</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4Dashboard/CDP4Dashboard.csproj
+++ b/CDP4Dashboard/CDP4Dashboard.csproj
@@ -9,8 +9,8 @@
 	<Product>Dashboard</Product>
 	<Description>CDP4-COMET Dashboard Plugin</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4DiagramEditor/CDP4DiagramEditor.csproj
+++ b/CDP4DiagramEditor/CDP4DiagramEditor.csproj
@@ -9,8 +9,8 @@
     <Product>CDP4DiagramEditor</Product>
     <Description>CDP4-COMET Diagram Editor plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4Grapher/CDP4Grapher.csproj
+++ b/CDP4Grapher/CDP4Grapher.csproj
@@ -9,8 +9,8 @@
     <Product>Grapher</Product>
     <Description>CDP4-COMET Grapher Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4IME/COMET-CE.csproj
+++ b/CDP4IME/COMET-CE.csproj
@@ -11,8 +11,8 @@
     <Product>CDP4-COMET</Product>
     <Description>The CDP4-COMET Integrated Modelling Environment</Description>
     <Copyright>Copyright © Starion Group S.A</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <UseWPF>true</UseWPF>

--- a/CDP4IMEInstaller/CDP4Addin.wxs
+++ b/CDP4IMEInstaller/CDP4Addin.wxs
@@ -58,15 +58,15 @@
           </RegistryKey>
 
           <RegistryKey Key="InprocServer32">
-            <RegistryKey Key="11.0.0.10">
-              <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.10, Culture=neutral, PublicKeyToken=null"></RegistryValue>
+            <RegistryKey Key="11.0.0.11">
+              <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.11, Culture=neutral, PublicKeyToken=null"></RegistryValue>
               <RegistryValue Type="string" Name="Class" Value="CDP4AddinCE.Addin"></RegistryValue>
               <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319"></RegistryValue>
               <RegistryValue Type="string" Name="CodeBase" Value="file:///[#_17CAA5BE]"></RegistryValue>
             </RegistryKey>
 
             <RegistryValue Type="string" Value="mscoree.dll"></RegistryValue>
-            <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.10, Culture=neutral, PublicKeyToken=null"></RegistryValue>
+            <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.11, Culture=neutral, PublicKeyToken=null"></RegistryValue>
             <RegistryValue Type="string" Name="Class" Value="CDP4AddinCE.Addin"></RegistryValue>
             <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319"></RegistryValue>
             <RegistryValue Type="string" Name="ThreadingModel" Value="Both"></RegistryValue>
@@ -96,15 +96,15 @@
           </RegistryKey>
 
           <RegistryKey Key="InprocServer32">
-            <RegistryKey Key="11.0.0.10">
-              <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.10, Culture=neutral, PublicKeyToken=null"></RegistryValue>
+            <RegistryKey Key="11.0.0.11">
+              <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.11, Culture=neutral, PublicKeyToken=null"></RegistryValue>
               <RegistryValue Type="string" Name="Class" Value="CDP4AddinCE.TaskPaneWpfHostControl"></RegistryValue>
               <RegistryValue Type="string" Name="CodeBase" Value="[#_17CAA5BE]"></RegistryValue>
               <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319"></RegistryValue>
             </RegistryKey>
 
             <RegistryValue Type="string" Value="mscoree.dll"></RegistryValue>
-            <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.10, Culture=neutral, PublicKeyToken=null"></RegistryValue>
+            <RegistryValue Type="string" Name="Assembly" Value="CDP4AddinCE, Version=11.0.0.11, Culture=neutral, PublicKeyToken=null"></RegistryValue>
             <RegistryValue Type="string" Name="Class" Value="CDP4AddinCE.TaskPaneWpfHostControl"></RegistryValue>
             <RegistryValue Type="string" Name="CodeBase" Value="[#_17CAA5BE]"></RegistryValue>
             <RegistryValue Type="string" Name="RuntimeVersion" Value="v4.0.30319"></RegistryValue>

--- a/CDP4IMEInstaller/Product.wxs
+++ b/CDP4IMEInstaller/Product.wxs
@@ -1,6 +1,6 @@
 ﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
 
-  <Package Name="CDP4-COMET-CE" Language="1033" Version="11.0.0.10" Manufacturer="Starion Group S.A." UpgradeCode="83b3da1e-4a38-40f0-b2a6-5f58b32238a4" InstallerVersion="200">
+  <Package Name="CDP4-COMET-CE" Language="1033" Version="11.0.0.11" Manufacturer="Starion Group S.A." UpgradeCode="83b3da1e-4a38-40f0-b2a6-5f58b32238a4" InstallerVersion="200">
 
     <?include variables.wxi ?>
    

--- a/CDP4JsonFileDal/CDP4JsonFileDal.csproj
+++ b/CDP4JsonFileDal/CDP4JsonFileDal.csproj
@@ -11,8 +11,8 @@
 	  <Product>CDP4JsonFileDalPlugin</Product>
 	  <Description>CDP4-COMET Json File Dal Plugin</Description>
 	  <Copyright>Copyright © Starion Group S.A.</Copyright>
-	  <AssemblyVersion>11.0.0.10</AssemblyVersion>
-	  <FileVersion>11.0.0.10</FileVersion>
+	  <AssemblyVersion>11.0.0.11</AssemblyVersion>
+	  <FileVersion>11.0.0.11</FileVersion>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
 	  <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/CDP4LogInfo/CDP4LogInfo.csproj
+++ b/CDP4LogInfo/CDP4LogInfo.csproj
@@ -9,8 +9,8 @@
     <Product>CDP4LogInfo</Product>
     <Description>CDP4-COMET Logging plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4ObjectBrowser/CDP4ObjectBrowser.csproj
+++ b/CDP4ObjectBrowser/CDP4ObjectBrowser.csproj
@@ -9,8 +9,8 @@
     <Product>CDP4ObjectBrowser</Product>
     <Description>CDP4-COMET Object Browser Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4OfficeInfrastructure/CDP4OfficeInfrastructure.csproj
+++ b/CDP4OfficeInfrastructure/CDP4OfficeInfrastructure.csproj
@@ -7,8 +7,8 @@
     <Product>CDP4OfficeInfrastructure</Product>
     <Description>CDP4-COMET Office Infrastucture library</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/CDP4ParameterSheetGenerator/CDP4ParameterSheetGenerator.csproj
+++ b/CDP4ParameterSheetGenerator/CDP4ParameterSheetGenerator.csproj
@@ -9,8 +9,8 @@
 	<Product>CDP4ParameterSheetGenerator</Product>
 	<Description>CDP4-COMET Excel Addin Parameter Sheet Generator</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4PropertyGrid/CDP4PropertyGrid.csproj
+++ b/CDP4PropertyGrid/CDP4PropertyGrid.csproj
@@ -9,8 +9,8 @@
     <Product>CDP4PropertyGrid</Product>
     <Description>CDP4-COMET Property Grid Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4ReferenceDataMapper/CDP4ReferenceDataMapper.csproj
+++ b/CDP4ReferenceDataMapper/CDP4ReferenceDataMapper.csproj
@@ -9,8 +9,8 @@
 	<Product>CDP4ReferenceDataMapper</Product>
 	<Description>CDP4-COMET ReferenceData Mapper Plugin</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4RelationshipEditor/CDP4RelationshipEditor.csproj
+++ b/CDP4RelationshipEditor/CDP4RelationshipEditor.csproj
@@ -9,8 +9,8 @@
     <Product>CDP4RelationshipEditor</Product>
     <Description>CDP4-COMET Relationship Editor Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4Reporting/CDP4Reporting.csproj
+++ b/CDP4Reporting/CDP4Reporting.csproj
@@ -10,8 +10,8 @@
     <Product>CDP4Reporting</Product>
     <Description>CDP4-COMET Reporting Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
     <LangVersion>latest</LangVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>

--- a/CDP4Reporting/ViewModels/CodeDomCodeCompiler.cs
+++ b/CDP4Reporting/ViewModels/CodeDomCodeCompiler.cs
@@ -37,6 +37,19 @@ namespace CDP4Reporting.ViewModels
     public class CodeDomCodeCompiler : CodeCompilerBase
     {
         /// <summary>
+        /// Holds a reference to the assemblies cached from the current AppDomain. 
+        /// This is used to avoid the overhead of retrieving the assembly locations multiple times during compilation.
+        /// Also a bugfix for facade assemblies loaded in the first compile run, which are not loaded in subsequent runs, 
+        /// causing the assembly retrieval to fail and the compiler to throw an exception.
+        /// </summary>
+        private static string[] cachedAssemblyLocations;
+
+        /// <summary>
+        /// Holds a lock object for synchronizing access to the cached assembly locations. This ensures that only one thread can retrieve and cache the assembly locations at a time, preventing
+        /// </summary>
+        private static readonly object cacheLock = new object();
+
+        /// <summary>
         /// Creates a new instance of the <see cref="CodeDomCodeCompiler"/> class
         /// </summary>
         /// <param name="onOutput">An <see cref="Action{T}"/> of type <see cref="string"/> that is invoked when user output is needed during compilation or data retrieval</param>
@@ -61,13 +74,19 @@ namespace CDP4Reporting.ViewModels
                 WarningLevel = 0
             };
 
-            var currentAssemblies =
-                AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(x => !x.IsDynamic)
-                    .Select(x => x.Location)
-                    .ToArray();
+            if (cachedAssemblyLocations == null)
+            {
+                lock (cacheLock)
+                {
+                    cachedAssemblyLocations ??= AppDomain.CurrentDomain.GetAssemblies()
+                        .Where(x => !x.IsDynamic)
+                        .Where(x => !string.IsNullOrEmpty(x.Location))
+                        .Select(x => x.Location)
+                        .ToArray();
+                }
+            }
 
-            parameters.ReferencedAssemblies.AddRange(currentAssemblies);
+            parameters.ReferencedAssemblies.AddRange(cachedAssemblyLocations);
 
             var result = compiler.CompileAssemblyFromSource(parameters, source);
 

--- a/CDP4Scripting/CDP4Scripting.csproj
+++ b/CDP4Scripting/CDP4Scripting.csproj
@@ -8,8 +8,8 @@
     <Product>CDP4Scripting</Product>
     <Description>CDP4-COMET Scripting Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/CDP4ServicesDal/CDP4ServicesDal.csproj
+++ b/CDP4ServicesDal/CDP4ServicesDal.csproj
@@ -11,8 +11,8 @@
     <Product>CDP4ServicesDal</Product>
     <Description>CDP4-COMET Services DAL to be used exclusively with CDP4-COMET Services</Description>
     <Copyright>Copyright © Starion Group S.A</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/CDP4ShellDialogs/CDP4ShellDialogs.csproj
+++ b/CDP4ShellDialogs/CDP4ShellDialogs.csproj
@@ -7,8 +7,8 @@
     <Product>CDP4ShellDialogs</Product>
     <Description>CDP4-COMET Shell Dialogs</Description>
     <Copyright>Copyright © Starion Group S.A</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
     <OutputPath>bin\$(Configuration)\</OutputPath>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>

--- a/CDP4SiteDirectory/CDP4SiteDirectory.csproj
+++ b/CDP4SiteDirectory/CDP4SiteDirectory.csproj
@@ -9,8 +9,8 @@
     <Product>CDP4SiteDirectory</Product>
     <Description>CDP4-COMET SiteDirectory Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/EngineeringModel/EngineeringModel.csproj
+++ b/EngineeringModel/EngineeringModel.csproj
@@ -11,8 +11,8 @@
 	<Product>CDP4EngineeringModel</Product>
 	<Description>CDP4-COMET Engineering Model Plugin</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
   <LangVersion>latest</LangVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>

--- a/ProductTree/ProductTree.csproj
+++ b/ProductTree/ProductTree.csproj
@@ -12,8 +12,8 @@
     <Description>CDP4-COMET Product Tree Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
     <LangVersion>latest</LangVersion>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/RelationshipMatrix/CDP4RelationshipMatrix.csproj
+++ b/RelationshipMatrix/CDP4RelationshipMatrix.csproj
@@ -9,8 +9,8 @@
     <Product>RelationshipMatrix</Product>
     <Description>CDP4-COMET Relationship Matrix Plugin</Description>
     <Copyright>Copyright © Starion Group S.A.</Copyright>
-    <AssemblyVersion>11.0.0.10</AssemblyVersion>
-    <FileVersion>11.0.0.10</FileVersion>
+    <AssemblyVersion>11.0.0.11</AssemblyVersion>
+    <FileVersion>11.0.0.11</FileVersion>
 	  <UseWPF>true</UseWPF>
 	  <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/Requirements/Requirements.csproj
+++ b/Requirements/Requirements.csproj
@@ -11,8 +11,8 @@
 	<Product>Requirements</Product>
 	<Description>CDP4-COMET Requirements Plugin</Description>
 	<Copyright>Copyright © Starion Group S.A.</Copyright>
-	<AssemblyVersion>11.0.0.10</AssemblyVersion>
-	<FileVersion>11.0.0.10</FileVersion>
+	<AssemblyVersion>11.0.0.11</AssemblyVersion>
+	<FileVersion>11.0.0.11</FileVersion>
 	<UseWPF>true</UseWPF>
 	<UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
