### PR TITLE
Fixes:  Added additional sheets and directionality to raltionship exporter and two fixes in configurator #1403, #280, #1248, and #166 

### DIFF
--- a/RelationshipMatrix.Tests/ViewModel/MatrixExcelExporterTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/MatrixExcelExporterTestFixture.cs
@@ -1,0 +1,269 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MatrixExcelExporterTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4RelationshipMatrix.Tests.ViewModel
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4RelationshipMatrix.Helpers;
+    using CDP4RelationshipMatrix.Settings;
+    using CDP4RelationshipMatrix.ViewModels;
+
+    using ClosedXML.Excel;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="MatrixExcelExporter"/> class.
+    /// </summary>
+    [TestFixture]
+    public class MatrixExcelExporterTestFixture : ViewModelTestBase
+    {
+        /// <summary>
+        /// The arrow that denotes a relationship from the row <see cref="Thing"/> to the column <see cref="Thing"/>
+        /// </summary>
+        private const string RowToColumnMarker = "↑";
+
+        /// <summary>
+        /// The arrow that denotes a relationship from the column <see cref="Thing"/> to the row <see cref="Thing"/>
+        /// </summary>
+        private const string ColumnToRowMarker = "←";
+
+        /// <summary>
+        /// The arrow that denotes a bi-directional relationship
+        /// </summary>
+        private const string BiDirectionalMarker = "↔";
+
+        /// <summary>
+        /// The neutral marker that is used for any relationship when directionality is hidden
+        /// </summary>
+        private const string NeutralMarker = "X";
+
+        private RelationshipMatrixViewModel viewModel;
+        private string exportPath;
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+
+            this.viewModel = new RelationshipMatrixViewModel(
+                this.iteration,
+                this.session.Object,
+                this.thingDialogNavigationService.Object,
+                this.panelNavigationService.Object,
+                this.dialogNavigationService.Object,
+                this.pluginService.Object);
+
+            this.viewModel.SourceYConfiguration.SelectedClassKind = ClassKind.ElementDefinition;
+            this.viewModel.SourceXConfiguration.SelectedClassKind = ClassKind.ElementDefinition;
+
+            this.exportPath = Path.Combine(Path.GetTempPath(), $"relationshipmatrix_{Guid.NewGuid():N}.xlsx");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.viewModel.Dispose();
+
+            if (System.IO.File.Exists(this.exportPath))
+            {
+                System.IO.File.Delete(this.exportPath);
+            }
+        }
+
+        [Test]
+        public void VerifyThatExportMaintainsRelationshipDirectionalityWhenDirectionalityIsShown()
+        {
+            var matrix = this.BuildSingleRowMatrix();
+
+            var exporter = new MatrixExcelExporter(
+                this.viewModel.SourceXConfiguration,
+                this.viewModel.SourceYConfiguration,
+                this.viewModel.RelationshipConfiguration,
+                matrix,
+                this.iteration,
+                true);
+
+            Assert.DoesNotThrow(() => exporter.Export(this.exportPath));
+
+            using (var workbook = new XLWorkbook(this.exportPath))
+            {
+                var worksheet = workbook.Worksheet("Matrix");
+
+                Assert.That(worksheet.Cell(2, 2).GetString(), Is.EqualTo(RowToColumnMarker));
+                Assert.That(worksheet.Cell(2, 3).GetString(), Is.EqualTo(ColumnToRowMarker));
+                Assert.That(worksheet.Cell(2, 4).GetString(), Is.EqualTo(BiDirectionalMarker));
+
+                // a cell without a relationship is left blank (not an empty string) so it is not counted in the column totals
+                Assert.That(worksheet.Cell(2, 5).Value.IsBlank, Is.True);
+
+                // the trace count still reflects every cell that holds a relationship, regardless of its direction
+                Assert.That(worksheet.Cell(2, 6).GetValue<int>(), Is.EqualTo(3));
+
+                // the bottom totals row counts only the cells that actually hold a relationship in each column
+                Assert.That(worksheet.Cell(3, 2).GetValue<int>(), Is.EqualTo(1));
+                Assert.That(worksheet.Cell(3, 3).GetValue<int>(), Is.EqualTo(1));
+                Assert.That(worksheet.Cell(3, 4).GetValue<int>(), Is.EqualTo(1));
+                Assert.That(worksheet.Cell(3, 5).GetValue<int>(), Is.EqualTo(0));
+            }
+        }
+
+        [Test]
+        public void VerifyThatExportUsesNeutralMarkerWhenDirectionalityIsHidden()
+        {
+            var matrix = this.BuildSingleRowMatrix();
+
+            var exporter = new MatrixExcelExporter(
+                this.viewModel.SourceXConfiguration,
+                this.viewModel.SourceYConfiguration,
+                this.viewModel.RelationshipConfiguration,
+                matrix,
+                this.iteration,
+                false);
+
+            Assert.DoesNotThrow(() => exporter.Export(this.exportPath));
+
+            using (var workbook = new XLWorkbook(this.exportPath))
+            {
+                var worksheet = workbook.Worksheet("Matrix");
+
+                // every relationship is marked neutrally, irrespective of its direction
+                Assert.That(worksheet.Cell(2, 2).GetString(), Is.EqualTo(NeutralMarker));
+                Assert.That(worksheet.Cell(2, 3).GetString(), Is.EqualTo(NeutralMarker));
+                Assert.That(worksheet.Cell(2, 4).GetString(), Is.EqualTo(NeutralMarker));
+                Assert.That(worksheet.Cell(2, 5).Value.IsBlank, Is.True);
+
+                Assert.That(worksheet.Cell(2, 6).GetValue<int>(), Is.EqualTo(3));
+            }
+        }
+
+        [Test]
+        public void VerifyThatExportWritesRelationshipsListingSheet()
+        {
+            this.rule.ForwardRelationshipName = "traces";
+            this.viewModel.RelationshipConfiguration.SelectedRule = this.rule;
+
+            var matrix = this.BuildSingleRowMatrix();
+
+            var exporter = new MatrixExcelExporter(
+                this.viewModel.SourceXConfiguration,
+                this.viewModel.SourceYConfiguration,
+                this.viewModel.RelationshipConfiguration,
+                matrix,
+                this.iteration,
+                true);
+
+            Assert.DoesNotThrow(() => exporter.Export(this.exportPath));
+
+            using (var workbook = new XLWorkbook(this.exportPath))
+            {
+                var worksheet = workbook.Worksheet("Relationships");
+
+                // header row
+                Assert.That(worksheet.Cell(1, 1).GetString(), Is.EqualTo("Source"));
+                Assert.That(worksheet.Cell(1, 2).GetString(), Is.EqualTo("Relationship"));
+                Assert.That(worksheet.Cell(1, 3).GetString(), Is.EqualTo("Target"));
+                Assert.That(worksheet.Cell(1, 4).GetString(), Is.EqualTo("Categories"));
+                Assert.That(worksheet.Cell(1, 5).GetString(), Is.EqualTo("Owner"));
+
+                var dataRows = worksheet.RowsUsed().Skip(1).ToList();
+
+                // the four distinct relationships shown in the matrix are listed
+                Assert.That(dataRows.Count, Is.EqualTo(4));
+
+                var exportedPairs = dataRows
+                    .Select(row => (Source: row.Cell(1).GetString(), Target: row.Cell(3).GetString()))
+                    .ToList();
+
+                Assert.That(exportedPairs, Does.Contain((this.elementDef11.UserFriendlyName, this.elementDef12.UserFriendlyName)));
+                Assert.That(exportedPairs, Does.Contain((this.elementDef21.UserFriendlyName, this.elementDef11.UserFriendlyName)));
+                Assert.That(exportedPairs, Does.Contain((this.elementDef11.UserFriendlyName, this.elementDef22.UserFriendlyName)));
+                Assert.That(exportedPairs, Does.Contain((this.elementDef22.UserFriendlyName, this.elementDef11.UserFriendlyName)));
+
+                // every listed relationship carries the rule forward name, its categories and its owner
+                foreach (var row in dataRows)
+                {
+                    Assert.That(row.Cell(2).GetString(), Is.EqualTo("traces"));
+                    Assert.That(row.Cell(4).GetString(), Is.EqualTo(this.catRel.Name));
+                    Assert.That(row.Cell(5).GetString(), Is.EqualTo(this.domain.Name));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds a single-row matrix that contains one cell of each <see cref="RelationshipDirectionKind"/>
+        /// </summary>
+        /// <returns>The populated <see cref="MatrixViewModel"/></returns>
+        private MatrixViewModel BuildSingleRowMatrix()
+        {
+            var matrix = this.viewModel.Matrix;
+
+            matrix.Records.Clear();
+            matrix.Columns.Clear();
+
+            matrix.Columns.Add(new ColumnDefinition(MatrixViewModel.CDP4_NAME_HEADER, MatrixViewModel.ROW_NAME_COLUMN, true));
+            matrix.Columns.Add(new ColumnDefinition(this.elementDef12, DisplayKind.ShortName));
+            matrix.Columns.Add(new ColumnDefinition(this.elementDef21, DisplayKind.ShortName));
+            matrix.Columns.Add(new ColumnDefinition(this.elementDef22, DisplayKind.ShortName));
+            matrix.Columns.Add(new ColumnDefinition(this.elementDef31, DisplayKind.ShortName));
+
+            // relationship from the row Thing (ed11) to the column Thing (ed12)
+            var rowToColumn = new BinaryRelationship(Guid.NewGuid(), this.assembler.Cache, this.uri) { Source = this.elementDef11, Target = this.elementDef12, Owner = this.domain };
+            rowToColumn.Category.Add(this.catRel);
+
+            // relationship from the column Thing (ed21) to the row Thing (ed11)
+            var columnToRow = new BinaryRelationship(Guid.NewGuid(), this.assembler.Cache, this.uri) { Source = this.elementDef21, Target = this.elementDef11, Owner = this.domain };
+            columnToRow.Category.Add(this.catRel);
+
+            // bi-directional relationship between the row Thing (ed11) and the column Thing (ed22)
+            var bidirectionalForward = new BinaryRelationship(Guid.NewGuid(), this.assembler.Cache, this.uri) { Source = this.elementDef11, Target = this.elementDef22, Owner = this.domain };
+            bidirectionalForward.Category.Add(this.catRel);
+
+            var bidirectionalReverse = new BinaryRelationship(Guid.NewGuid(), this.assembler.Cache, this.uri) { Source = this.elementDef22, Target = this.elementDef11, Owner = this.domain };
+            bidirectionalReverse.Category.Add(this.catRel);
+
+            var record = new Dictionary<string, MatrixCellViewModel>
+            {
+                { MatrixViewModel.ROW_NAME_COLUMN, new MatrixCellViewModel(this.elementDef11, null, null, this.rule, DisplayKind.ShortName) },
+                { this.elementDef12.ShortName, new MatrixCellViewModel(this.elementDef11, this.elementDef12, new[] { rowToColumn }, this.rule, DisplayKind.ShortName) },
+                { this.elementDef21.ShortName, new MatrixCellViewModel(this.elementDef11, this.elementDef21, new[] { columnToRow }, this.rule, DisplayKind.ShortName) },
+                { this.elementDef22.ShortName, new MatrixCellViewModel(this.elementDef11, this.elementDef22, new[] { bidirectionalForward, bidirectionalReverse }, this.rule, DisplayKind.ShortName) },
+                { this.elementDef31.ShortName, new MatrixCellViewModel(this.elementDef11, this.elementDef31, null, this.rule, DisplayKind.ShortName) }
+            };
+
+            matrix.Records.Add(record);
+
+            return matrix;
+        }
+    }
+}

--- a/RelationshipMatrix.Tests/ViewModel/SourceConfigurationViewModelTestFixture.cs
+++ b/RelationshipMatrix.Tests/ViewModel/SourceConfigurationViewModelTestFixture.cs
@@ -25,9 +25,14 @@
 
 namespace CDP4RelationshipMatrix.Tests.ViewModel
 {
+    using System;
     using System.Collections.Generic;
 
+    using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Dal.Events;
 
     using CDP4RelationshipMatrix.ViewModels;
 
@@ -88,6 +93,95 @@ namespace CDP4RelationshipMatrix.Tests.ViewModel
 
             this.source.SourceYConfiguration.IncludeSubcategories = true;
             Assert.AreEqual(this.categoryStringResult4, this.source.SourceYConfiguration.CategoriesString);
+
+            this.source.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatOnlyCategorizableClassKindsAreAvailableInTheSelectors()
+        {
+            this.settings.PossibleClassKinds.Add(ClassKind.Requirement);
+            this.settings.PossibleClassKinds.Add(ClassKind.Parameter);
+            this.settings.PossibleClassKinds.Add(ClassKind.NestedElement);
+            this.settings.PossibleClassKinds.Add(ClassKind.ParametricConstraint);
+
+            var viewModel = new RelationshipMatrixViewModel(
+                this.iteration,
+                this.session.Object,
+                this.thingDialogNavigationService.Object,
+                this.panelNavigationService.Object,
+                this.dialogNavigationService.Object,
+                this.pluginService.Object);
+
+            var possibleClassKinds = viewModel.SourceXConfiguration.PossibleClassKinds;
+
+            // categorizable types remain available
+            Assert.That(possibleClassKinds, Does.Contain(ClassKind.ElementDefinition));
+            Assert.That(possibleClassKinds, Does.Contain(ClassKind.ElementUsage));
+            Assert.That(possibleClassKinds, Does.Contain(ClassKind.Requirement));
+
+            // non-categorizable types are excluded
+            Assert.That(possibleClassKinds, Does.Not.Contain(ClassKind.Parameter));
+            Assert.That(possibleClassKinds, Does.Not.Contain(ClassKind.NestedElement));
+            Assert.That(possibleClassKinds, Does.Not.Contain(ClassKind.ParametricConstraint));
+
+            viewModel.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatOwnersDefaultToAllWhenClassKindIsSelected()
+        {
+            var configuration = this.source.SourceXConfiguration;
+
+            configuration.SelectedClassKind = ClassKind.ElementDefinition;
+
+            Assert.That(configuration.PossibleOwners, Is.Not.Empty);
+            Assert.That(configuration.SelectedOwners, Is.EquivalentTo(configuration.PossibleOwners));
+
+            this.source.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatAddedActiveDomainIsSelectedWhenAllOwnersAreSelected()
+        {
+            var configuration = this.source.SourceXConfiguration;
+
+            configuration.SelectedClassKind = ClassKind.ElementDefinition;
+
+            var addedDomain = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "domain2", ShortName = "domain2" };
+            this.sitedir.Domain.Add(addedDomain);
+            this.engineeringModelSetup.ActiveDomain.Add(addedDomain);
+            this.assembler.Cache.TryAdd(new CacheKey(addedDomain.Iid, null), new Lazy<Thing>(() => addedDomain));
+
+            this.rev.SetValue(this.engineeringModelSetup, 10);
+            this.messageBus.SendObjectChangeEvent(this.engineeringModelSetup, EventKind.Updated);
+
+            Assert.That(configuration.PossibleOwners, Does.Contain(addedDomain));
+            Assert.That(configuration.SelectedOwners, Does.Contain(addedDomain));
+
+            this.source.Dispose();
+        }
+
+        [Test]
+        public void VerifyThatAddedActiveDomainIsNotSelectedWhenOwnerSelectionIsPartial()
+        {
+            var configuration = this.source.SourceXConfiguration;
+
+            configuration.SelectedClassKind = ClassKind.ElementDefinition;
+
+            // narrow the selection so that not all owners are selected
+            configuration.SelectedOwners = new List<DomainOfExpertise>();
+
+            var addedDomain = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "domain2", ShortName = "domain2" };
+            this.sitedir.Domain.Add(addedDomain);
+            this.engineeringModelSetup.ActiveDomain.Add(addedDomain);
+            this.assembler.Cache.TryAdd(new CacheKey(addedDomain.Iid, null), new Lazy<Thing>(() => addedDomain));
+
+            this.rev.SetValue(this.engineeringModelSetup, 10);
+            this.messageBus.SendObjectChangeEvent(this.engineeringModelSetup, EventKind.Updated);
+
+            Assert.That(configuration.PossibleOwners, Does.Contain(addedDomain));
+            Assert.That(configuration.SelectedOwners, Is.Empty);
 
             this.source.Dispose();
         }

--- a/RelationshipMatrix/Helpers/MatrixExcelExporter.cs
+++ b/RelationshipMatrix/Helpers/MatrixExcelExporter.cs
@@ -45,13 +45,20 @@ namespace CDP4RelationshipMatrix.Helpers
         /// <summary>
         /// Initializes a new instance of the <see cref="MatrixExcelExporter"/> class
         /// </summary>
-        public MatrixExcelExporter(SourceConfigurationViewModel sourceXConfiguration, SourceConfigurationViewModel sourceYConfiguration, RelationshipConfigurationViewModel relationshipConfiguration, MatrixViewModel matrix, Iteration iteration)
+        /// <param name="sourceXConfiguration">The x axis configuration</param>
+        /// <param name="sourceYConfiguration">The y axis configuration</param>
+        /// <param name="relationshipConfiguration">The relationship configuration</param>
+        /// <param name="matrix">The matrix to export</param>
+        /// <param name="iteration">The <see cref="Iteration"/> the matrix belongs to</param>
+        /// <param name="showDirectionality">A value indicating whether the directionality of relationships should be exported</param>
+        public MatrixExcelExporter(SourceConfigurationViewModel sourceXConfiguration, SourceConfigurationViewModel sourceYConfiguration, RelationshipConfigurationViewModel relationshipConfiguration, MatrixViewModel matrix, Iteration iteration, bool showDirectionality)
         {
             this.SourceXConfiguration = sourceXConfiguration ?? throw new ArgumentNullException(nameof(sourceXConfiguration));
             this.SourceYConfiguration = sourceYConfiguration ?? throw new ArgumentNullException(nameof(sourceYConfiguration));
             this.RelationshipConfiguration = relationshipConfiguration ?? throw new ArgumentNullException(nameof(relationshipConfiguration));
             this.Matrix = matrix ?? throw new ArgumentNullException(nameof(matrix));
             this.Iteration = iteration ?? throw new ArgumentNullException(nameof(iteration));
+            this.ShowDirectionality = showDirectionality;
         }
 
         /// <summary>
@@ -80,6 +87,12 @@ namespace CDP4RelationshipMatrix.Helpers
         public Iteration Iteration { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the directionality of relationships is exported.
+        /// When <c>false</c>, a neutral marker is used for every relationship, matching the matrix display when directionality is hidden.
+        /// </summary>
+        public bool ShowDirectionality { get; }
+
+        /// <summary>
         /// Exports the matrix into a excel workbook
         /// </summary>
         /// <param name="path">The path to save the file to.</param>
@@ -93,6 +106,7 @@ namespace CDP4RelationshipMatrix.Helpers
             using (var workbook = new XLWorkbook())
             {
                 this.ConstructMatrixSheet(workbook);
+                this.ConstructRelationshipListSheet(workbook);
                 this.ConstructMetaSheet(workbook);
                 workbook.SaveAs(path);
             }
@@ -155,14 +169,14 @@ namespace CDP4RelationshipMatrix.Helpers
 
                 for (var j = 1; j < this.Matrix.Records[i - 1].Count; j++)
                 {
-                    var trace = relation[j].RelationshipDirection != RelationshipDirectionKind.None;
+                    var relationshipDirection = relation[j].RelationshipDirection;
 
-                    if (trace)
+                    if (relationshipDirection != RelationshipDirectionKind.None)
                     {
                         traceCount++;
+                        
+                        worksheetMatrix.Cell(i + 1, j + 1).Value = this.GetDirectionalityMarker(relationshipDirection);
                     }
-
-                    worksheetMatrix.Cell(i + 1, j + 1).Value = trace ? "X" : string.Empty;
                 }
 
                 worksheetMatrix.Cell(i + 1, this.Matrix.Records[i - 1].Count + 1).Value = traceCount;
@@ -213,6 +227,82 @@ namespace CDP4RelationshipMatrix.Helpers
 
             // set tab color
             worksheetMatrix.SetTabColor(XLColor.DarkSeaGreen);
+        }
+
+        /// <summary>
+        /// Constructs the sheet that lists, in a tabular form, every <see cref="BinaryRelationship"/> shown in the matrix
+        /// together with its attributes (source, relationship name, target, categories and owner).
+        /// </summary>
+        /// <param name="workbook">The workbook</param>
+        private void ConstructRelationshipListSheet(XLWorkbook workbook)
+        {
+            var worksheet = workbook.Worksheets.Add("Relationships");
+
+            worksheet.Cell(1, 1).Value = "Source";
+            worksheet.Cell(1, 2).Value = "Relationship";
+            worksheet.Cell(1, 3).Value = "Target";
+            worksheet.Cell(1, 4).Value = "Categories";
+            worksheet.Cell(1, 5).Value = "Owner";
+
+            worksheet.Row(1).Style.Font.Bold = true;
+            
+            var relationships = this.Matrix.Records
+                .SelectMany(record => record.Values)
+                .SelectMany(cell => cell.Relationships)
+                .GroupBy(relationship => relationship.Iid)
+                .Select(group => group.First())
+                .OrderBy(relationship => relationship.Source?.UserFriendlyName)
+                .ThenBy(relationship => relationship.Target?.UserFriendlyName)
+                .ToList();
+
+            var forwardRelationshipName = this.RelationshipConfiguration.SelectedRule?.ForwardRelationshipName ?? string.Empty;
+
+            for (var i = 0; i < relationships.Count; i++)
+            {
+                var relationship = relationships[i];
+                var row = i + 2;
+
+                worksheet.Cell(row, 1).Value = relationship.Source?.UserFriendlyName ?? string.Empty;
+                worksheet.Cell(row, 2).Value = forwardRelationshipName;
+                worksheet.Cell(row, 3).Value = relationship.Target?.UserFriendlyName ?? string.Empty;
+                worksheet.Cell(row, 4).Value = string.Join(", ", relationship.Category.Select(category => category.Name));
+                worksheet.Cell(row, 5).Value = relationship.Owner?.Name ?? string.Empty;
+            }
+
+            worksheet.Columns().AdjustToContents();
+            worksheet.SetTabColor(XLColor.LightSteelBlue);
+        }
+
+        /// <summary>
+        /// Gets the textual marker that represents the directionality of a relationship for an exported cell
+        /// </summary>
+        /// <param name="relationshipDirection">The <see cref="RelationshipDirectionKind"/> asserted on the cell</param>
+        /// <returns>
+        /// An arrow denoting the direction of the relationship between the row and column <see cref="Thing"/> when
+        /// <see cref="ShowDirectionality"/> is <c>true</c>; a neutral "X" marker when directionality is hidden;
+        /// or an empty string when no relationship exists
+        /// </returns>
+        private string GetDirectionalityMarker(RelationshipDirectionKind relationshipDirection)
+        {
+            if (relationshipDirection == RelationshipDirectionKind.None)
+            {
+                return string.Empty;
+            }
+
+            if (!this.ShowDirectionality)
+            {
+                return "X";
+            }
+
+            switch (relationshipDirection)
+            {
+                case RelationshipDirectionKind.RowThingToColumnThing:
+                    return "↑";
+                case RelationshipDirectionKind.ColumnThingToRowThing:
+                    return "←";
+                default:
+                    return "↔";
+            }
         }
 
         /// <summary>

--- a/RelationshipMatrix/ViewModels/RelationshipMatrixViewModel.cs
+++ b/RelationshipMatrix/ViewModels/RelationshipMatrixViewModel.cs
@@ -996,7 +996,7 @@ namespace CDP4RelationshipMatrix.ViewModels
             try
             {
                 // initiate exporter
-                var exporter = new MatrixExcelExporter(this.SourceXConfiguration, this.SourceYConfiguration, this.RelationshipConfiguration, this.Matrix, this.Thing);
+                var exporter = new MatrixExcelExporter(this.SourceXConfiguration, this.SourceYConfiguration, this.RelationshipConfiguration, this.Matrix, this.Thing, this.ShowDirectionality);
 
                 exporter.Export(path);
             }

--- a/RelationshipMatrix/ViewModels/SourceConfigurationViewModel.cs
+++ b/RelationshipMatrix/ViewModels/SourceConfigurationViewModel.cs
@@ -32,6 +32,7 @@ namespace CDP4RelationshipMatrix.ViewModels
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Mvvm;
@@ -143,8 +144,8 @@ namespace CDP4RelationshipMatrix.ViewModels
                         onLightUpdateAction.Invoke();
                     }
                 };
