### PR TITLE
fixes issue #1315 and #1067. Custom select all button and possible to select deprecated domains

### DIFF
--- a/EngineeringModel.Tests/ViewModels/Dialogs/EngineeringModelSetupDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/EngineeringModelSetupDialogViewModelTestFixture.cs
@@ -39,7 +39,9 @@ namespace CDP4EngineeringModel.Tests
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
+    using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
+    using CDP4Composition.Services;
 
     using CDP4Dal;
     using CDP4Dal.DAL;
@@ -47,11 +49,15 @@ namespace CDP4EngineeringModel.Tests
 
     using CDP4EngineeringModel.ViewModels;
 
+    using CommonServiceLocator;
+
     using Moq;
 
     using NUnit.Framework;
 
     using ReactiveUI;
+
+    using ActiveDomainRowViewModel = CDP4Composition.CommonView.ViewModels.ActiveDomainRowViewModel;
 
     /// <summary>
     /// suite of tests for the <see cref="EngineeringModelSetupDialogViewModel"/> class.
@@ -98,6 +104,8 @@ namespace CDP4EngineeringModel.Tests
         private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
         private SiteDirectory siteDirClone;
         private CDPMessageBus messageBus;
+        private Mock<IServiceLocator> serviceLocator;
+        private Mock<IFilterStringService> filterStringService;
 
         [SetUp]
         public void SetUp()
@@ -106,6 +114,11 @@ namespace CDP4EngineeringModel.Tests
 
             this.messageBus = new CDPMessageBus();
             this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+
+            this.filterStringService = new Mock<IFilterStringService>();
+            this.serviceLocator = new Mock<IServiceLocator>();
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
 
             this.uri = new Uri("http://test.com");
             this.siteDirectory = new SiteDirectory(Guid.NewGuid(), this.cache, this.uri);
@@ -389,9 +402,9 @@ namespace CDP4EngineeringModel.Tests
 
             this.viewModel = new EngineeringModelSetupDialogViewModel(engineeringModelSetup.Clone(false), transaction, this.session.Object, true, ThingDialogKind.Update, null, this.siteDirClone);
 
-            // Count of visible items
+            // Count of visible items: the two non-deprecated domains plus domain1 (deprecated but assigned, so always visible)
             var visibleDomains = this.viewModel.PossibleActiveDomain.Count(d => d.IsVisible);
-            Assert.AreEqual(2, visibleDomains);
+            Assert.AreEqual(3, visibleDomains);
 
             this.viewModel.ShowDeprecatedDomains = true;
             visibleDomains = this.viewModel.PossibleActiveDomain.Count(d => d.IsVisible);
@@ -401,6 +414,129 @@ namespace CDP4EngineeringModel.Tests
             Assert.AreEqual(2, deprecatedDomains);
 
             Assert.AreEqual(this.viewModel.PossibleActiveDomain[0].Name, domain1.Name);
