### PR TITLE
fixed a bug that showed the deprecated persons and roles in their broswer #1383

### DIFF
--- a/CDP4SiteDirectory.Tests/PersonBrowser/PersonBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/PersonBrowser/PersonBrowserViewModelTestFixture.cs
@@ -166,6 +166,30 @@ namespace CDP4SiteDirectory.Tests
             this.navigation.Verify(x => x.Navigate(It.IsAny<Person>(), It.IsAny<IThingTransaction>(), this.session.Object, true, ThingDialogKind.Update, this.navigation.Object, It.IsAny<Thing>(), null));
         }
 
+        [Test]
+        public async Task VerifyThatDeprecatedPersonPropagatesIsDeprecatedToParticipantChildren()
+        {
+            var modelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri);
+            this.siteDir.Model.Add(modelSetup);
+
+            var participant = new Participant(Guid.NewGuid(), this.cache, this.uri) { Person = this.person };
+            modelSetup.Participant.Add(participant);
+
+            this.person.IsDeprecated = true;
+
+            var browser = new PersonBrowserViewModel(this.session.Object, this.siteDir, this.navigation.Object, this.panelnavigation.Object, null, null);
+
+            await this.DelayedCheck(() => browser.SingleRunBackgroundWorker == null);
+
+            var personRow = browser.PersonRowViewModels.Single(x => x.Thing == this.person);
+            Assert.IsTrue(personRow.IsDeprecated);
+
+            var participantRow = (ParticipantRowViewModel)personRow.ContainedRows.Single(x => x.Thing == participant);
+            Assert.IsTrue(participantRow.IsDeprecated);
+
+            browser.Dispose();
+        }
+
         /// <summary>
         /// Checks for <see cref="BackgroundWorker"/>s to finish
         /// </summary>

--- a/CDP4SiteDirectory.Tests/RoleBrowser/RoleBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/RoleBrowser/RoleBrowserViewModelTestFixture.cs
@@ -134,6 +134,26 @@ namespace CDP4SiteDirectory.Tests
         }
 
         [Test]
+        public void VerifyThatDeprecatedRolePropagatesIsDeprecatedToPermissionChildren()
+        {
+            var permission = new PersonPermission(Guid.NewGuid(), this.cache, this.uri) { ObjectClass = ClassKind.Alias };
+            this.personRole.PersonPermission.Add(permission);
+            this.personRole.IsDeprecated = true;
+
+            var viewmodel = new RoleBrowserViewModel(this.session.Object, this.siteDir, null, this.navigation.Object, null, null);
+
+            var personRoleRow = viewmodel.Roles.First();
+            var deprecatedRoleRow = (PersonRoleRowViewModel)personRoleRow.ContainedRows.Single(x => x.Thing == this.personRole);
+
+            Assert.IsTrue(deprecatedRoleRow.IsDeprecated);
+
+            var permissionRow = (PersonPermissionRowViewModel)deprecatedRoleRow.ContainedRows.Single(x => x.Thing == permission);
+            Assert.IsTrue(permissionRow.IsDeprecated);
+
+            viewmodel.Dispose();
+        }
+
+        [Test]
         public void VerifyThatNewRolesAreAdded()
         {
             var viewmodel = new RoleBrowserViewModel(this.session.Object, this.siteDir, null, this.navigation.Object, null, null);

--- a/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml
+++ b/CDP4SiteDirectory/Views/PersonBrowser/PersonBrowser.xaml
@@ -111,6 +111,8 @@
                              Grid.Row="2"
                              ItemsSource="{Binding Path=PersonRowViewModels}"
                              SelectedItem="{Binding SelectedThing}"
+                             FilterString="{Binding FilterString, Mode=TwoWay}"
+                             IsFilterEnabled="{Binding IsFilterEnabled, Mode=TwoWay}"
                              services:GridUpdateService.UpdateStarted="{Binding HasUpdateStarted}">
             <i:Interaction.Behaviors>
                 <dragDrop:FrameworkElementDragBehavior />

--- a/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml
+++ b/CDP4SiteDirectory/Views/RoleBrowser/RoleBrowser.xaml
@@ -133,7 +133,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <views:CommonThingControl GridView="{Binding ElementName=View}" />
+        <views:CommonThingControl GridView="{Binding ElementName=View}" FilteringMode="ParentBranch" />
 
         <views:SessionHeader Grid.Row="1" />
 


### PR DESCRIPTION

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
fix: #1383  
fixed a bug that showed the deprecated persons and roles in their respective browser even when the deprecatedThings visibility was off
Added filterintMode="ParentBranch" to the rolesbrowser.xaml and added filtering to personsbrowser

