### PR TITLE
Fix 1071: Deprecated categories not always shown and no longer selectable

### DIFF
--- a/CDP4Composition.Tests/CommonView/ViewModels/ReferenceSourceDialogViewModelTestFixture.cs
+++ b/CDP4Composition.Tests/CommonView/ViewModels/ReferenceSourceDialogViewModelTestFixture.cs
@@ -177,6 +177,29 @@ namespace CDP4CommonView.Tests
         }
 
         [Test]
+        public void VerifyThatPossibleCategoriesGetPopulated()
+        {
+            var siteRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), null, null) { ShortName = "GenericRDL" };
+
+            var applicableCategory = new Category(Guid.NewGuid(), null, null) { ShortName = "REFSRC", Name = "ReferenceSource category" };
+            applicableCategory.PermissibleClass.Add(ClassKind.ReferenceSource);
+
+            var nonApplicableCategory = new Category(Guid.NewGuid(), null, null) { ShortName = "OTHER", Name = "Other category" };
+            nonApplicableCategory.PermissibleClass.Add(ClassKind.ElementDefinition);
+
+            siteRdl.DefinedCategory.Add(applicableCategory);
+            siteRdl.DefinedCategory.Add(nonApplicableCategory);
+
+            var openRdls = new List<ReferenceDataLibrary> { siteRdl };
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(openRdls);
+
+            this.viewmodel = new ReferenceSourceDialogViewModel(this.referenceSource, this.transaction, this.session.Object, true, ThingDialogKind.Create, null, null, null);
+
+            Assert.AreEqual(1, this.viewmodel.PossibleCategory.Count);
+            Assert.AreEqual(applicableCategory.ShortName, this.viewmodel.PossibleCategory.Single().ShortName);
+        }
+
+        [Test]
         public void VerifyThatTheLanguageCodesArePopulated()
         {
             var siteRdl = new SiteReferenceDataLibrary() { ShortName = "GenericRDL" };

--- a/CDP4Composition.Tests/Converters/CategoryVisibilityConverterTestFixture.cs
+++ b/CDP4Composition.Tests/Converters/CategoryVisibilityConverterTestFixture.cs
@@ -1,0 +1,129 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategoryVisibilityConverterTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Tests.Converters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Converters;
+    using CDP4Composition.Services;
+
+    using CommonServiceLocator;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="CategoryVisibilityConverter"/> (GitHub issue #1071).
+    /// </summary>
+    [TestFixture]
+    public class CategoryVisibilityConverterTestFixture
+    {
+        private CategoryVisibilityConverter converter;
+
+        private Mock<IServiceLocator> serviceLocator;
+
+        private Mock<IFilterStringService> filterStringService;
+
+        private Category nonDeprecatedCategory;
+
+        private Category deprecatedCategory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.converter = new CategoryVisibilityConverter();
+
+            this.filterStringService = new Mock<IFilterStringService>();
+            this.serviceLocator = new Mock<IServiceLocator>();
+            this.serviceLocator.Setup(x => x.GetInstance<IFilterStringService>()).Returns(this.filterStringService.Object);
+            ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
+
+            this.nonDeprecatedCategory = new Category(Guid.NewGuid(), null, null) { ShortName = "ND", Name = "NonDeprecated", IsDeprecated = false };
+            this.deprecatedCategory = new Category(Guid.NewGuid(), null, null) { ShortName = "D1", Name = "Deprecated1", IsDeprecated = true };
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedCategoryIsHiddenWhenShowDeprecatedThingsIsOff()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(false);
+
+            var possible = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory };
+            var selected = new List<Category>();
+
+            var result = ((IEnumerable<Category>)this.converter.Convert(new object[] { possible, selected }, null, null, null)).ToList();
+
+            Assert.That(result, Is.EquivalentTo(new[] { this.nonDeprecatedCategory }));
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedCategoryIsShownWhenShowDeprecatedThingsIsOn()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(true);
+
+            var possible = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory };
+            var selected = new List<Category>();
+
+            var result = ((IEnumerable<Category>)this.converter.Convert(new object[] { possible, selected }, null, null, null)).ToList();
+
+            Assert.That(result, Is.EquivalentTo(new[] { this.nonDeprecatedCategory, this.deprecatedCategory }));
+        }
+
+        [Test]
+        public void VerifyThatAssignedDeprecatedCategoryIsShownWhenShowDeprecatedThingsIsOff()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(false);
+
+            var possible = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory };
+            var selected = new List<Category> { this.deprecatedCategory };
+
+            var result = ((IEnumerable<Category>)this.converter.Convert(new object[] { possible, selected }, null, null, null)).ToList();
+
+            Assert.That(result, Is.EquivalentTo(new[] { this.nonDeprecatedCategory, this.deprecatedCategory }));
+        }
+
+        [Test]
+        public void VerifyThatConvertHandlesNullValues()
+        {
+            this.filterStringService.Setup(x => x.ShowDeprecatedThings).Returns(false);
+
+            var result = ((IEnumerable<Category>)this.converter.Convert(new object[] { null, null }, null, null, null)).ToList();
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void VerifyThatConvertBackThrows()
+        {
+            Assert.Throws<NotSupportedException>(() => this.converter.ConvertBack(null, null, null, null));
+        }
+    }
+}