+        }
+
+        [Test]
+        public void VerifyThatSelectAllDoesNotSelectDeprecatedDomains()
+        {
+            this.viewModel = this.CreateActiveDomainViewModel(out var normalDomain, out var otherNormalDomain, out var deprecatedDomain, activeDomainSelector: (n, o, d) => new[] { n });
+
+            this.viewModel.ShowDeprecatedDomains = true;
+            this.viewModel.AreAllActiveDomainsSelected = true;
+
+            Assert.IsFalse(this.viewModel.ActiveDomain.Any(r => r.IsDeprecated), "Select All must not select deprecated domains.");
+            Assert.IsTrue(this.viewModel.ActiveDomain.Any(r => r.DomainOfExpertise == normalDomain));
+            Assert.IsTrue(this.viewModel.ActiveDomain.Any(r => r.DomainOfExpertise == otherNormalDomain));
+        }
+
+        [Test]
+        public void VerifyThatUnselectAllDoesNotUnselectDeprecatedDomains()
+        {
+            this.viewModel = this.CreateActiveDomainViewModel(out var normalDomain, out _, out var deprecatedDomain, activeDomainSelector: (n, o, d) => new[] { n, d });
+
+            this.viewModel.ShowDeprecatedDomains = true;
+            this.viewModel.AreAllActiveDomainsSelected = false;
+
+            Assert.IsTrue(this.viewModel.ActiveDomain.Any(r => r.DomainOfExpertise == deprecatedDomain), "Unselect All must not unselect an already-assigned deprecated domain.");
+            Assert.IsFalse(this.viewModel.ActiveDomain.Any(r => r.DomainOfExpertise == normalDomain));
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedDomainCanBeIndividuallyAssigned()
+        {
+            this.viewModel = this.CreateActiveDomainViewModel(out var normalDomain, out _, out var deprecatedDomain, activeDomainSelector: (n, o, d) => new[] { n });
+
+            this.viewModel.ShowDeprecatedDomains = true;
+
+            var deprecatedRow = this.viewModel.PossibleActiveDomain.Single(r => r.DomainOfExpertise == deprecatedDomain);
+
+            this.viewModel.ActiveDomain = new ReactiveList<ActiveDomainRowViewModel>(this.viewModel.ActiveDomain.Concat(new[] { deprecatedRow }));
+
+            Assert.IsTrue(this.viewModel.ActiveDomain.Contains(deprecatedRow), "A deprecated domain ticked individually must be assignable.");
+            Assert.IsTrue(deprecatedRow.IsEnabled);
+        }
+
+        [Test]
+        public void VerifyThatShowDeprecatedDomainsInitializesFromGlobalSetting()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(true);
+
+            this.viewModel = this.CreateActiveDomainViewModel(out _, out _, out var deprecatedDomain, activeDomainSelector: (n, o, d) => new[] { n });
+
+            Assert.IsTrue(this.viewModel.ShowDeprecatedDomains, "The local toggle must default to the global Show Deprecated Things setting.");
+
+            var deprecatedRow = this.viewModel.PossibleActiveDomain.Single(r => r.DomainOfExpertise == deprecatedDomain);
+            Assert.IsTrue(deprecatedRow.IsVisible, "Deprecated domains must be visible when the global setting shows deprecated things.");
+        }
+
+        [Test]
+        public void VerifyThatAssignedDeprecatedDomainIsAlwaysVisible()
+        {
+            this.viewModel = this.CreateActiveDomainViewModel(out _, out _, out var deprecatedDomain, activeDomainSelector: (n, o, d) => new[] { n, d });
+
+            Assert.IsFalse(this.viewModel.ShowDeprecatedDomains);
+
+            var deprecatedRow = this.viewModel.PossibleActiveDomain.Single(r => r.DomainOfExpertise == deprecatedDomain);
+
+            Assert.IsTrue(deprecatedRow.IsVisible, "An assigned deprecated domain must stay visible even when deprecated domains are hidden.");
+        }
+
+        [Test]
+        public void VerifyThatUnassignedDeprecatedDomainIsHiddenWhenDeprecatedAreHidden()
+        {
+            this.viewModel = this.CreateActiveDomainViewModel(out _, out _, out var deprecatedDomain, activeDomainSelector: (n, o, d) => new[] { n });
+
+            Assert.IsFalse(this.viewModel.ShowDeprecatedDomains);
+
+            var deprecatedRow = this.viewModel.PossibleActiveDomain.Single(r => r.DomainOfExpertise == deprecatedDomain);
+
+            Assert.IsFalse(deprecatedRow.IsVisible, "An unassigned deprecated domain must be hidden when deprecated domains are hidden.");
+        }
+
+        [Test]
+        public void VerifyThatAreAllActiveDomainsSelectedReflectsSelectionOfNonDeprecatedDomains()
+        {
+            this.viewModel = this.CreateActiveDomainViewModel(out _, out _, out _, activeDomainSelector: (n, o, d) => new[] { n });
+
+            this.viewModel.ShowDeprecatedDomains = true;
+
+            Assert.IsFalse(this.viewModel.AreAllActiveDomainsSelected, "Not all non-deprecated domains are selected yet.");
+
+            this.viewModel.AreAllActiveDomainsSelected = true;
+
+            Assert.IsTrue(this.viewModel.AreAllActiveDomainsSelected);
+            Assert.IsFalse(this.viewModel.ActiveDomain.Any(r => r.IsDeprecated));
+        }
+
+        /// <summary>
+        /// Creates an <see cref="EngineeringModelSetupDialogViewModel"/> in Update mode with two non-deprecated domains
+        /// and one deprecated domain in the container <see cref="SiteDirectory"/>.
+        /// </summary>
+        private EngineeringModelSetupDialogViewModel CreateActiveDomainViewModel(out DomainOfExpertise normalDomain, out DomainOfExpertise otherNormalDomain, out DomainOfExpertise deprecatedDomain, Func<DomainOfExpertise, DomainOfExpertise, DomainOfExpertise, DomainOfExpertise[]> activeDomainSelector = null)
+        {
+            normalDomain = new DomainOfExpertise(Guid.NewGuid(), null, this.uri) { Name = "normal" };
+            otherNormalDomain = new DomainOfExpertise(Guid.NewGuid(), null, this.uri) { Name = "otherNormal" };
+            deprecatedDomain = new DomainOfExpertise(Guid.NewGuid(), null, this.uri) { Name = "deprecated", IsDeprecated = true };
+
+            this.siteDirClone.Domain.Add(normalDomain);
+            this.siteDirClone.Domain.Add(otherNormalDomain);
+            this.siteDirClone.Domain.Add(deprecatedDomain);
+
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri);
+
+            var selected = activeDomainSelector?.Invoke(normalDomain, otherNormalDomain, deprecatedDomain) ?? new[] { normalDomain };
+
+            foreach (var domain in selected)
+            {
+                engineeringModelSetup.ActiveDomain.Add(domain);
+            }
+
+            this.cache.TryAdd(new CacheKey(engineeringModelSetup.Iid, null), new Lazy<Thing>(() => engineeringModelSetup));
+
+            var transactionContext = TransactionContextResolver.ResolveContext(this.siteDirectory);
+            var transaction = new ThingTransaction(transactionContext, this.siteDirClone);
+
+            return new EngineeringModelSetupDialogViewModel(engineeringModelSetup.Clone(false), transaction, this.session.Object, true, ThingDialogKind.Update, null, this.siteDirClone);
         }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/EngineeringModelSetupDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/EngineeringModelSetupDialogViewModel.cs
