### PR TITLE
Fixes #443 Does not show depcrecated rules in the userruleverificationdialog

### DIFF
--- a/EngineeringModel.Tests/Dialogs/UserRuleVerificationDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/UserRuleVerificationDialogViewModelTestFixture.cs
@@ -40,6 +40,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
 
     using CDP4Dal;
     using CDP4Dal.DAL;
@@ -47,6 +48,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
     using CDP4Dal.Permission;
 
     using CDP4EngineeringModel.ViewModels;
+
+    using CommonServiceLocator;
 
     using Moq;
 
@@ -79,6 +82,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         private BinaryRelationshipRule binaryRelationshipRule;
         private DecompositionRule decompositionRule;
         private CDPMessageBus messageBus;
+        private Mock<IServiceLocator> serviceLocator;
+        private Mock<IFilterStringService> filterStringService;
 
         [SetUp]
         public void SetUp()
@@ -87,6 +92,11 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             this.messageBus = new CDPMessageBus();
             this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+
+            this.filterStringService = new Mock<IFilterStringService>();
+            this.serviceLocator = new Mock<IServiceLocator>();
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
 
             this.siteDirectory = new SiteDirectory(Guid.NewGuid(), this.cache, this.uri);
             this.systemDomainOfExpertise = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "System", ShortName = "SYS" };
@@ -168,6 +178,49 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             Assert.AreEqual("System [SYS]", dialog.Owner);
             Assert.IsTrue(dialog.IsActive);
+            Assert.AreEqual(this.binaryRelationshipRule, dialog.SelectedRule);
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedRulesAreHiddenWhenShowDeprecatedThingsIsOff()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(false);
+            this.decompositionRule.IsDeprecated = true;
+
+            var clone = this.ruleVerificationList.Clone(false);
+
+            var dialog = new UserRuleVerificationDialogViewModel(this.userRuleVerification, this.thingTransaction, this.session.Object, true, ThingDialogKind.Inspect, this.thingDialogNavigationService.Object, clone, null);
+
+            CollectionAssert.DoesNotContain(dialog.PossibleRule, this.decompositionRule);
+            CollectionAssert.Contains(dialog.PossibleRule, this.binaryRelationshipRule);
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedRulesAreShownWhenShowDeprecatedThingsIsOn()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(true);
+            this.decompositionRule.IsDeprecated = true;
+
+            var clone = this.ruleVerificationList.Clone(false);
+
+            var dialog = new UserRuleVerificationDialogViewModel(this.userRuleVerification, this.thingTransaction, this.session.Object, true, ThingDialogKind.Inspect, this.thingDialogNavigationService.Object, clone, null);
+
+            CollectionAssert.Contains(dialog.PossibleRule, this.decompositionRule);
+            CollectionAssert.Contains(dialog.PossibleRule, this.binaryRelationshipRule);
+        }
+
+        [Test]
+        public void VerifyThatAssignedDeprecatedRuleRemainsVisibleWhenShowDeprecatedThingsIsOff()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(false);
+            
+            this.binaryRelationshipRule.IsDeprecated = true;
+
+            var clone = this.ruleVerificationList.Clone(false);
+
+            var dialog = new UserRuleVerificationDialogViewModel(this.userRuleVerification, this.thingTransaction, this.session.Object, true, ThingDialogKind.Inspect, this.thingDialogNavigationService.Object, clone, null);
+
+            CollectionAssert.Contains(dialog.PossibleRule, this.binaryRelationshipRule);
             Assert.AreEqual(this.binaryRelationshipRule, dialog.SelectedRule);
         }
 

--- a/EngineeringModel/ViewModels/Dialogs/UserRuleVerificationDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/UserRuleVerificationDialogViewModel.cs
@@ -59,6 +59,11 @@ namespace CDP4EngineeringModel.ViewModels
         private readonly BinaryRelationshipRule defaultRule = new BinaryRelationshipRule(Guid.NewGuid(), null, null) { Name = "-", ShortName = "-" };
 
         /// <summary>
+        /// The <see cref="IFilterStringService"/> that exposes whether deprecated things are shown.
+        /// </summary>
+        private IFilterStringService filterStringService;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="UserRuleVerificationDialogViewModel"/> class.
         /// </summary>
         /// <remarks>
@@ -158,7 +163,12 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleRule();
 
-            var showDeprecatedThings = ServiceLocator.Current.GetInstance<IFilterStringService>().ShowDeprecatedThings;
+            if (this.filterStringService == null)
+            {
+                this.filterStringService = ServiceLocator.Current.GetInstance<IFilterStringService>();
+            }
+
+            var showDeprecatedThings = this.filterStringService.ShowDeprecatedThings;
 
             var rules = this.GetPossibleRule();
 

--- a/EngineeringModel/ViewModels/Dialogs/UserRuleVerificationDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/UserRuleVerificationDialogViewModel.cs
@@ -41,6 +41,9 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
+    using CDP4Composition.Services;
+
+    using CommonServiceLocator;
 
     using ReactiveUI;
 
@@ -155,9 +158,17 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleRule();
 
+            var showDeprecatedThings = ServiceLocator.Current.GetInstance<IFilterStringService>().ShowDeprecatedThings;
+
             var rules = this.GetPossibleRule();
+
             foreach (var rule in rules)
             {
+                if (!showDeprecatedThings && rule.IsDeprecated && !Equals(rule, this.SelectedRule))
+                {
+                    continue;
+                }
+
                 this.PossibleRule.Add(rule);
             }
         }

--- a/EngineeringModel/Views/Dialogs/UserRuleVerificationDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/UserRuleVerificationDialog.xaml
@@ -12,6 +12,13 @@
              d:DesignWidth="300"
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"
              mc:Ignorable="d">
+    <dx:DXWindow.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/CDP4Styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </dx:DXWindow.Resources>
     <lc:LayoutControl Margin="5"
                       Orientation="Vertical"
                       ScrollBars="None">
@@ -34,6 +41,7 @@
                                                               UpdateSourceTrigger=PropertyChanged}"
                                           IsReadOnly="{Binding IsReadOnly}"
                                           IsTextEditable="False"
+                                          ItemContainerStyle="{StaticResource ComboBoxEditItemStyleDeprecated}"
                                           ItemsSource="{Binding Path=PossibleRule}"
                                           ShowCustomItems="False" />
                         <Button Grid.Column="1"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

fixes #443 

**UserRuleVerificationDialogViewModel**: PopulatePossibleRule now reads the global IFilterStringService.ShowDeprecatedThings. When it's off, deprecated rules are skipped — except the rule currently assigned to the verification (SelectedRule, which the autogen base sets to Thing.Rule before populate), so the dropdown still shows/keeps an already-assigned deprecated rule. When on, all rules are shown.

**UserRuleVerificationDialog.xaml**: merged CDP4Styles.xaml and applied ItemContainerStyle="{StaticResource ComboBoxEditItemStyleDeprecated}" to the Rule combo, so deprecated rules render greyed (LightGray, Opacity 0.5) — same shared style used by the Category pickers.