--- a/CDP4Composition.Tests/Mvvm/Behaviours/CategorySelectionFilterTestFixture.cs
+++ b/CDP4Composition.Tests/Mvvm/Behaviours/CategorySelectionFilterTestFixture.cs
@@ -1,0 +1,171 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategorySelectionFilterTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Tests.Mvvm.Behaviours
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Mvvm.Behaviours;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="CategorySelectionFilter"/> class that encodes the deprecation visibility rule
+    /// used when assigning <see cref="Category"/>s to a categorizable thing (GitHub issue #1071).
+    /// </summary>
+    [TestFixture]
+    public class CategorySelectionFilterTestFixture
+    {
+        private Category nonDeprecatedCategory;
+
+        private Category deprecatedCategory;
+
+        private Category anotherDeprecatedCategory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.nonDeprecatedCategory = new Category(Guid.NewGuid(), null, null) { ShortName = "ND", Name = "NonDeprecated", IsDeprecated = false };
+            this.deprecatedCategory = new Category(Guid.NewGuid(), null, null) { ShortName = "D1", Name = "Deprecated1", IsDeprecated = true };
+            this.anotherDeprecatedCategory = new Category(Guid.NewGuid(), null, null) { ShortName = "D2", Name = "Deprecated2", IsDeprecated = true };
+        }
+
+        [Test]
+        public void VerifyThatNonDeprecatedCategoryIsAlwaysVisible()
+        {
+            Assert.That(CategorySelectionFilter.IsVisible(this.nonDeprecatedCategory, false, new List<Category>()), Is.True);
+            Assert.That(CategorySelectionFilter.IsVisible(this.nonDeprecatedCategory, true, new List<Category>()), Is.True);
+        }
+
+        [Test]
+        public void VerifyThatDeprecatedCategoryIsVisibleWhenShowDeprecatedThingsIsOn()
+        {
+            Assert.That(CategorySelectionFilter.IsVisible(this.deprecatedCategory, true, new List<Category>()), Is.True);
+        }
+
+        [Test]
+        public void VerifyThatUnassignedDeprecatedCategoryIsHiddenWhenShowDeprecatedThingsIsOff()
+        {
+            Assert.That(CategorySelectionFilter.IsVisible(this.deprecatedCategory, false, new List<Category>()), Is.False);
+        }
+
+        [Test]
+        public void VerifyThatAssignedDeprecatedCategoryIsVisibleWhenShowDeprecatedThingsIsOff()
+        {
+            var selected = new List<Category> { this.deprecatedCategory };
+
+            Assert.That(CategorySelectionFilter.IsVisible(this.deprecatedCategory, false, selected), Is.True);
+        }
+
+        [Test]
+        public void VerifyThatNullCategoryIsNotVisible()
+        {
+            Assert.That(CategorySelectionFilter.IsVisible(null, true, new List<Category>()), Is.False);
+        }
+
+        [Test]
+        public void VerifyThatNullSelectionIsHandled()
+        {
+            Assert.That(CategorySelectionFilter.IsVisible(this.deprecatedCategory, false, null), Is.False);
+            Assert.That(CategorySelectionFilter.IsVisible(this.nonDeprecatedCategory, false, null), Is.True);
+        }
+
+        [Test]
+        public void VerifyThatSelectAllSelectsAllNonDeprecatedCategories()
+        {
+            var visible = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory };
+            var current = new List<Category>();
+
+            var result = CategorySelectionFilter.GetSelectAllSelection(visible, current);
+
+            Assert.That(result, Is.EquivalentTo(new[] { this.nonDeprecatedCategory }));
+        }
+
+        [Test]
+        public void VerifyThatSelectAllNeverSelectsDeprecatedCategories()
+        {
+            // even when a deprecated category is visible, Select All must not select it
+            var visible = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory, this.anotherDeprecatedCategory };
+            var current = new List<Category>();
+
+            var result = CategorySelectionFilter.GetSelectAllSelection(visible, current);
+
+            Assert.That(result.Any(c => c.IsDeprecated), Is.False);
+            Assert.That(result, Is.EquivalentTo(new[] { this.nonDeprecatedCategory }));
+        }
+
+        [Test]
+        public void VerifyThatSelectAllPreservesAlreadyAssignedDeprecatedCategory()
+        {
+            // an already-assigned deprecated category stays selected through Select All, but is not newly selected
+            var visible = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory };
+            var current = new List<Category> { this.deprecatedCategory };
+
+            var result = CategorySelectionFilter.GetSelectAllSelection(visible, current);
+
+            Assert.That(result, Is.EquivalentTo(new[] { this.nonDeprecatedCategory, this.deprecatedCategory }));
+        }
+
+        [Test]
+        public void VerifyThatDeselectAllKeepsAssignedDeprecatedCategories()
+        {
+            var current = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory };
+
+            var result = CategorySelectionFilter.GetDeselectAllSelection(current);
+
+            Assert.That(result, Is.EquivalentTo(new[] { this.deprecatedCategory }));
+        }
+
+        [Test]
+        public void VerifyThatAreAllSelectableCategoriesSelectedReflectsSelection()
+        {
+            var visible = new List<Category> { this.nonDeprecatedCategory, this.deprecatedCategory };
+
+            Assert.That(CategorySelectionFilter.AreAllSelectableCategoriesSelected(visible, new List<Category>()), Is.False);
+            Assert.That(CategorySelectionFilter.AreAllSelectableCategoriesSelected(visible, new List<Category> { this.nonDeprecatedCategory }), Is.True);
+        }
+
+        [Test]
+        public void VerifyThatAreAllSelectableCategoriesSelectedIsFalseWhenNoneSelectable()
+        {
+            var visible = new List<Category> { this.deprecatedCategory };
+
+            Assert.That(CategorySelectionFilter.AreAllSelectableCategoriesSelected(visible, new List<Category>()), Is.False);
+        }
+
+        [Test]
+        public void VerifyThatSelectAllHelpersHandleNullInput()
+        {
+            Assert.That(CategorySelectionFilter.GetSelectAllSelection(null, null), Is.Empty);
+            Assert.That(CategorySelectionFilter.GetDeselectAllSelection(null), Is.Empty);
+            Assert.That(CategorySelectionFilter.AreAllSelectableCategoriesSelected(null, null), Is.False);
+        }
+    }
+}