@@ -82,7 +82,7 @@ namespace CDP4EngineeringModel.ViewModels
 
             this.SelectedOrganizations = new ReactiveList<Organization>();
 
-            this.filterStringService = ServiceLocator.Current.GetInstance<IFilterStringService>();
+            this.filterStringService ??= ServiceLocator.Current.GetInstance<IFilterStringService>();
             this.ShowDeprecatedDomains = this.filterStringService.ShowDeprecatedThings;
 
             this.WhenAnyValue(vm => vm.ShowDeprecatedDomains).Subscribe(_ => this.ShowHideDeprecatedDomains());

--- a/EngineeringModel/ViewModels/Dialogs/EngineeringModelSetupDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/EngineeringModelSetupDialogViewModel.cs
@@ -63,6 +63,11 @@ namespace CDP4EngineeringModel.ViewModels
     public class EngineeringModelSetupDialogViewModel : CDP4CommonView.EngineeringModelSetupDialogViewModel, IThingDialogViewModel
     {
         /// <summary>
+        /// The (injected) <see cref="IFilterStringService" />
+        /// </summary>
+        private IFilterStringService filterStringService;
+
+        /// <summary>
         /// Initialize the dialog
         /// </summary>
         protected override void Initialize()
@@ -77,7 +82,8 @@ namespace CDP4EngineeringModel.ViewModels
 
             this.SelectedOrganizations = new ReactiveList<Organization>();
 
-            this.ShowDeprecatedDomains = ServiceLocator.Current.GetInstance<IFilterStringService>().ShowDeprecatedThings;
+            this.filterStringService = ServiceLocator.Current.GetInstance<IFilterStringService>();
+            this.ShowDeprecatedDomains = this.filterStringService.ShowDeprecatedThings;
 
             this.WhenAnyValue(vm => vm.ShowDeprecatedDomains).Subscribe(_ => this.ShowHideDeprecatedDomains());
 

--- a/EngineeringModel/ViewModels/Dialogs/EngineeringModelSetupDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/EngineeringModelSetupDialogViewModel.cs
@@ -41,6 +41,9 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
+
+    using CommonServiceLocator;
 
     using ReactiveUI;
 
@@ -72,38 +75,21 @@ namespace CDP4EngineeringModel.ViewModels
             this.PossibleActiveDomain = new ReactiveList<ActiveDomainRowViewModel>();
             this.ActiveDomain = new ReactiveList<ActiveDomainRowViewModel>();
 
-            this.ActiveDomain.ItemsAdded.Subscribe(this.SetActiveState);
-            this.ActiveDomain.ItemsRemoved.Subscribe(this.SetInactiveState);
-
             this.SelectedOrganizations = new ReactiveList<Organization>();
 
+            this.ShowDeprecatedDomains = ServiceLocator.Current.GetInstance<IFilterStringService>().ShowDeprecatedThings;
+
             this.WhenAnyValue(vm => vm.ShowDeprecatedDomains).Subscribe(_ => this.ShowHideDeprecatedDomains());
+
+            this.WhenAnyValue(vm => vm.ActiveDomain).Subscribe(_ =>
+            {
+                this.RaisePropertyChanged(nameof(this.AreAllActiveDomainsSelected));
+                this.ShowHideDeprecatedDomains();
+            });
         }
 
         /// <summary>
