### PR TITLE
Feat/gh1362 bug adding more than 1 definition per language to defined things and requirements

### DIFF
--- a/CDP4Composition.Tests/CommonView/ViewModels/DefinitionDialogViewModelTestFixture.cs
+++ b/CDP4Composition.Tests/CommonView/ViewModels/DefinitionDialogViewModelTestFixture.cs
@@ -26,6 +26,7 @@
 namespace CDP4CommonView.Tests
 {
     using System;
+    using System.Linq;
     using System.Reactive.Concurrency;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
@@ -224,6 +225,71 @@ namespace CDP4CommonView.Tests
             Assert.IsTrue(this.viewmodel.SelectedExample.Value.Equals(this.viewmodel.Example[2].Value));
             await this.viewmodel.DeleteExampleCommand.Execute();
             Assert.AreEqual(this.viewmodel.Example.Count, 2);
+        }
+
+        [Test]
+        public void VerifyThatLanguageUsedByAnotherDefinitionIsNotSelectable()
+        {
+            var existingDefinition = new Definition(Guid.NewGuid(), null, null) { LanguageCode = "en", Content = "English definition" };
+            var newDefinition = new Definition(Guid.NewGuid(), null, null) { LanguageCode = null, Content = null };
+
+            var requirement = new Requirement(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.assembler.Cache.TryAdd(new CacheKey(requirement.Iid, null), new Lazy<Thing>(() => requirement));
+
+            var clone = requirement.Clone(false);
+            clone.Definition.Add(existingDefinition);
+            clone.Definition.Add(newDefinition);
+
+            this.transaction.CreateOrUpdate(clone);
+
+            var vm = new DefinitionDialogViewModel(newDefinition, this.transaction, this.session.Object, true, ThingDialogKind.Create, null, clone, null);
+            
+            Assert.That(vm.PossibleLanguageCode.Any(x => x.Name == "en"), Is.False);
+            Assert.That(vm.SelectedLanguageCode, Is.Not.Null);
+            Assert.That(vm.SelectedLanguageCode.Name, Is.Not.EqualTo("en"));
+        }
+
+        [Test]
+        public void VerifyThatDefinitionsInDifferentLanguagesCanCoexist()
+        {
+            var englishDefinition = new Definition(Guid.NewGuid(), null, null) { LanguageCode = "en", Content = "English definition" };
+            var frenchDefinition = new Definition(Guid.NewGuid(), null, null) { LanguageCode = "fr", Content = "French definition" };
+
+            var requirement = new Requirement(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.assembler.Cache.TryAdd(new CacheKey(requirement.Iid, null), new Lazy<Thing>(() => requirement));
+
+            var clone = requirement.Clone(false);
+            clone.Definition.Add(englishDefinition);
+            clone.Definition.Add(frenchDefinition);
+
+            this.transaction.CreateOrUpdate(clone);
+
+            var vm = new DefinitionDialogViewModel(englishDefinition, this.transaction, this.session.Object, true, ThingDialogKind.Update, null, clone, null);
+
+            Assert.That(vm.SelectedLanguageCode.Name, Is.EqualTo("en"));
+            Assert.That(vm.PossibleLanguageCode.Any(x => x.Name == "en"), Is.True);
+            Assert.That(vm.PossibleLanguageCode.Any(x => x.Name == "fr"), Is.False);
+        }
+
+        [Test]
+        public void VerifyThatTheOneDefinitionPerLanguageRuleAppliesToAnyDefinedThing()
+        {
+            var existingDefinition = new Definition(Guid.NewGuid(), null, null) { LanguageCode = "en", Content = "English definition" };
+            var newDefinition = new Definition(Guid.NewGuid(), null, null) { LanguageCode = null, Content = null };
+
+            var group = new RequirementsGroup(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.assembler.Cache.TryAdd(new CacheKey(group.Iid, null), new Lazy<Thing>(() => group));
+
+            var clone = group.Clone(false);
+            clone.Definition.Add(existingDefinition);
+            clone.Definition.Add(newDefinition);
+
+            this.transaction.CreateOrUpdate(clone);
+
+            var vm = new DefinitionDialogViewModel(newDefinition, this.transaction, this.session.Object, true, ThingDialogKind.Create, null, clone, null);
+
+            Assert.That(vm.PossibleLanguageCode.Any(x => x.Name == "en"), Is.False);
+            Assert.That(vm.SelectedLanguageCode.Name, Is.Not.EqualTo("en"));
         }
     }
 }

--- a/CDP4Composition/CommonView/ViewModels/DefinitionDialogViewModel.cs
+++ b/CDP4Composition/CommonView/ViewModels/DefinitionDialogViewModel.cs
@@ -200,55 +200,60 @@ namespace CDP4CommonView.ViewModels
         protected override void UpdateProperties()
         {
             base.UpdateProperties();
-            
+
             var definedThing = (DefinedThing)this.Container;
             this.PossibleLanguageCode.Clear();
-            var usedCodes = definedThing.Definition.Select(x => x.LanguageCode);            
-            var languageCodeUsages = new List<LanguageCodeUsage>();
-            foreach (var usedCode in usedCodes)
+
+            var languageCodesToExclude = definedThing.Definition
+                .Where(definition => definition.Iid != this.Thing.Iid)
+                .Select(definition => definition.LanguageCode)
+                .Where(languageCode => !string.IsNullOrEmpty(languageCode))
+                .ToList();
+
+            var customLanguageCodeUsages = new List<LanguageCodeUsage>();
+
+            foreach (var usedCode in definedThing.Definition.Select(x => x.LanguageCode))
             {
-                if (usedCode == null)
+                if (string.IsNullOrEmpty(usedCode) || languageCodesToExclude.Contains(usedCode) || CultureInfoUtility.CultureInfoAvailable.Any(x => x.Name == usedCode))
                 {
                     continue;
                 }
 
-                var cultureInfo = CultureInfoUtility.CultureInfoAvailable.SingleOrDefault(x => x.Name == usedCode);
-
-                if (cultureInfo == null)
+                try
                 {
-                    try
-                    {
-                        cultureInfo = new CultureInfo(usedCode);
-                        var languageCodeUsage = new LanguageCodeUsage(cultureInfo, true);
-                        languageCodeUsages.Add(languageCodeUsage);
-                    }
-                    catch (CultureNotFoundException ex)
-                    {
-                        var languageCodeUsage = new LanguageCodeUsage(usedCode, usedCode, true);
-                        languageCodeUsages.Add(languageCodeUsage);
-                        logger.Debug(ex, "The culture {0} could not be found and is ignored", usedCode);
-                    }
+                    customLanguageCodeUsages.Add(new LanguageCodeUsage(new CultureInfo(usedCode), true));
+                }
+                catch (CultureNotFoundException ex)
+                {
+                    customLanguageCodeUsages.Add(new LanguageCodeUsage(usedCode, usedCode, true));
+                    logger.Debug(ex, "The culture {0} could not be found and is ignored", usedCode);
                 }
             }
-            
-            this.PossibleLanguageCode.AddRange(languageCodeUsages.OrderBy(x => x.FullName));
+
+            this.PossibleLanguageCode.AddRange(customLanguageCodeUsages.OrderBy(x => x.FullName));
 
             foreach (var cultureInfo in CultureInfoUtility.CultureInfoAvailable)
             {
-                if (languageCodeUsages.All(x => x.Name != cultureInfo.Name))
+                if (languageCodesToExclude.Contains(cultureInfo.Name))
                 {
-                    var languageCodeUsage = new LanguageCodeUsage(cultureInfo, false);
-                    this.PossibleLanguageCode.Add(languageCodeUsage);
+                    continue;
+                }
+
+                if (customLanguageCodeUsages.All(x => x.Name != cultureInfo.Name))
+                {
+                    this.PossibleLanguageCode.Add(new LanguageCodeUsage(cultureInfo, false));
                 }
             }
 
             if (string.IsNullOrEmpty(this.Thing.LanguageCode))
             {
-                this.SelectedLanguageCode = this.PossibleLanguageCode.Single(x => x.Name == CultureInfoUtility.DefaultCultureName);
+                this.SelectedLanguageCode =
+                    this.PossibleLanguageCode.FirstOrDefault(x => x.Name == CultureInfoUtility.DefaultCultureName)
+                    ?? this.PossibleLanguageCode.FirstOrDefault();
             }
             else
             {
-                this.SelectedLanguageCode = this.PossibleLanguageCode.Single(x => x.Name == this.Thing.LanguageCode);
+                this.SelectedLanguageCode = this.PossibleLanguageCode.FirstOrDefault(x => x.Name == this.Thing.LanguageCode);
             }
         }
 

--- a/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
@@ -29,6 +29,7 @@ namespace CDP4Requirements.Tests.Dialogs
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reactive.Concurrency;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
     using System.Windows.Input;
@@ -52,6 +53,8 @@ namespace CDP4Requirements.Tests.Dialogs
     using Moq;
 
     using NUnit.Framework;
+
+    using ReactiveUI;
 
     [TestFixture]
     internal class RequirementDialogViewModelTestFixture
@@ -82,6 +85,7 @@ namespace CDP4Requirements.Tests.Dialogs
         [SetUp]
         public void Setup()
         {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
             this.messageBus = new CDPMessageBus();
             this.session = new Mock<ISession>();
             this.permissionService = new Mock<IPermissionService>();
@@ -293,6 +297,107 @@ namespace CDP4Requirements.Tests.Dialogs
             vm.RequirementText = "some text";
 
             Assert.IsTrue(((ICommand)vm.OkCommand).CanExecute(null));
+        }
+
+        [Test]
+        public async Task VerifyThatTheRequirementTextLanguageIsReservedWhileCreatingADefinition()
+        {
+            var vm = new RequirementDialogViewModel(this.requirement, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.clone);
+
+            vm.RequirementText = "the requirement";
+            var reservedLanguage = vm.SelectedLanguageCode.Name;
+
+            var languageWasReservedDuringNavigation = false;
+
+            this.thingDialogNavigationService
+                .Setup(x => x.Navigate(It.IsAny<Definition>(), It.IsAny<IThingTransaction>(), It.IsAny<ISession>(), It.IsAny<bool>(), ThingDialogKind.Create, It.IsAny<IThingDialogNavigationService>(), It.IsAny<Thing>(), It.IsAny<IEnumerable<Thing>>()))
+                .Callback<Thing, IThingTransaction, ISession, bool, ThingDialogKind, IThingDialogNavigationService, Thing, IEnumerable<Thing>>(
+                    (_, _, _, _, _, _, container, _) =>
+                        languageWasReservedDuringNavigation = ((Requirement)container).Definition.Any(definition => definition.LanguageCode == reservedLanguage))
+                .Returns(false);
+
+            await vm.CreateDefinitionCommand.Execute();
+            
+            Assert.IsTrue(languageWasReservedDuringNavigation);
+            Assert.IsFalse(this.requirement.Definition.Any(definition => definition.LanguageCode == reservedLanguage));
+        }
+
+        [Test]
+        public async Task VerifyThatNoLanguageIsReservedWhenThereIsNoRequirementDescription()
+        {
+            var vm = new RequirementDialogViewModel(this.requirement, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.clone);
+
+            var anyLanguageReservedDuringNavigation = true;
+
+            this.thingDialogNavigationService
+                .Setup(x => x.Navigate(It.IsAny<Definition>(), It.IsAny<IThingTransaction>(), It.IsAny<ISession>(), It.IsAny<bool>(), ThingDialogKind.Create, It.IsAny<IThingDialogNavigationService>(), It.IsAny<Thing>(), It.IsAny<IEnumerable<Thing>>()))
+                .Callback<Thing, IThingTransaction, ISession, bool, ThingDialogKind, IThingDialogNavigationService, Thing, IEnumerable<Thing>>(
+                    (_, _, _, _, _, _, container, _) =>
+                        anyLanguageReservedDuringNavigation = ((Requirement)container).Definition.Any())
+                .Returns(false);
+
+            await vm.CreateDefinitionCommand.Execute();
+
+            Assert.IsFalse(anyLanguageReservedDuringNavigation);
+        }
+
+        [Test]
+        public async Task VerifyThatCreatingADefinitionDoesNotOverwriteTheRequirementDescription()
+        {
+            var vm = new RequirementDialogViewModel(this.requirement, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.clone);
+
+            vm.RequirementText = "the description";
+            var descriptionLanguage = vm.SelectedLanguageCode.Name;
+            
+            this.thingDialogNavigationService
+                .Setup(x => x.Navigate(It.IsAny<Definition>(), It.IsAny<IThingTransaction>(), It.IsAny<ISession>(), It.IsAny<bool>(), ThingDialogKind.Create, It.IsAny<IThingDialogNavigationService>(), It.IsAny<Thing>(), It.IsAny<IEnumerable<Thing>>()))
+                .Callback<Thing, IThingTransaction, ISession, bool, ThingDialogKind, IThingDialogNavigationService, Thing, IEnumerable<Thing>>(
+                    (_, _, _, _, _, _, container, _) =>
+                        ((Requirement)container).Definition.Add(new Definition(Guid.NewGuid(), this.cache, this.uri) { LanguageCode = "nl", Content = "de eis" }))
+                .Returns(true);
+
+            await vm.CreateDefinitionCommand.Execute();
+
+            Assert.AreEqual(descriptionLanguage, vm.SelectedLanguageCode.Name);
+            Assert.AreEqual("the description", vm.RequirementText);
+        }
+
+        [Test]
+        public void VerifyThatTheFirstDefinitionIsShownAsTheRequirementDescription()
+        {
+            this.requirement.Definition.Add(new Definition(Guid.NewGuid(), this.cache, this.uri) { LanguageCode = "da", Content = "den oprindelige beskrivelse" });
+            this.requirement.Definition.Add(new Definition(Guid.NewGuid(), this.cache, this.uri) { LanguageCode = "en", Content = "added later" });
+
+            var vm = new RequirementDialogViewModel(this.requirement, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.clone);
+
+            Assert.AreEqual("da", vm.SelectedLanguageCode.Name);
+            Assert.AreEqual("den oprindelige beskrivelse", vm.RequirementText);
+        }
+
+        [Test]
+        public async Task VerifyThatEditingTheDescriptionLanguageMovesTheSelectionInsteadOfDuplicating()
+        {
+            this.requirement.Definition.Add(new Definition(Guid.NewGuid(), this.cache, this.uri) { LanguageCode = "en", Content = "the description" });
+
+            var vm = new RequirementDialogViewModel(this.requirement, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.clone);
+
+            Assert.AreEqual("en", vm.SelectedLanguageCode.Name);
+            
+            this.thingDialogNavigationService
+                .Setup(x => x.Navigate(It.IsAny<Thing>(), It.IsAny<IThingTransaction>(), It.IsAny<ISession>(), It.IsAny<bool>(), ThingDialogKind.Update, It.IsAny<IThingDialogNavigationService>(), It.IsAny<Thing>(), It.IsAny<IEnumerable<Thing>>()))
+                .Callback(() => this.requirement.Definition.First().LanguageCode = "da")
+                .Returns(true);
+
+            vm.SelectedDefinition = vm.Definition.Single();
+            await vm.EditDefinitionCommand.Execute();
+            
+            Assert.AreEqual("da", vm.SelectedLanguageCode.Name);
+            Assert.AreEqual("the description", vm.RequirementText);
         }
     }
 }