--- a/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml
+++ b/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml
@@ -4,7 +4,9 @@
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                   xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
                   xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+                  xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:behaviours="clr-namespace:CDP4Composition.Mvvm.Behaviours"
                   xmlns:converters="clr-namespace:CDP4Composition.Converters"
                   xmlns:themes="http://schemas.devexpress.com/winfx/2008/xaml/editors/themekeys"
                   Header="Category"
@@ -18,8 +20,17 @@
                 <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/CDP4Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <converters:ReactiveCategoryToObjectListConverter x:Key="ReactiveCategoryToObjectListConverter" />
+            <converters:CategoryVisibilityConverter x:Key="CategoryVisibilityConverter" />
+            <converters:NotConverter x:Key="NotConverter" />
         </ResourceDictionary>
     </dxlc:LayoutGroup.Resources>
+    <dxlc:LayoutItem HorizontalAlignment="Left">
+        <CheckBox x:Name="SelectAllCategoriesCheckBox"
+                  Content="Select All"
+                  Margin="10,0,0,0"
+                  VerticalAlignment="Center"
+                  IsEnabled="{Binding IsReadOnly, Converter={StaticResource NotConverter}}" />
+    </dxlc:LayoutItem>
     <dxlc:LayoutItem>
         <dxe:ListBoxEdit Name="CategoriesList"
                          MaxHeight="350"
@@ -31,10 +42,18 @@
                         EditValue="{Binding Category,
                                             Converter={StaticResource ReactiveCategoryToObjectListConverter},
                                             UpdateSourceTrigger=PropertyChanged}"
-                        ItemsSource="{Binding PossibleCategory}"
                         SelectionMode="Multiple">
+            <dxmvvm:Interaction.Behaviors>
+                <behaviours:CategorySelectAllBehavior SelectAllCheckBox="{Binding ElementName=SelectAllCategoriesCheckBox}" />
+            </dxmvvm:Interaction.Behaviors>
+            <dxe:ListBoxEdit.ItemsSource>
+                <MultiBinding Converter="{StaticResource CategoryVisibilityConverter}" Mode="OneTime">
+                    <Binding Path="PossibleCategory" />
+                    <Binding Path="Category" />
+                </MultiBinding>
+            </dxe:ListBoxEdit.ItemsSource>
             <dxe:ListBoxEdit.StyleSettings>
-                <dxe:CheckedListBoxEditStyleSettings ItemContainerStyle="{StaticResource ListBoxEditItemStyleDeprecated}" />
+                <dxe:CheckedListBoxEditStyleSettings ShowSelectAllItem="False" ItemContainerStyle="{StaticResource ListBoxEditItemStyleDeprecatedNotSelectable}" />
             </dxe:ListBoxEdit.StyleSettings>
         </dxe:ListBoxEdit>
     </dxlc:LayoutItem>

--- a/CDP4Composition/CommonView/Resources/CDP4Styles.xaml
+++ b/CDP4Composition/CommonView/Resources/CDP4Styles.xaml
@@ -34,12 +34,41 @@
         </Style.Triggers>
     </Style>
 
+    <!-- Like ListBoxEditItemStyleDeprecated, but a deprecated item can only be deselected, never (re)selected: an
+         unselected deprecated item is disabled. A selected (already assigned) deprecated item stays enabled so it can
+         still be unchecked. This also prevents Select-All from checking deprecated items. -->
+    <Style BasedOn="{StaticResource ListBoxEditItemStyleDeprecated}" TargetType="{x:Type dxe:ListBoxEditItem}" x:Key="ListBoxEditItemStyleDeprecatedNotSelectable">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsDeprecated}" Value="True" />
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="IsEnabled" Value="False" />
+            </MultiDataTrigger>
+        </Style.Triggers>
+    </Style>
+
     <Style BasedOn="{StaticResource {themes:EditorListBoxThemeKey ResourceKey=CheckBoxItemStyle}}" TargetType="{x:Type dxe:ComboBoxEditItem}" x:Key="ComboBoxEditItemStyleDeprecated">
         <Style.Triggers>
             <DataTrigger Binding="{Binding IsDeprecated}" Value="True">
                 <Setter Property="Background" Value="LightGray"/>
                 <Setter Property="Opacity" Value="0.5"/>
             </DataTrigger>