-        /// Set active domain inactive state
-        /// </summary>
-        /// <param name="oldRow">
-        ///     <see cref="ActiveDomainRowViewModel" />
-        /// </param>
-        private void SetInactiveState(ActiveDomainRowViewModel oldRow)
-        {
-            oldRow.IsEnabled = false;
-        }
-
-        /// <summary>
-        /// Set active domain active state
-        /// </summary>
-        /// <param name="newRow">
-        ///     <see cref="ActiveDomainRowViewModel" />
-        /// </param>
-        private void SetActiveState(ActiveDomainRowViewModel newRow)
-        {
-            newRow.IsEnabled = true;
-        }
-
-        /// <summary>
-        /// Show/hide deprecated domains from the view
+        /// Updates the visibility of the deprecated <see cref="DomainOfExpertise" /> rows.
         /// </summary>
         private void ShowHideDeprecatedDomains()
         {
@@ -111,7 +97,7 @@ namespace CDP4EngineeringModel.ViewModels
 
             foreach (var activeDomainRowViewModel in deprecatedItems)
             {
-                activeDomainRowViewModel.IsVisible = this.ShowDeprecatedDomains;
+                activeDomainRowViewModel.IsVisible = this.ShowDeprecatedDomains || this.ActiveDomain.Contains(activeDomainRowViewModel);
             }
         }
 
@@ -127,7 +113,7 @@ namespace CDP4EngineeringModel.ViewModels
 
             foreach (var domainOfExpertise in sitedir.Domain.OrderBy(x => x.Name))
             {
-                var activeDomainRowModel = new ActiveDomainRowViewModel(domainOfExpertise, !this.ShowDeprecatedDomains && !domainOfExpertise.IsDeprecated);
+                var activeDomainRowModel = new ActiveDomainRowViewModel(domainOfExpertise, !domainOfExpertise.IsDeprecated);
                 this.PossibleActiveDomain.Add(activeDomainRowModel);
             }
 
@@ -141,6 +127,8 @@ namespace CDP4EngineeringModel.ViewModels
                     activeDomainRowModel.IsEnabled = true;
                 }
             }
+
+            this.ShowHideDeprecatedDomains();
         }
 
         /// <summary>
@@ -453,9 +441,43 @@ namespace CDP4EngineeringModel.ViewModels
         public new ReactiveList<ActiveDomainRowViewModel> PossibleActiveDomain { get; set; }
 
         /// <summary>
+        /// Backing field for <see cref="ActiveDomain" />
+        /// </summary>
+        private ReactiveList<ActiveDomainRowViewModel> activeDomain;
+
+        /// <summary>
         /// Gets or sets the value of active domain.
         /// </summary>