-
-            this.possibleClassKind.AddRange(this.PluginSetting.PossibleClassKinds.OrderBy(x => x.ToString()));
+            
+            this.possibleClassKind.AddRange(this.PluginSetting.PossibleClassKinds.Where(IsCategorizableClassKind).OrderBy(x => x.ToString()));
             this.possibleDisplayKinds.AddRange(this.PluginSetting.PossibleDisplayKinds.OrderBy(x => x.ToString()));
 
             this.PossibleCategories = new ReactiveList<Category>();
@@ -206,6 +207,18 @@ namespace CDP4RelationshipMatrix.ViewModels
                 });
 
             this.Disposables.Add(categorySubscription);
+
+            var activeDomainSubscription = this.Session.CDPMessageBus
+                .Listen<ObjectChangedEvent>(typeof(EngineeringModelSetup))
+                .Where(objectChange => objectChange.ChangedThing.Cache == this.Session.Assembler.Cache)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ =>
+                {
+                    this.PopulatePossibleOwners();
+                    this.OnLightUpdateAction();
+                });
+
+            this.Disposables.Add(activeDomainSubscription);
         }
 
         /// <summary>
@@ -423,15 +436,34 @@ namespace CDP4RelationshipMatrix.ViewModels
         }
 
         /// <summary>