+        </Style.Triggers>
+    </Style>
+
+    <!-- Like ComboBoxEditItemStyleDeprecated, but a deprecated item can only be deselected, never (re)selected: an
+         unselected deprecated item is disabled. Used by the checked-combobox category pickers. -->
+    <Style BasedOn="{StaticResource ComboBoxEditItemStyleDeprecated}" TargetType="{x:Type dxe:ComboBoxEditItem}" x:Key="ComboBoxEditItemStyleDeprecatedNotSelectable">
+        <Style.Triggers>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding IsDeprecated}" Value="True" />
+                    <Condition Binding="{Binding IsSelected, RelativeSource={RelativeSource Self}}" Value="False" />
+                </MultiDataTrigger.Conditions>
+                <Setter Property="IsEnabled" Value="False" />
+            </MultiDataTrigger>
         </Style.Triggers>
     </Style>
 

--- a/CDP4Composition/CommonView/ViewModels/ReferenceSourceDialogViewModel.cs
+++ b/CDP4Composition/CommonView/ViewModels/ReferenceSourceDialogViewModel.cs
@@ -100,7 +100,11 @@ namespace CDP4CommonView.ViewModels
         public ReferenceSourceDialogViewModel(ReferenceSource referenceSource, IThingTransaction transaction, ISession session, bool isRoot, ThingDialogKind dialogKind, IThingDialogNavigationService thingDialogNavigationService, Thing container = null, IEnumerable<Thing> chainOfContainers = null)
             : base(referenceSource, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
         {
-            this.WhenAnyValue(vm => vm.Container).Subscribe(_ => this.PopulatePossiblePublishedIn());            
+            this.WhenAnyValue(vm => vm.Container).Subscribe(_ =>
+            {
+                this.PopulatePossiblePublishedIn();
+                this.PopulatePossibleCategories();
+            });
         }
 
         /// <summary>
@@ -185,6 +189,29 @@ namespace CDP4CommonView.ViewModels
 
                 this.PossiblePublishedIn.AddRange(allPossibleReferenceSources);
             }
+        }
+
+        /// <summary>
+        /// Populates the <see cref="CDP4CommonView.ReferenceSourceDialogViewModel.PossibleCategory"/> property with the
+        /// <see cref="Category"/>s of the container <see cref="ReferenceDataLibrary"/> (and its required libraries) that
+        /// are applicable to a <see cref="ReferenceSource"/>.
+        /// </summary>
+        private void PopulatePossibleCategories()
+        {
+            this.PossibleCategory.Clear();
+
+            var containerRdl = this.Container as ReferenceDataLibrary;
+
+            if (containerRdl == null)
+            {
+                return;
+            }
+
+            var allowedCategories = new List<Category>(containerRdl.DefinedCategory.Where(c => c.PermissibleClass.Contains(this.Thing.ClassKind)));
+            allowedCategories.AddRange(containerRdl.GetRequiredRdls().SelectMany(rdl => rdl.DefinedCategory)
+                .Where(c => c.PermissibleClass.Contains(this.Thing.ClassKind)));
+
+            this.PossibleCategory.AddRange(allowedCategories.OrderBy(c => c.ShortName));
         }
     }
 }