--- a/Requirements/ViewModels/Dialogs/RequirementDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementDialogViewModel.cs
@@ -88,7 +88,22 @@ namespace CDP4Requirements.ViewModels
         /// Backing field for <see cref="RequirementText"/>
         /// </summary>
         private string requirementText;
-        
+
+        /// <summary>
+        /// A value indicating whether the reload of <see cref="RequirementText"/> on a change of
+        /// <see cref="SelectedLanguageCode"/> must be suppressed. This is set while the selected language is
+        /// re-pointed to a rebuilt instance for the same language, so that re-populating the Definitions list does
+        /// not discard the description the user has entered.
+        /// </summary>
+        private bool suppressRequirementTextUpdate;
+
+        /// <summary>
+        /// A value indicating whether the next re-population of the Definitions list must keep the currently selected
+        /// description language. This is set only after a Definition is created from the Definitions tab, so that
+        /// adding a Definition does not change the description; on edit or delete the selection follows the Definitions.
+        /// </summary>
+        private bool preserveSelectedLanguageOnPopulate;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RequirementDialogViewModel"/> class.
         /// </summary>
@@ -255,7 +270,13 @@ namespace CDP4Requirements.ViewModels
 
             this.InspectSimpleParameterValueCommand = ReactiveCommandCreator.Create(() => this.ExecuteInspectCommand(this.SelectedSimpleParameterValue.Thing), canExecuteInspectSelectedSimpleParameterValueCommand);
 
