### PR TITLE
Added a method to close the scriptingpanels when there are no open sessions #1255

### DIFF
--- a/CDP4Scripting.Tests/ViewModels/ScriptingEngineRibbonPageGroupTestFixture.cs
+++ b/CDP4Scripting.Tests/ViewModels/ScriptingEngineRibbonPageGroupTestFixture.cs
@@ -40,6 +40,7 @@ namespace CDP4Scripting.Tests.ViewModels
     using CDP4Composition.Navigation.Events;
 
     using CDP4Dal;
+    using CDP4Dal.Events;
 
     using CDP4Scripting.Events;
     using CDP4Scripting.Interfaces;
@@ -367,6 +368,60 @@ namespace CDP4Scripting.Tests.ViewModels
             Assert.IsTrue(this.scriptingEngineRibbonPageGroupViewModel.CollectionScriptPanelViewModels.Contains(panel2.Object));
             Assert.IsFalse(this.scriptingEngineRibbonPageGroupViewModel.CollectionScriptPanelViewModels.Contains(panel1.Object));
             Assert.IsFalse(this.scriptingEngineRibbonPageGroupViewModel.PathScriptingFiles.ContainsKey("panel 1"));
+        }
+
+        [Test]
+        public void VerifyThatScriptPanelsAreClosedWhenLastSessionIsClosed()
+        {
+            var avalonEditor = new TextEditor();
+
+            var panel1 = new Mock<ScriptPanelViewModel>("panel 1", this.scriptingProxy.Object, this.messageBus, "*.py", this.openSessions, true);
+            panel1.As<IPanelViewModel>();
+            panel1.As<IScriptPanelViewModel>().SetupProperty(x => x.Caption, "panel 1");
+            panel1.SetupProperty(x => x.AvalonEditor, avalonEditor);
+
+            var panel2 = new Mock<ScriptPanelViewModel>("panel 2", this.scriptingProxy.Object, this.messageBus, "*.py", this.openSessions, true);
+            panel2.As<IPanelViewModel>();
+            panel2.As<IScriptPanelViewModel>().SetupProperty(x => x.Caption, "panel 2");
+            panel2.SetupProperty(x => x.AvalonEditor, avalonEditor);
+
+            this.scriptingEngineRibbonPageGroupViewModel.CollectionScriptPanelViewModels.Add(panel1.Object);
+            this.scriptingEngineRibbonPageGroupViewModel.CollectionScriptPanelViewModels.Add(panel2.Object);
+
+            var session = new Mock<ISession>();
+
+            this.messageBus.SendMessage(new SessionEvent(session.Object, SessionStatus.Open));
+            Assert.AreEqual(1, this.scriptingEngineRibbonPageGroupViewModel.OpenSessions.Count);
+
+            this.messageBus.SendMessage(new SessionEvent(session.Object, SessionStatus.Closed));
+            Assert.AreEqual(0, this.scriptingEngineRibbonPageGroupViewModel.OpenSessions.Count);
+
+            this.panelNavigationService.Verify(x => x.CloseInDock(panel1.Object as IPanelViewModel), Times.Once);
+            this.panelNavigationService.Verify(x => x.CloseInDock(panel2.Object as IPanelViewModel), Times.Once);
+        }
+
+        [Test]
+        public void VerifyThatScriptPanelsAreNotClosedWhenOtherSessionsRemainOpen()
+        {
+            var avalonEditor = new TextEditor();
+
+            var panel1 = new Mock<ScriptPanelViewModel>("panel 1", this.scriptingProxy.Object, this.messageBus, "*.py", this.openSessions, true);
+            panel1.As<IPanelViewModel>();
+            panel1.As<IScriptPanelViewModel>().SetupProperty(x => x.Caption, "panel 1");
+            panel1.SetupProperty(x => x.AvalonEditor, avalonEditor);
+
+            this.scriptingEngineRibbonPageGroupViewModel.CollectionScriptPanelViewModels.Add(panel1.Object);
+
+            var session1 = new Mock<ISession>();
+            var session2 = new Mock<ISession>();
+
+            this.messageBus.SendMessage(new SessionEvent(session1.Object, SessionStatus.Open));
+            this.messageBus.SendMessage(new SessionEvent(session2.Object, SessionStatus.Open));
+            
+            this.messageBus.SendMessage(new SessionEvent(session1.Object, SessionStatus.Closed));
+            Assert.AreEqual(1, this.scriptingEngineRibbonPageGroupViewModel.OpenSessions.Count);
+
+            this.panelNavigationService.Verify(x => x.CloseInDock(It.IsAny<IPanelViewModel>()), Times.Never);
         }
     }
 }

--- a/CDP4Scripting/ViewModels/ScriptingEngineRibbonPageGroupViewModel.cs
+++ b/CDP4Scripting/ViewModels/ScriptingEngineRibbonPageGroupViewModel.cs
@@ -365,6 +365,23 @@ namespace CDP4Scripting.ViewModels
             else if (sessionChange.Status == SessionStatus.Closed)
             {
                 this.OpenSessions.Remove(sessionChange.Session);
+
+                if (this.OpenSessions.Count == 0)
+                {
+                    this.CloseAllScriptPanels();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Closes all the open <see cref="IScriptPanelViewModel"/>s. This is invoked when the last <see cref="ISession"/> is
+        /// closed so that the scripting panels are cleaned up on disconnect, like the other panels of the application.
+        /// </summary>
+        private void CloseAllScriptPanels()
+        {
+            foreach (var scriptPanelViewModel in this.CollectionScriptPanelViewModels.ToList())
+            {
+                this.PanelNavigationService.CloseInDock(scriptPanelViewModel as IPanelViewModel);
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Fix #1255

Added  a method to close the scriptingpanels when there are no open sessions anymore to the ScriptingEngineRibbonPageGroupViewModel.cs