--- a/CDP4Composition/Converters/CategoryVisibilityConverter.cs
+++ b/CDP4Composition/Converters/CategoryVisibilityConverter.cs
@@ -1,0 +1,115 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategoryVisibilityConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Converters
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Windows.Data;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Mvvm.Behaviours;
+    using CDP4Composition.Services;
+
+    using CommonServiceLocator;
+
+    /// <summary>
+    /// A <see cref="IMultiValueConverter"/> that filters the possible <see cref="Category"/>s shown when assigning
+    /// <see cref="Category"/>s to a <see cref="CDP4Common.CommonData.ICategorizableThing"/>. Deprecated
+    /// <see cref="Category"/>s are only shown when deprecated things are globally visible
+    /// (<see cref="IFilterStringService.ShowDeprecatedThings"/>) or when they are already assigned to the thing.
+    /// </summary>
+    public class CategoryVisibilityConverter : IMultiValueConverter
+    {
+        /// <summary>
+        /// Filters the possible <see cref="Category"/>s based on the deprecation rules.
+        /// </summary>
+        /// <param name="values">
+        /// The bound values: the possible <see cref="Category"/>s (index 0) and the selected <see cref="Category"/>s (index 1).
+        /// </param>
+        /// <param name="targetType">The target type.</param>
+        /// <param name="parameter">The optional parameter.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/>.</param>
+        /// <returns>The <see cref="Category"/>s that should be visible.</returns>
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            var possibleCategories = ToCategoryList(values != null && values.Length > 0 ? values[0] : null);
+            var selectedCategories = ToCategoryList(values != null && values.Length > 1 ? values[1] : null);
+
+            var showDeprecatedThings = GetShowDeprecatedThings();
+
+            return possibleCategories
+                .Where(category => CategorySelectionFilter.IsVisible(category, showDeprecatedThings, selectedCategories))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Not supported. The filtered list is read-only; the selection is handled by the editor's edit value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="targetTypes">The target types.</param>
+        /// <param name="parameter">The optional parameter.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/>.</param>
+        /// <returns>Nothing; this method always throws.</returns>
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException($"{nameof(CategoryVisibilityConverter)} only supports one-way conversion.");
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether deprecated things are globally visible.
+        /// </summary>
+        /// <returns>True if deprecated things are shown; otherwise false (also the default when no service is available).</returns>
+        private static bool GetShowDeprecatedThings()
+        {
+            if (!ServiceLocator.IsLocationProviderSet)
+            {
+                return false;
+            }
+
+            return ServiceLocator.Current.GetInstance<IFilterStringService>().ShowDeprecatedThings;
+        }
+
+        /// <summary>
+        /// Converts a bound value into a list of <see cref="Category"/>.
+        /// </summary>
+        /// <param name="value">The bound value.</param>
+        /// <returns>The <see cref="Category"/>s contained in <paramref name="value"/>.</returns>
+        private static IReadOnlyList<Category> ToCategoryList(object value)
+        {
+            if (value is IEnumerable enumerable && !(value is string))
+            {
+                return enumerable.OfType<Category>().ToList();
+            }
+
+            return new List<Category>();
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/Behaviours/CategoryComboBoxVisibilityBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategoryComboBoxVisibilityBehavior.cs
@@ -1,0 +1,185 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategoryComboBoxVisibilityBehavior.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm.Behaviours
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
+    using System.Windows;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Services;
+
+    using CommonServiceLocator;
+
+    using DevExpress.Mvvm.UI.Interactivity;
+    using DevExpress.Xpf.Editors;
+
+    /// <summary>
+    /// A <see cref="Behavior{T}"/> that applies the deprecation visibility rules to a category <see cref="ComboBoxEdit"/>
+    /// (e.g. the checked-combobox in the relationship creator). Deprecated <see cref="Category"/>s are only shown when
+    /// deprecated things are globally visible (<see cref="IFilterStringService.ShowDeprecatedThings"/>) or when they are
+    /// already selected. Unlike a one-time converter, the filter is re-applied every time the drop-down opens, so it
+    /// always reflects the current global setting even in a long-lived browser panel.
+    /// </summary>
+    public class CategoryComboBoxVisibilityBehavior : Behavior<ComboBoxEdit>
+    {
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> for the <see cref="PossibleCategories"/>.
+        /// </summary>
+        public static readonly DependencyProperty PossibleCategoriesProperty =
+            DependencyProperty.Register(
+                nameof(PossibleCategories),
+                typeof(IEnumerable),
+                typeof(CategoryComboBoxVisibilityBehavior),
+                new PropertyMetadata(null, OnPossibleCategoriesChanged));
+
+        /// <summary>
+        /// The <see cref="DependencyPropertyDescriptor"/> used to observe the drop-down open state.
+        /// </summary>
+        private DependencyPropertyDescriptor popupOpenDescriptor;
+
+        /// <summary>
+        /// Gets or sets the full set of possible <see cref="Category"/>s (before the deprecation filter is applied).
+        /// </summary>
+        public IEnumerable PossibleCategories
+        {
+            get => (IEnumerable)this.GetValue(PossibleCategoriesProperty);
+            set => this.SetValue(PossibleCategoriesProperty, value);
+        }
+
+        /// <summary>
+        /// Executes when this behavior is attached to its <see cref="ComboBoxEdit"/>.
+        /// </summary>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            this.AssociatedObject.Loaded += this.OnLoaded;
+
+            this.popupOpenDescriptor = DependencyPropertyDescriptor.FromProperty(PopupBaseEdit.IsPopupOpenProperty, typeof(ComboBoxEdit));
+            this.popupOpenDescriptor?.AddValueChanged(this.AssociatedObject, this.OnPopupOpenChanged);
+
+            this.ApplyFilter();
+        }
+
+        /// <summary>
+        /// Executes when this behavior is detached from its <see cref="ComboBoxEdit"/>.
+        /// </summary>
+        protected override void OnDetaching()
+        {
+            this.AssociatedObject.Loaded -= this.OnLoaded;
+            this.popupOpenDescriptor?.RemoveValueChanged(this.AssociatedObject, this.OnPopupOpenChanged);
+
+            base.OnDetaching();
+        }
+
+        /// <summary>
+        /// Re-applies the filter when the bound <see cref="PossibleCategories"/> change.
+        /// </summary>
+        /// <param name="d">The <see cref="DependencyObject"/>.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/>.</param>
+        private static void OnPossibleCategoriesChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            (d as CategoryComboBoxVisibilityBehavior)?.ApplyFilter();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether deprecated things are globally visible.
+        /// </summary>
+        /// <returns>True if deprecated things are shown; otherwise false (also the default when no service is available).</returns>
+        private static bool GetShowDeprecatedThings()
+        {
+            if (!ServiceLocator.IsLocationProviderSet)
+            {
+                return false;
+            }
+
+            return ServiceLocator.Current.GetInstance<IFilterStringService>().ShowDeprecatedThings;
+        }
+
+        /// <summary>
+        /// Converts a value into a list of <see cref="Category"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The <see cref="Category"/>s contained in <paramref name="value"/>.</returns>
+        private static IReadOnlyList<Category> ToCategoryList(object value)
+        {
+            if (value is IEnumerable enumerable && !(value is string))
+            {
+                return enumerable.OfType<Category>().ToList();
+            }
+
+            return new List<Category>();
+        }
+
+        /// <summary>
+        /// Handles the <see cref="FrameworkElement.Loaded"/> event.
+        /// </summary>
+        /// <param name="sender">The <see cref="ComboBoxEdit"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            this.ApplyFilter();
+        }
+
+        /// <summary>
+        /// Handles the change of the drop-down open state, re-applying the filter when it opens.
+        /// </summary>
+        /// <param name="sender">The <see cref="ComboBoxEdit"/>.</param>
+        /// <param name="e">The <see cref="EventArgs"/>.</param>
+        private void OnPopupOpenChanged(object sender, EventArgs e)
+        {
+            if (this.AssociatedObject != null && this.AssociatedObject.IsPopupOpen)
+            {
+                this.ApplyFilter();
+            }
+        }
+
+        /// <summary>
+        /// Sets the editor's items source to the visible <see cref="Category"/>s based on the deprecation rules.
+        /// </summary>
+        private void ApplyFilter()
+        {
+            if (this.AssociatedObject == null || this.PossibleCategories == null)
+            {
+                return;
+            }
+
+            var possibleCategories = this.PossibleCategories.OfType<Category>().ToList();
+            var selectedCategories = ToCategoryList(this.AssociatedObject.EditValue);
+            var showDeprecatedThings = GetShowDeprecatedThings();
+
+            this.AssociatedObject.ItemsSource = possibleCategories
+                .Where(category => CategorySelectionFilter.IsVisible(category, showDeprecatedThings, selectedCategories))
+                .ToList();
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectAllBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectAllBehavior.cs
@@ -1,0 +1,216 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategorySelectAllBehavior.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm.Behaviours
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Windows;
+    using System.Windows.Controls;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using DevExpress.Mvvm.UI.Interactivity;
+    using DevExpress.Xpf.Editors;
+
+    /// <summary>
+    /// A <see cref="Behavior{T}"/> that drives a custom "Select All" <see cref="CheckBox"/> for the category
+    /// <see cref="ListBoxEdit"/>. It replaces the built-in Select-All item (which would also check deprecated
+    /// <see cref="Category"/>s): checking the box selects every visible non-deprecated <see cref="Category"/> while
+    /// preserving the already-assigned deprecated ones; unchecking it deselects the non-deprecated ones while keeping
+    /// the assigned deprecated ones. The box also reflects whether all selectable categories are selected.
+    /// </summary>
+    public class CategorySelectAllBehavior : Behavior<ListBoxEdit>
+    {
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> for the <see cref="SelectAllCheckBox"/>.
+        /// </summary>
+        public static readonly DependencyProperty SelectAllCheckBoxProperty =
+            DependencyProperty.Register(
+                nameof(SelectAllCheckBox),
+                typeof(CheckBox),
+                typeof(CategorySelectAllBehavior),
+                new PropertyMetadata(null));
+
+        /// <summary>
+        /// A value indicating whether the <see cref="CheckBox"/> events have been hooked.
+        /// </summary>
+        private bool isHooked;
+
+        /// <summary>
+        /// A value indicating whether the <see cref="CheckBox"/> state is being updated programmatically, used to guard
+        /// against re-entrancy.
+        /// </summary>
+        private bool isUpdatingCheckBox;
+
+        /// <summary>
+        /// Gets or sets the "Select All" <see cref="CheckBox"/> that this behavior drives.
+        /// </summary>
+        public CheckBox SelectAllCheckBox
+        {
+            get => (CheckBox)this.GetValue(SelectAllCheckBoxProperty);
+            set => this.SetValue(SelectAllCheckBoxProperty, value);
+        }
+
+        /// <summary>
+        /// Executes when this behavior is attached to its <see cref="ListBoxEdit"/>.
+        /// </summary>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            this.AssociatedObject.Loaded += this.OnLoaded;
+            this.AssociatedObject.EditValueChanged += this.OnEditValueChanged;
+        }
+
+        /// <summary>
+        /// Executes when this behavior is detached from its <see cref="ListBoxEdit"/>.
+        /// </summary>
+        protected override void OnDetaching()
+        {
+            this.AssociatedObject.Loaded -= this.OnLoaded;
+            this.AssociatedObject.EditValueChanged -= this.OnEditValueChanged;
+
+            if (this.SelectAllCheckBox != null && this.isHooked)
+            {
+                this.SelectAllCheckBox.Checked -= this.OnSelectAllChecked;
+                this.SelectAllCheckBox.Unchecked -= this.OnSelectAllUnchecked;
+                this.isHooked = false;
+            }
+
+            base.OnDetaching();
+        }
+
+        /// <summary>
+        /// Handles the <see cref="FrameworkElement.Loaded"/> event to hook the <see cref="CheckBox"/> (its binding is
+        /// resolved by now) and to initialize its state.
+        /// </summary>
+        /// <param name="sender">The <see cref="ListBoxEdit"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            if (this.SelectAllCheckBox != null && !this.isHooked)
+            {
+                this.SelectAllCheckBox.Checked += this.OnSelectAllChecked;
+                this.SelectAllCheckBox.Unchecked += this.OnSelectAllUnchecked;
+                this.isHooked = true;
+            }
+
+            this.UpdateCheckBoxState();
+        }
+
+        /// <summary>
+        /// Handles the <see cref="BaseEdit.EditValueChanged"/> event to keep the <see cref="CheckBox"/> state in sync.
+        /// </summary>
+        /// <param name="sender">The <see cref="ListBoxEdit"/>.</param>
+        /// <param name="e">The <see cref="EditValueChangedEventArgs"/>.</param>
+        private void OnEditValueChanged(object sender, EditValueChangedEventArgs e)
+        {
+            this.UpdateCheckBoxState();
+        }
+
+        /// <summary>
+        /// Handles the checking of the "Select All" <see cref="CheckBox"/>.
+        /// </summary>
+        /// <param name="sender">The <see cref="CheckBox"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnSelectAllChecked(object sender, RoutedEventArgs e)
+        {
+            if (this.isUpdatingCheckBox)
+            {
+                return;
+            }
+
+            var result = CategorySelectionFilter.GetSelectAllSelection(this.GetVisibleCategories(), ToCategoryList(this.AssociatedObject.EditValue));
+            this.AssociatedObject.EditValue = result.Cast<object>().ToList();
+        }
+
+        /// <summary>
+        /// Handles the unchecking of the "Select All" <see cref="CheckBox"/>.
+        /// </summary>
+        /// <param name="sender">The <see cref="CheckBox"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnSelectAllUnchecked(object sender, RoutedEventArgs e)
+        {
+            if (this.isUpdatingCheckBox)
+            {
+                return;
+            }
+
+            var result = CategorySelectionFilter.GetDeselectAllSelection(ToCategoryList(this.AssociatedObject.EditValue));
+            this.AssociatedObject.EditValue = result.Cast<object>().ToList();
+        }
+
+        /// <summary>
+        /// Updates the checked state of the <see cref="CheckBox"/> to reflect whether all selectable categories are selected.
+        /// </summary>
+        private void UpdateCheckBoxState()
+        {
+            if (this.SelectAllCheckBox == null)
+            {
+                return;
+            }
+
+            var allSelected = CategorySelectionFilter.AreAllSelectableCategoriesSelected(this.GetVisibleCategories(), ToCategoryList(this.AssociatedObject.EditValue));
+
+            this.isUpdatingCheckBox = true;
+
+            try
+            {
+                this.SelectAllCheckBox.IsChecked = allSelected;
+            }
+            finally
+            {
+                this.isUpdatingCheckBox = false;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/>s that are currently visible in the picker (its items source).
+        /// </summary>
+        /// <returns>The visible <see cref="Category"/>s.</returns>
+        private IReadOnlyList<Category> GetVisibleCategories()
+        {
+            return ToCategoryList(this.AssociatedObject.ItemsSource);
+        }
+
+        /// <summary>
+        /// Converts a value into a list of <see cref="Category"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The <see cref="Category"/>s contained in <paramref name="value"/>.</returns>
+        private static IReadOnlyList<Category> ToCategoryList(object value)
+        {
+            if (value is IEnumerable enumerable && !(value is string))
+            {
+                return enumerable.OfType<Category>().ToList();
+            }
+
+            return new List<Category>();
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectionFilter.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectionFilter.cs
@@ -1,0 +1,114 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategorySelectionFilter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm.Behaviours
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Provides the deprecation-aware selection and visibility rules that are shared by every place where
+    /// <see cref="Category"/>s can be assigned to a <see cref="CDP4Common.CommonData.ICategorizableThing"/>.
+    /// </summary>
+    /// <remarks>
+    /// The logic is kept free of any UI dependency so that it can be unit tested and reused by the
+    /// <see cref="CDP4Composition.Converters.CategoryVisibilityConverter"/>. When deprecated things are hidden globally,
+    /// only non-deprecated and already-selected (assigned) deprecated <see cref="Category"/>s are visible. A deprecated
+    /// <see cref="Category"/> being unselectable (but deselectable) is enforced in the shared item style, not here.
+    /// </remarks>
+    public static class CategorySelectionFilter
+    {
+        /// <summary>
+        /// Determines whether the <paramref name="category"/> should be visible in a category picker.
+        /// </summary>
+        /// <param name="category">The <see cref="Category"/> to evaluate.</param>
+        /// <param name="showDeprecatedThings">
+        /// A value indicating whether deprecated <see cref="CDP4Common.CommonData.IDeprecatableThing"/>s are shown globally.
+        /// </param>
+        /// <param name="selectedCategories">The <see cref="Category"/>s that are currently selected (assigned).</param>
+        /// <returns>True if the <paramref name="category"/> should be shown; otherwise false.</returns>
+        public static bool IsVisible(Category category, bool showDeprecatedThings, IReadOnlyCollection<Category> selectedCategories)
+        {
+            if (category == null)
+            {
+                return false;
+            }
+
+            if (showDeprecatedThings || !category.IsDeprecated)
+            {
+                return true;
+            }
+
+            return selectedCategories != null && selectedCategories.Contains(category);
+        }
+
+        /// <summary>
+        /// Computes the selection after a "Select All": every non-deprecated <see cref="Category"/> that is visible is
+        /// added, while the current selection (including any already-assigned deprecated <see cref="Category"/>) is
+        /// preserved. Deprecated <see cref="Category"/>s are never newly selected.
+        /// </summary>
+        /// <param name="visibleCategories">The <see cref="Category"/>s currently visible in the picker.</param>
+        /// <param name="currentSelection">The <see cref="Category"/>s that are currently selected.</param>
+        /// <returns>The resulting selection.</returns>
+        public static IReadOnlyList<Category> GetSelectAllSelection(IEnumerable<Category> visibleCategories, IEnumerable<Category> currentSelection)
+        {
+            var current = currentSelection?.ToList() ?? new List<Category>();
+            var selectable = (visibleCategories ?? Enumerable.Empty<Category>()).Where(category => !category.IsDeprecated);
+
+            return current.Union(selectable).ToList();
+        }
+
+        /// <summary>
+        /// Computes the selection after a "Deselect All": every non-deprecated <see cref="Category"/> is removed, while
+        /// the already-assigned deprecated <see cref="Category"/>s are preserved so they are not silently unassigned.
+        /// </summary>
+        /// <param name="currentSelection">The <see cref="Category"/>s that are currently selected.</param>
+        /// <returns>The resulting selection.</returns>
+        public static IReadOnlyList<Category> GetDeselectAllSelection(IEnumerable<Category> currentSelection)
+        {
+            var current = currentSelection?.ToList() ?? new List<Category>();
+
+            return current.Where(category => category.IsDeprecated).ToList();
+        }
+
+        /// <summary>
+        /// Determines whether every selectable (visible, non-deprecated) <see cref="Category"/> is currently selected,
+        /// used to reflect the state of the "Select All" toggle.
+        /// </summary>
+        /// <param name="visibleCategories">The <see cref="Category"/>s currently visible in the picker.</param>
+        /// <param name="currentSelection">The <see cref="Category"/>s that are currently selected.</param>
+        /// <returns>True if there is at least one selectable category and they are all selected; otherwise false.</returns>
+        public static bool AreAllSelectableCategoriesSelected(IEnumerable<Category> visibleCategories, IEnumerable<Category> currentSelection)
+        {
+            var selectable = (visibleCategories ?? Enumerable.Empty<Category>()).Where(category => !category.IsDeprecated).ToList();
+            var current = new HashSet<Category>(currentSelection ?? Enumerable.Empty<Category>());
+
+            return selectable.Count > 0 && selectable.All(current.Contains);
+        }
+    }
+}

--- a/EngineeringModel/Views/RelationshipBrowser/RelationshipBrowser.xaml
+++ b/EngineeringModel/Views/RelationshipBrowser/RelationshipBrowser.xaml
@@ -13,6 +13,7 @@
              xmlns:dynamic="clr-namespace:System.Dynamic;assembly=System.Core"
              xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:behaviours="clr-namespace:CDP4Composition.Mvvm.Behaviours;assembly=CDP4Composition"
              xmlns:views1="clr-namespace:CDP4EngineeringModel.Views"
              xmlns:viewModels="clr-namespace:CDP4EngineeringModel.ViewModels"
              xmlns:items="clr-namespace:CDP4CommonView.Items;assembly=CDP4Composition"
@@ -185,15 +186,18 @@
                         </dxlc:LayoutGroup>
 
                         <dxlc:LayoutItem Label="Categories: ">
-                            <dxe:ComboBoxEdit ItemsSource="{Binding PossibleCategories, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                              DisplayMember="Name"
+                            <dxe:ComboBoxEdit DisplayMember="Name"
                                               SeparatorString=", "
                                               AllowNullInput="True"
                                               ShowNullText="True"
                                               NullText="No Categories"
+                                              ItemContainerStyle="{StaticResource ComboBoxEditItemStyleDeprecatedNotSelectable}"
                                               EditValue="{Binding AppliedCategories, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CategoryListConverter}}">
+                                <dxmvvm:Interaction.Behaviors>
+                                    <behaviours:CategoryComboBoxVisibilityBehavior PossibleCategories="{Binding PossibleCategories}" />
+                                </dxmvvm:Interaction.Behaviors>
                                 <dxe:ComboBoxEdit.StyleSettings>
-                                    <dxe:CheckedComboBoxStyleSettings />
+                                    <dxe:CheckedComboBoxStyleSettings ShowSelectAllItem="False" />
                                 </dxe:ComboBoxEdit.StyleSettings>
                             </dxe:ComboBoxEdit>
                         </dxlc:LayoutItem>
@@ -245,15 +249,18 @@
                             </dxg:GridControl>
                         </dxlc:LayoutItem>
                         <dxlc:LayoutItem Label="Categories: ">
-                            <dxe:ComboBoxEdit ItemsSource="{Binding PossibleCategories, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
-                                              DisplayMember="Name"
+                            <dxe:ComboBoxEdit DisplayMember="Name"
                                               SeparatorString=", "
                                               AllowNullInput="True"
                                               ShowNullText="True"
                                               NullText="No Categories"
+                                              ItemContainerStyle="{StaticResource ComboBoxEditItemStyleDeprecatedNotSelectable}"
                                               EditValue="{Binding AppliedCategories, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource CategoryListConverter}}">
+                                <dxmvvm:Interaction.Behaviors>
+                                    <behaviours:CategoryComboBoxVisibilityBehavior PossibleCategories="{Binding PossibleCategories}" />
+                                </dxmvvm:Interaction.Behaviors>
                                 <dxe:ComboBoxEdit.StyleSettings>
-                                    <dxe:CheckedComboBoxStyleSettings />
+                                    <dxe:CheckedComboBoxStyleSettings ShowSelectAllItem="False" />
                                 </dxe:ComboBoxEdit.StyleSettings>
                             </dxe:ComboBoxEdit>
                         </dxlc:LayoutItem>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
fixes: #1071 
Now categories follows the following rules:

Visibility — when the global Show Deprecated Things toggle is off, only non-deprecated and already-assigned deprecated categories are shown; when on, deprecated categories appear (greyed).
Not selectable, only deselectable — a deprecated category that isn't already assigned can't be ticked; an assigned one can still be unticked.
Select All — selects only non-deprecated categories.

Added a CategoryVisibilityConverter with a CategorySelection filter to filter the list.
Added two new item styles to disable unselected deprecated items to be selected.
Disabled the DevExpress built-in select-all and added a custom Select-All (CategorySelectAllBehavior + checkbox) for the dialogs.
CategoryComboBoxVisibilityBehavior re-filters the relationship dropdown each time it opens.