-            this.WhenAnyValue(x => x.SelectedLanguageCode).Where(x => x != null).Subscribe(x => this.UpdateRequirementText());
+            this.WhenAnyValue(x => x.SelectedLanguageCode).Where(x => x != null && !this.suppressRequirementTextUpdate).Subscribe(x => this.UpdateRequirementText());
+
+            var canCreateDefinition = this.WhenAnyValue(vm => vm.IsReadOnly, v => !v);
+            this.CreateDefinitionCommand = ReactiveCommandCreator.Create(this.ExecuteCreateDefinitionCommand, canCreateDefinition);
+
+            var canEditDefinition = this.WhenAny(vm => vm.SelectedDefinition, v => v.Value != null && !this.IsReadOnly);
+            this.EditDefinitionCommand = ReactiveCommandCreator.Create(() => this.ExecuteEditCommand(this.SelectedDefinition.Thing, this.PopulateDefinition), canEditDefinition);
         }
 
         /// <summary>
@@ -374,12 +395,56 @@ namespace CDP4Requirements.ViewModels
         }
 
         /// <summary>
+        /// Executes the creation of a new <see cref="Definition"/> from the Definitions tab.
+        /// </summary>
+        private void ExecuteCreateDefinitionCommand()
+        {
+            var newDefinition = new Definition();
+
+            Definition languageReservation = null;
+
+            var descriptionLanguage = this.SelectedLanguageCode?.Name;
+
+            if (!string.IsNullOrWhiteSpace(this.RequirementText)
+                && !string.IsNullOrEmpty(descriptionLanguage)
+                && this.Thing.Definition.All(definition => definition.LanguageCode != descriptionLanguage))
+            {
+                languageReservation = new Definition(Guid.NewGuid(), null, null) { LanguageCode = descriptionLanguage };
+                this.Thing.Definition.Add(languageReservation);
+            }
+
+            bool? result;
+
+            try
+            {
+                result = this.thingDialogNavigationService.Navigate(newDefinition, this.transaction, this.Session, false, ThingDialogKind.Create, this.thingDialogNavigationService, this.Thing, this.ChainOfContainer);
+            }
+            finally
+            {
+                if (languageReservation != null)
+                {
+                    this.Thing.Definition.Remove(languageReservation);
+                }
+            }
+
+            if (result == true)
+            {
+                this.preserveSelectedLanguageOnPopulate = true;
+                this.PopulateDefinition();
+            }
+        }
+
+        /// <summary>
         /// Update the language code
         /// </summary>
         private void UpdateLanguageCodes()
         {
+            var previouslySelectedLanguage = this.SelectedLanguageCode?.Name;
+            var preserveSelectedLanguage = this.preserveSelectedLanguageOnPopulate;
+            this.preserveSelectedLanguageOnPopulate = false;
+
             this.PossibleLanguageCode.Clear();
-            
+
             var usedCodes = this.Thing.Definition.Select(x => x.LanguageCode);
 
             var languageCodeUsages = new List<LanguageCodeUsage>();            
@@ -415,14 +480,26 @@ namespace CDP4Requirements.ViewModels
                 }
             }
             