+        /// Asserts whether instances of the provided <see cref="ClassKind"/> are <see cref="ICategorizableThing"/>,
+        /// and can therefore be selected and filtered by <see cref="Category"/> in the relationship matrix.
+        /// </summary>
+        /// <param name="classKind">The <see cref="ClassKind"/> to check</param>
+        /// <returns>true if instances of the <see cref="ClassKind"/> are categorizable</returns>
+        private static bool IsCategorizableClassKind(ClassKind classKind)
+        {
+            return TypeInitializer.Initialize(classKind) is ICategorizableThing;
+        }
+
+        /// <summary>
         /// Populates the possible <see cref="DomainOfExpertise"/> of the <see cref="PossibleOwners"/> property
         /// </summary>
         private void PopulatePossibleOwners()
         {
+            var allOwnersWereSelected = this.PossibleOwners.Count == 0
+                                        || this.PossibleOwners.All(owner => this.SelectedOwners.Contains(owner));
+
             this.PossibleOwners.Clear();
 
             var engineeringModel = this.Iteration.TopContainer as EngineeringModel;
             var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
             this.PossibleOwners.AddRange(domains);
+
+            if (allOwnersWereSelected)
+            {
+                this.SelectedOwners = new List<DomainOfExpertise>(this.PossibleOwners);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Show directionality in exporter  of RelationshipMatrix and added two sheets.

owner as default all in configuration
only show IcCategorizableThings in dropdown

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes: #1403 , #280 , #1248 , and #166
Show directionality in exporter  of RelationshipMatrix and added two sheets.

owner as default all in configuration
only show IcCategorizableThings in dropdown however issue #166 said also that requirementsgroup and specification need to be out check this 