### PR TITLE
Align Locked filestoreitem icon for commonFileStorBrowser #1396

### DIFF
--- a/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/FileRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/FileStoreBrowsers/FileRowViewModelTestFixture.cs
@@ -126,6 +126,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.CommonFileStoreBrowser
             Assert.AreEqual(this.fileRevision1.Name, viewModel.Name);
             Assert.AreEqual(this.fileRevision1.Creator.Person.Name, viewModel.CreatorValue);
             Assert.IsFalse(viewModel.IsLocked);
+            Assert.IsFalse(viewModel.ThingStatus.IsLocked);
             Assert.AreEqual(string.Empty, viewModel.Locker);
             Assert.AreEqual("1", viewModel.Name);
             this.fileStoreFileAndFolderHandler.Verify(x => x.UpdateFileRowPosition(this.file, It.IsAny<FileRevision>()), Times.Never);
@@ -135,6 +136,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.CommonFileStoreBrowser
             this.messageBus.SendObjectChangeEvent(this.file, EventKind.Updated);
 
             Assert.IsTrue(viewModel.IsLocked);
+            Assert.IsTrue(viewModel.ThingStatus.IsLocked);
             Assert.AreEqual("John Doe", viewModel.Locker);
             this.fileStoreFileAndFolderHandler.Verify(x => x.UpdateFileRowPosition(this.file, It.IsAny<FileRevision>()), Times.Never);
 

--- a/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowser.xaml
+++ b/EngineeringModel/Views/FileStoreBrowsers/CommonFileStoreBrowser.xaml
@@ -73,8 +73,9 @@
                             <Image Style="{StaticResource ThingIcon}">
                                 <Image.Source>
                                     <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
-                                        <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
-                                        <Binding Path="DataContext.Row.IsLocked" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
+                                        <Binding Path="DataContext.Row.ThingStatus" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
+                                        <Binding Path="DataContext.Row.ThingStatus.IsHidden" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
+                                        <Binding Path="DataContext.Row.ThingStatus.IsLocked" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
                                     </MultiBinding>
                                 </Image.Source>
                             </Image>


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

fix: #1396 

Aligned the llocked file items icon of the commonfilestorebrowser to be the same as the domainfilestorebrowser by 
Using the same bindings FileRowViewmModel template in the CommonFileStoreBrowser.xaml as used in the DomainFileStoreBrowser.xaml to convert properly to the locked image format.