+            if (preserveSelectedLanguage && previouslySelectedLanguage != null)
+            {
+                var preserved = this.PossibleLanguageCode.FirstOrDefault(x => x.Name == previouslySelectedLanguage);
+
+                if (preserved != null)
+                {
+                    this.suppressRequirementTextUpdate = true;
+                    this.SelectedLanguageCode = preserved;
+                    this.suppressRequirementTextUpdate = false;
+                    return;
+                }
+            }
+
             if (this.Thing.Definition.Count == 0)
             {
                 this.SelectedLanguageCode = this.PossibleLanguageCode.Single(x => x.Name == CultureInfoUtility.DefaultCultureName);
                 return;
             }
 
-            var definition = this.Thing.Definition.SingleOrDefault(x => x.LanguageCode == CultureInfoUtility.DefaultCultureName) ?? this.Thing.Definition.First();
-            
+            var definition = this.Thing.Definition.First();
             this.SelectedLanguageCode = this.PossibleLanguageCode.Single(x => x.Name == definition.LanguageCode);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
fix #1362 

Prevent duplicate language codes when adding multiple definitions to a requirement

- Exclude language codes already used by sibling definitions from
  PossibleLanguageCode in DefinitionDialogViewModel, so each language
  can only be assigned once across a DefinedThing's definitions
- Reserve the current description language while the Create Definition
  dialog is open, then remove the reservation afterwards, so the new
  Definition dialog cannot pick the same language as the requirement text
- Preserve the selected description language after PopulateDefinition
  runs (via preserveSelectedLanguageOnPopulate flag), preventing the
  requirement text from being discarded or replaced when a definition is
  added