-        public new ReactiveList<ActiveDomainRowViewModel> ActiveDomain { get; set; }
+        public new ReactiveList<ActiveDomainRowViewModel> ActiveDomain
+        {
+            get => this.activeDomain;
+            set => this.RaiseAndSetIfChanged(ref this.activeDomain, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all non-deprecated <see cref="DomainOfExpertise" /> rows are selected.
+        /// </summary>
+        public bool AreAllActiveDomainsSelected
+        {
+            get => (this.PossibleActiveDomain != null)
+                   && this.PossibleActiveDomain.Any(row => !row.IsDeprecated)
+                   && this.PossibleActiveDomain.Where(row => !row.IsDeprecated).All(row => this.ActiveDomain.Contains(row));
+
+            set
+            {
+                if (value)
+                {
+                    var nonDeprecatedDomains = this.PossibleActiveDomain.Where(row => !row.IsDeprecated);
+                    this.ActiveDomain = new ReactiveList<ActiveDomainRowViewModel>(this.ActiveDomain.Union(nonDeprecatedDomains));
+                }
+                else
+                {
+                    this.ActiveDomain = new ReactiveList<ActiveDomainRowViewModel>(this.ActiveDomain.Where(row => row.IsDeprecated));
+                }
+
+                this.RaisePropertyChanged();
+            }
+        }
 
         /// <summary>
         /// Gets or sets the ShortName

--- a/EngineeringModel/Views/Dialogs/EngineeringModelSetupDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/EngineeringModelSetupDialog.xaml
@@ -108,16 +108,24 @@
                 </lc:LayoutGroup>
 
                 <lc:LayoutGroup Header="Active Domain" Orientation="Vertical" IsEnabled="{Binding IsActiveDomainSelectionReadOnly, Converter={StaticResource NotConverter}}">
-                    <lc:LayoutItem HorizontalAlignment="Right">
-                        <dx:SimpleButton x:Name="ShowDeprecatedDomainBox"
-                                         Margin="0,0,10,0"
-                                         IsChecked="{Binding ShowDeprecatedDomains}"
-                                         Glyph="{dx:DXImage Image=Show_16x16.png}"
-                                         ToolTip="Show Deprecated Domains of Expertise"
-                                         ButtonKind="Toggle"
-                                         Width="25"
-                                         Height="25"/>
-                    </lc:LayoutItem>
+                    <lc:LayoutGroup Orientation="Horizontal">
+                        <lc:LayoutItem HorizontalAlignment="Left">
+                            <CheckBox Content="Select All"
+                                      Margin="10,0,0,0"
+                                      VerticalAlignment="Center"
+                                      IsChecked="{Binding AreAllActiveDomainsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        </lc:LayoutItem>
+                        <lc:LayoutItem HorizontalAlignment="Right">
+                            <dx:SimpleButton x:Name="ShowDeprecatedDomainBox"
+                                             Margin="0,0,10,0"
+                                             IsChecked="{Binding ShowDeprecatedDomains}"
+                                             Glyph="{dx:DXImage Image=Show_16x16.png}"
+                                             ToolTip="Show Deprecated Domains of Expertise"
+                                             ButtonKind="Toggle"
+                                             Width="25"
+                                             Height="25"/>
+                        </lc:LayoutItem>
+                    </lc:LayoutGroup>
                     <lc:LayoutItem>
                         <dxe:ListBoxEdit
                             MaxHeight="250"
@@ -129,14 +137,14 @@
                             ItemsSource="{Binding PossibleActiveDomain}">
 
                             <dxe:ListBoxEdit.StyleSettings>
-                                <dxe:CheckedListBoxEditStyleSettings>
+                                <dxe:CheckedListBoxEditStyleSettings ShowSelectAllItem="False">
                                     <dxe:CheckedListBoxEditStyleSettings.ItemContainerStyle>
                                         <Style BasedOn="{StaticResource {themes:EditorListBoxThemeKey ResourceKey=CheckBoxItemStyle}}" TargetType="dxe:ListBoxEditItem">
                                             <Setter Property="Visibility" Value="{Binding IsVisible, Converter={dxmvvm:BooleanToVisibilityConverter}}" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding Path=IsDeprecated}" Value="True">
-                                                    <Setter Property = "FontStyle" Value="Italic"/>
-                                                    <Setter Property = "IsEnabled" Value="{Binding IsEnabled}" />
+                                                    <Setter Property="Background" Value="LightGray" />
+                                                    <Setter Property="Opacity" Value="0.5" />
                                                 </DataTrigger>
                                             </Style.Triggers>
                                         </Style>


### PR DESCRIPTION
… logic in the viewmodel. and made the toggle view button initially correspond with the global one

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

fixes: #1315  and #1067 

-Grey out deprecated domains
-Custom select all that only selects the not deprecated domains
-Possible to select/deselect deprecated domain
-always show selected deprecated domains
-Local deprecated things visibility initially corresponds with the global one 

