### PR TITLE
Fixes #973 and #1348 All browser react properly to closing and opening a model or siteRDL and reloading afterwards

### DIFF
--- a/BasicRdl.Tests/ViewModels/CategoryBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/CategoryBrowserViewModelTestFixture.cs
@@ -82,6 +82,7 @@ namespace BasicRdl.Tests.ViewModels
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDir.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
         }
 
         [TearDown]
@@ -108,6 +109,7 @@ namespace BasicRdl.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDir;
+            this.siteDir.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             this.messageBus.SendObjectChangeEvent(cat, EventKind.Added);
@@ -119,12 +121,36 @@ namespace BasicRdl.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatCategoryRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var vm = new CategoryBrowserViewModel(this.session.Object, this.siteDir, null, null, null, null);
+            var iid = Guid.NewGuid();
+
+            var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDir };
+            this.siteDir.SiteReferenceDataLibrary.Add(sRdl);
+
+            var category = new Category(iid, this.assembler.Cache, this.uri) { Name = "cat", ShortName = "cat", Container = sRdl };
+            this.messageBus.SendObjectChangeEvent(category, EventKind.Added);
+
+            var reInstantiatedCategory = new Category(iid, this.assembler.Cache, this.uri) { Name = "cat", ShortName = "cat", Container = sRdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedCategory, EventKind.Added);
+
+            Assert.AreEqual(1, vm.Categories.Count(x => x.Thing.Iid == iid));
+
+            var removedCategory = new Category(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedCategory, EventKind.Removed);
+
+            Assert.IsFalse(vm.Categories.Any(x => x.Thing.Iid == iid));
+        }
+
+        [Test]
         public void VerifyThatUpdatedCategoryEventAreCaught()
         {
             var vm = new CategoryBrowserViewModel(this.session.Object, this.siteDir, null, null, null, null);
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDir;
+            this.siteDir.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -177,6 +203,7 @@ namespace BasicRdl.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDir;
+            this.siteDir.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -190,6 +217,40 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.Categories.All(x => x.ContainerRdl == "test"));
+        }
+
+        [Test]
+        public void VerifyThatAddedCategoryFromClosedReferenceDataLibraryIsIgnored()
+        {
+            // A reload re-reads the SiteDirectory deeply and re-adds Things from closed RDLs to the cache; such an
+            // Added event must be ignored, otherwise data from a closed Iteration/Model RDL reappears on reload.
+            var vm = new CategoryBrowserViewModel(this.session.Object, this.siteDir, null, null, null, null);
+
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDir };
+            var category = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat", ShortName = "cat", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(category, EventKind.Added);
+
+            Assert.IsFalse(vm.Categories.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsCategories()
+        {
+            // Re-opening a previously closed RDL (e.g. when re-opening an Iteration) raises RdlOpened; the browser
+            // must then show that library's Categories again.
+            var vm = new CategoryBrowserViewModel(this.session.Object, this.siteDir, null, null, null, null);
+
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDir };
+            var category = new Category(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat", ShortName = "cat", Container = rdl };
+            rdl.DefinedCategory.Add(category);
+
+            Assert.IsFalse(vm.Categories.Any(x => x.Thing.Iid == category.Iid));
+
+            this.siteDir.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, vm.Categories.Count(x => x.Thing.Iid == category.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/ConstantsBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/ConstantsBrowserViewModelTestFixture.cs
@@ -60,6 +60,7 @@ namespace BasicRDL.Tests.ViewModels
         private Mock<IPermissionService> permissionService;
         private Uri uri;
         private SiteDirectory siteDirectory;
+        private SiteReferenceDataLibrary siteRdl;
         private ConstantsBrowserViewModel browser;
         private List<ReferenceDataLibrary> openRdlList;
         private Person person;
@@ -86,10 +87,15 @@ namespace BasicRDL.Tests.ViewModels
             this.siteDirectory = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "site directory" };
             this.person = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "John", Surname = "Doe" };
 
+            this.siteRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "test RDL", ShortName = "testRDL", Container = this.siteDirectory };
+            this.siteDirectory.SiteReferenceDataLibrary.Add(this.siteRdl);
+
             this.openRdlList = new List<ReferenceDataLibrary>(this.siteDirectory.SiteReferenceDataLibrary);
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDirectory.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
 
             this.browser = new ConstantsBrowserViewModel(this.session.Object, this.siteDirectory, this.dialogNavigation.Object, this.navigation.Object, null, null);
         }
@@ -122,7 +128,8 @@ namespace BasicRDL.Tests.ViewModels
                                {
                                    Name = "constant name",
                                    ShortName = "constantshortname",
-                                   Scale = ratioScale
+                                   Scale = ratioScale,
+                                   Container = this.siteRdl
                                };
 
             this.messageBus.SendObjectChangeEvent(constant, EventKind.Added);
@@ -130,6 +137,27 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(constant, EventKind.Removed);
             Assert.AreEqual(0, this.browser.Constants.Count);
+        }
+
+        [Test]
+        public void VerifyThatConstantRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var iid = Guid.NewGuid();
+
+            var ratioScale = new RatioScale(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs" };
+
+            var constant = new Constant(iid, this.assembler.Cache, this.uri) { Name = "c", ShortName = "c", Scale = ratioScale, Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(constant, EventKind.Added);
+
+            var reInstantiatedConstant = new Constant(iid, this.assembler.Cache, this.uri) { Name = "c", ShortName = "c", Scale = ratioScale, Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedConstant, EventKind.Added);
+
+            Assert.AreEqual(1, this.browser.Constants.Count(x => x.Thing.Iid == iid));
+
+            var removedConstant = new Constant(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedConstant, EventKind.Removed);
+
+            Assert.IsFalse(this.browser.Constants.Any(x => x.Thing.Iid == iid));
         }
 
         [Test]
@@ -147,7 +175,8 @@ namespace BasicRDL.Tests.ViewModels
             {
                 Name = "constant name",
                 ShortName = "constantshortname",
-                Scale = ratioScale
+                Scale = ratioScale,
+                Container = this.siteRdl
             };
 
             this.messageBus.SendObjectChangeEvent(constant, EventKind.Added);
@@ -186,6 +215,7 @@ namespace BasicRDL.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;
+            this.siteDirectory.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new Constant(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new Constant(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -199,6 +229,32 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.Constants.All(x => x.ContainerRdl == "test"));
+        }
+
+        [Test]
+        public void VerifyThatAddedConstantFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var constant = new Constant(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "c", ShortName = "c", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(constant, EventKind.Added);
+
+            Assert.IsFalse(this.browser.Constants.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsConstants()
+        {
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var constant = new Constant(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "c", ShortName = "c", Container = rdl };
+            rdl.Constant.Add(constant);
+
+            Assert.IsFalse(this.browser.Constants.Any(x => x.Thing.Iid == constant.Iid));
+
+            this.siteDirectory.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.browser.Constants.Count(x => x.Thing.Iid == constant.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/FileTypeBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/FileTypeBrowserViewModelTestFixture.cs
@@ -86,7 +86,7 @@ namespace BasicRDL.Tests.ViewModels
             this.srdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
 
             this.siteDirectory.SiteReferenceDataLibrary.Add(this.srdl);
-            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new HashSet<ReferenceDataLibrary>(this.siteDirectory.SiteReferenceDataLibrary));
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDirectory.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
@@ -133,6 +133,25 @@ namespace BasicRDL.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatFileTypeRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var iid = Guid.NewGuid();
+
+            var filetype = new FileType(iid, this.assembler.Cache, this.uri) { Name = "ft", ShortName = "ft", Extension = "txt", Container = this.srdl };
+            this.messageBus.SendObjectChangeEvent(filetype, EventKind.Added);
+
+            var reInstantiatedFileType = new FileType(iid, this.assembler.Cache, this.uri) { Name = "ft", ShortName = "ft", Extension = "txt", Container = this.srdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedFileType, EventKind.Added);
+
+            Assert.AreEqual(1, this.browser.FileTypes.Count(x => x.Thing.Iid == iid));
+
+            var removedFileType = new FileType(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedFileType, EventKind.Removed);
+
+            Assert.IsFalse(this.browser.FileTypes.Any(x => x.Thing.Iid == iid));
+        }
+
+        [Test]
         public void VerifyThatRdlShortnameIsUpdated()
         {
             this.srdl.FileType.Clear();
@@ -140,6 +159,7 @@ namespace BasicRDL.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;
+            this.siteDirectory.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new FileType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new FileType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -153,6 +173,34 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.FileTypes.All(x => x.ContainerRdl == "test"));
+        }
+
+        [Test]
+        public void VerifyThatAddedFileTypeFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var initialCount = this.browser.FileTypes.Count;
+
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var filetype = new FileType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ft", ShortName = "ft", Extension = "txt", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(filetype, EventKind.Added);
+
+            Assert.AreEqual(initialCount, this.browser.FileTypes.Count);
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsFileTypes()
+        {
+           var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var filetype = new FileType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "ft", ShortName = "ft", Extension = "txt", Container = rdl };
+            rdl.FileType.Add(filetype);
+
+            Assert.IsFalse(this.browser.FileTypes.Any(x => x.Thing.Iid == filetype.Iid));
+
+            this.siteDirectory.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.browser.FileTypes.Count(x => x.Thing.Iid == filetype.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/GlossaryBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/GlossaryBrowserViewModelTestFixture.cs
@@ -93,6 +93,8 @@ namespace BasicRDL.Tests.ViewModels
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
 
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDirectory.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
+
             this.glossaryBrowser = new GlossaryBrowserViewModel(this.session.Object, this.siteDirectory, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
         }
 
@@ -147,6 +149,7 @@ namespace BasicRDL.Tests.ViewModels
 
             var rdl = new ModelReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             rdl.Glossary.Add(glossary2);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new ReferenceDataLibrary[] { this.srdl, rdl });
             this.messageBus.SendObjectChangeEvent(glossary2, EventKind.Added);
             Assert.IsTrue(this.glossaryBrowser.Glossaries.Count == 2);
         }
@@ -176,6 +179,21 @@ namespace BasicRDL.Tests.ViewModels
             // Remove a glossary
             this.messageBus.SendObjectChangeEvent(glossary, EventKind.Removed);
             Assert.IsFalse(this.glossaryBrowser.Glossaries.Any());
+        }
+
+        [Test]
+        public void VerifyThatGlossaryRowIsRemovedRegardlessOfInstance()
+        {
+            var iid = Guid.NewGuid();
+
+            var glossary = new Glossary(iid, this.assembler.Cache, this.uri) { Name = "test Glossary", ShortName = "TG", Container = this.srdl };
+            this.messageBus.SendObjectChangeEvent(glossary, EventKind.Added);
+            Assert.AreEqual(1, this.glossaryBrowser.Glossaries.Count(x => x.Thing.Iid == iid));
+
+            var removedGlossary = new Glossary(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedGlossary, EventKind.Removed);
+
+            Assert.IsFalse(this.glossaryBrowser.Glossaries.Any(x => x.Thing.Iid == iid));
         }
 
         [Test]
@@ -280,6 +298,7 @@ namespace BasicRDL.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;
+            this.siteDirectory.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new Glossary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new Glossary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -293,6 +312,32 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.Glossaries.Count(x => x.ContainerRdlShortName == "test") == 2);
+        }
+
+        [Test]
+        public void VerifyThatAddedGlossaryFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var glossary = new Glossary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "g", ShortName = "g", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(glossary, EventKind.Added);
+
+            Assert.IsFalse(this.glossaryBrowser.Glossaries.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsGlossaries()
+        {
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var glossary = new Glossary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "g", ShortName = "g", Container = rdl };
+            rdl.Glossary.Add(glossary);
+
+            Assert.IsFalse(this.glossaryBrowser.Glossaries.Any(x => x.Thing.Iid == glossary.Iid));
+
+            this.siteDirectory.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.glossaryBrowser.Glossaries.Count(x => x.Thing.Iid == glossary.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/MeasurementScalesBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/MeasurementScalesBrowserViewModelTestFixture.cs
@@ -52,6 +52,7 @@ namespace BasicRdl.Tests.ViewModels
         private Mock<IPermissionService> permissionService;
         private Uri uri;
         private SiteDirectory siteDirectory;
+        private SiteReferenceDataLibrary siteRdl;
         private MeasurementScalesBrowserViewModel measurementScalesBrowserViewModel;
         private Person person;
         private Assembler assembler;
@@ -74,10 +75,12 @@ namespace BasicRdl.Tests.ViewModels
 
             this.siteDirectory = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "site directory" };
             this.person = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "John", Surname = "Doe" };
+            this.siteRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "test RDL", ShortName = "testRDL", Container = this.siteDirectory };
+            this.siteDirectory.SiteReferenceDataLibrary.Add(this.siteRdl);
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
-
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDirectory.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
             this.measurementScalesBrowserViewModel = new MeasurementScalesBrowserViewModel(this.session.Object, this.siteDirectory, null, null, null, null);
         }
 
@@ -112,7 +115,8 @@ namespace BasicRdl.Tests.ViewModels
             {
                 Name = "ratio scale",
                 ShortName = "ratioscale",
-                Unit = simpleUnit
+                Unit = simpleUnit,
+                Container = this.siteRdl
             };
 
             this.messageBus.SendObjectChangeEvent(ratioScale, EventKind.Added);
@@ -120,6 +124,27 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(ratioScale, EventKind.Removed);
             Assert.IsFalse(this.measurementScalesBrowserViewModel.MeasurementScales.Any(x => x.Thing == ratioScale));
+        }
+
+        [Test]
+        public void VerifyThatMeasurementScaleRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var iid = Guid.NewGuid();
+
+            var simpleUnit = new SimpleUnit(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "u", ShortName = "u" };
+
+            var scale = new RatioScale(iid, this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Unit = simpleUnit, Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(scale, EventKind.Added);
+
+            var reInstantiatedScale = new RatioScale(iid, this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Unit = simpleUnit, Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedScale, EventKind.Added);
+
+            Assert.AreEqual(1, this.measurementScalesBrowserViewModel.MeasurementScales.Count(x => x.Thing.Iid == iid));
+
+            var removedScale = new RatioScale(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedScale, EventKind.Removed);
+
+            Assert.IsFalse(this.measurementScalesBrowserViewModel.MeasurementScales.Any(x => x.Thing.Iid == iid));
         }
 
         [Test]
@@ -156,6 +181,7 @@ namespace BasicRdl.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;
+            this.siteDirectory.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new CyclicRatioScale(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new CyclicRatioScale(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -169,6 +195,32 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.MeasurementScales.Count(x => x.ContainerRdl == "test") == 2);
+        }
+
+        [Test]
+        public void VerifyThatAddedMeasurementScaleFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var scale = new RatioScale(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(scale, EventKind.Added);
+
+            Assert.IsFalse(this.measurementScalesBrowserViewModel.MeasurementScales.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsMeasurementScales()
+        {
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var scale = new RatioScale(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Container = rdl };
+            rdl.Scale.Add(scale);
+
+            Assert.IsFalse(this.measurementScalesBrowserViewModel.MeasurementScales.Any(x => x.Thing.Iid == scale.Iid));
+
+            this.siteDirectory.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.measurementScalesBrowserViewModel.MeasurementScales.Count(x => x.Thing.Iid == scale.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/MeasurementUnitsBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/MeasurementUnitsBrowserViewModelTestFixture.cs
@@ -53,6 +53,7 @@ namespace BasicRdl.Tests.ViewModels
         private Mock<IPermissionService> permissionService;
         private Mock<IPermissionService> nonpermissivePermissionService;
         private SiteDirectory siteDir;
+        private SiteReferenceDataLibrary siteRdl;
         private Uri uri;
         private MeasurementUnitsBrowserViewModel measurementUnitsViewModel;
         private Person person;
@@ -80,9 +81,14 @@ namespace BasicRdl.Tests.ViewModels
 
             this.siteDir = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "site directory" };
             this.person = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "John", Surname = "Doe" };
+
+            this.siteRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "test RDL", ShortName = "testRDL", Container = this.siteDir };
+            this.siteDir.SiteReferenceDataLibrary.Add(this.siteRdl);
+
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDir.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
 
             this.measurementUnitsViewModel = new MeasurementUnitsBrowserViewModel(this.session.Object, this.siteDir, null, null, null, null);
         }
@@ -114,7 +120,8 @@ namespace BasicRdl.Tests.ViewModels
             var simpleUnit = new SimpleUnit(Guid.NewGuid(), this.assembler.Cache, this.uri)
             {
                 Name = "simple unit name",
-                ShortName = "simpleunitshortname"
+                ShortName = "simpleunitshortname",
+                Container = this.siteRdl
             };
 
             this.messageBus.SendObjectChangeEvent(simpleUnit, EventKind.Added);
@@ -124,6 +131,25 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(simpleUnit, EventKind.Removed);
             Assert.IsFalse(this.measurementUnitsViewModel.MeasurementUnits.Any(x => x.Thing == simpleUnit));
+        }
+
+        [Test]
+        public void VerifyThatMeasurementUnitRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var iid = Guid.NewGuid();
+
+            var simpleUnit = new SimpleUnit(iid, this.assembler.Cache, this.uri) { Name = "u", ShortName = "u", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(simpleUnit, EventKind.Added);
+
+            var reInstantiatedUnit = new SimpleUnit(iid, this.assembler.Cache, this.uri) { Name = "u", ShortName = "u", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedUnit, EventKind.Added);
+
+            Assert.AreEqual(1, this.measurementUnitsViewModel.MeasurementUnits.Count(x => x.Thing.Iid == iid));
+
+            var removedUnit = new SimpleUnit(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedUnit, EventKind.Removed);
+
+            Assert.IsFalse(this.measurementUnitsViewModel.MeasurementUnits.Any(x => x.Thing.Iid == iid));
         }
 
         [Test]
@@ -154,6 +180,7 @@ namespace BasicRdl.Tests.ViewModels
         public void VerifyThatAnyUnitCannotBeCreatedWithNonPermissiveService()
         {
             this.session.Setup(x => x.PermissionService).Returns(this.nonpermissivePermissionService.Object);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new List<ReferenceDataLibrary>());
             var browser = new MeasurementUnitsBrowserViewModel(this.session.Object, this.siteDir, null, null, null, null);
             Assert.IsFalse(browser.CanCreateRdlElement);
 
@@ -170,6 +197,7 @@ namespace BasicRdl.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDir;
+            this.siteDir.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new LinearConversionUnit(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new LinearConversionUnit(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -183,6 +211,32 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.MeasurementUnits.Count(x => x.ContainerRdl == "test") == 2);
+        }
+
+        [Test]
+        public void VerifyThatAddedMeasurementUnitFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDir };
+            var unit = new SimpleUnit(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "u", ShortName = "u", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(unit, EventKind.Added);
+
+            Assert.IsFalse(this.measurementUnitsViewModel.MeasurementUnits.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsMeasurementUnits()
+        {
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDir };
+            var unit = new SimpleUnit(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "u", ShortName = "u", Container = rdl };
+            rdl.Unit.Add(unit);
+
+            Assert.IsFalse(this.measurementUnitsViewModel.MeasurementUnits.Any(x => x.Thing.Iid == unit.Iid));
+
+            this.siteDir.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.measurementUnitsViewModel.MeasurementUnits.Count(x => x.Thing.Iid == unit.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
@@ -64,6 +64,7 @@ namespace BasicRdl.Tests.ViewModels
         private Mock<IServiceLocator> serviceLocator;
         private Uri uri;
         private SiteDirectory siteDirectory;
+        private SiteReferenceDataLibrary siteRdl;
         private ParameterTypesBrowserViewModel ParameterTypesBrowserViewModel;
         private Person person;
         private Assembler assembler;
@@ -102,12 +103,18 @@ namespace BasicRdl.Tests.ViewModels
             this.siteDirectory =
                 new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "site directory" };
 
+            this.siteRdl =
+                new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "test RDL", ShortName = "testRDL" };
+
+            this.siteDirectory.SiteReferenceDataLibrary.Add(this.siteRdl);
+
             this.person =
                 new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "John", Surname = "Doe" };
 
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new ReferenceDataLibrary[] { this.siteRdl });
 
             this.ParameterTypesBrowserViewModel = new ParameterTypesBrowserViewModel(this.session.Object,
                 this.siteDirectory, this.dialogNavigationService.Object, this.panelNavigationService.Object, null, null,
@@ -134,14 +141,14 @@ namespace BasicRdl.Tests.ViewModels
         [Test]
         public void VerifyThatParameterTypeEventsAreCaught()
         {
-            var textParamType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            var textParamType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteRdl };
 
             this.messageBus.SendObjectChangeEvent(textParamType, EventKind.Added);
             Assert.AreEqual(1, this.ParameterTypesBrowserViewModel.ParameterTypes.Count);
             this.messageBus.SendObjectChangeEvent(textParamType, EventKind.Removed);
             Assert.IsFalse(this.ParameterTypesBrowserViewModel.ParameterTypes.Any());
 
-            var booleanParamType = new BooleanParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            var booleanParamType = new BooleanParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteRdl };
             this.messageBus.SendObjectChangeEvent(booleanParamType, EventKind.Added);
             Assert.AreEqual(1, this.ParameterTypesBrowserViewModel.ParameterTypes.Count);
             this.messageBus.SendObjectChangeEvent(booleanParamType, EventKind.Removed);
@@ -150,7 +157,7 @@ namespace BasicRdl.Tests.ViewModels
             var defaultScale = new CyclicRatioScale(Guid.NewGuid(), this.assembler.Cache, this.uri);
 
             var simpleQuantityKind =
-                new SimpleQuantityKind(Guid.NewGuid(), this.assembler.Cache, this.uri) { DefaultScale = defaultScale };
+                new SimpleQuantityKind(Guid.NewGuid(), this.assembler.Cache, this.uri) { DefaultScale = defaultScale, Container = this.siteRdl };
 
             this.messageBus.SendObjectChangeEvent(simpleQuantityKind, EventKind.Added);
             Assert.AreEqual(1, this.ParameterTypesBrowserViewModel.ParameterTypes.Count);
@@ -160,7 +167,8 @@ namespace BasicRdl.Tests.ViewModels
             var specializedQuantityKind =
                 new SpecializedQuantityKind(Guid.NewGuid(), this.assembler.Cache, this.uri)
                 {
-                    DefaultScale = defaultScale
+                    DefaultScale = defaultScale,
+                    Container = this.siteRdl
                 };
 
             this.messageBus.SendObjectChangeEvent(specializedQuantityKind, EventKind.Added);
@@ -169,12 +177,69 @@ namespace BasicRdl.Tests.ViewModels
             Assert.IsFalse(this.ParameterTypesBrowserViewModel.ParameterTypes.Any());
 
             var derivedQuantityKind =
-                new DerivedQuantityKind(Guid.NewGuid(), this.assembler.Cache, this.uri) { DefaultScale = defaultScale };
+                new DerivedQuantityKind(Guid.NewGuid(), this.assembler.Cache, this.uri) { DefaultScale = defaultScale, Container = this.siteRdl };
 
             this.messageBus.SendObjectChangeEvent(derivedQuantityKind, EventKind.Added);
             Assert.AreEqual(1, this.ParameterTypesBrowserViewModel.ParameterTypes.Count);
             this.messageBus.SendObjectChangeEvent(derivedQuantityKind, EventKind.Removed);
             Assert.IsFalse(this.ParameterTypesBrowserViewModel.ParameterTypes.Any());
+        }
+
+        [Test]
+        public void VerifyThatDuplicateAddedEventsDoNotCreateDuplicateRows()
+        {
+            var parameterType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteRdl };
+
+            this.messageBus.SendObjectChangeEvent(parameterType, EventKind.Added);
+            this.messageBus.SendObjectChangeEvent(parameterType, EventKind.Added);
+
+            Assert.AreEqual(1, this.ParameterTypesBrowserViewModel.ParameterTypes.Count);
+        }
+
+        [Test]
+        public void VerifyThatParameterTypeRowIsRemovedRegardlessOfInstance()
+        {
+            var iid = Guid.NewGuid();
+            var addedParameterType = new TextParameterType(iid, this.assembler.Cache, this.uri) { Container = this.siteRdl };
+
+            this.messageBus.SendObjectChangeEvent(addedParameterType, EventKind.Added);
+            Assert.AreEqual(1, this.ParameterTypesBrowserViewModel.ParameterTypes.Count);
+
+            var removedParameterType = new TextParameterType(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedParameterType, EventKind.Removed);
+
+            Assert.IsFalse(this.ParameterTypesBrowserViewModel.ParameterTypes.Any());
+        }
+
+        [Test]
+        public void VerifyThatAddedParameterTypeFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "closed RDL", ShortName = "closedRDL" };
+            this.siteDirectory.SiteReferenceDataLibrary.Add(closedRdl);
+
+            var parameterType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = closedRdl };
+            this.messageBus.SendObjectChangeEvent(parameterType, EventKind.Added);
+
+            Assert.IsFalse(this.ParameterTypesBrowserViewModel.ParameterTypes.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsParameterTypes()
+        {
+            var modelRdl = new ModelReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "model RDL", ShortName = "modelRDL" };
+            var parameterType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = modelRdl };
+            modelRdl.ParameterType.Add(parameterType);
+
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            engineeringModelSetup.RequiredRdl.Add(modelRdl);
+            this.siteDirectory.Model.Add(engineeringModelSetup);
+
+            Assert.IsFalse(this.ParameterTypesBrowserViewModel.ParameterTypes.Any(x => x.Thing.Iid == parameterType.Iid));
+
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new ReferenceDataLibrary[] { this.siteRdl, modelRdl });
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.ParameterTypesBrowserViewModel.ParameterTypes.Count(x => x.Thing.Iid == parameterType.Iid));
         }
 
         [Test]
@@ -220,6 +285,8 @@ namespace BasicRdl.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;
+            this.siteDirectory.SiteReferenceDataLibrary.Add(sRdl);
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(new ReferenceDataLibrary[] { sRdl });
 
             var cat = new BooleanParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri)
             {

--- a/BasicRdl.Tests/ViewModels/ReferenceSourceBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/ReferenceSourceBrowserViewModelTestFixture.cs
@@ -98,6 +98,8 @@ namespace BasicRDL.Tests.ViewModels
             this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
 
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDirectory.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
+
             this.browser = new ReferenceSourceBrowserViewModel(this.session.Object, this.siteDirectory, this.dialogNavigation.Object, this.navigation.Object, null, this.pluginSettingsService.Object);
         }
 
@@ -131,6 +133,25 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(referenceSource, EventKind.Removed);
             Assert.AreEqual(0, this.browser.ReferenceSources.Count);
+        }
+
+        [Test]
+        public void VerifyThatReferenceSourceRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var iid = Guid.NewGuid();
+
+            var referenceSource = new ReferenceSource(iid, this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(referenceSource, EventKind.Added);
+
+            var reInstantiatedReferenceSource = new ReferenceSource(iid, this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedReferenceSource, EventKind.Added);
+
+            Assert.AreEqual(1, this.browser.ReferenceSources.Count(x => x.Thing.Iid == iid));
+
+            var removedReferenceSource = new ReferenceSource(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedReferenceSource, EventKind.Removed);
+
+            Assert.IsFalse(this.browser.ReferenceSources.Any(x => x.Thing.Iid == iid));
         }
 
         [Test]
@@ -189,6 +210,7 @@ namespace BasicRDL.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;
+            this.siteDirectory.SiteReferenceDataLibrary.Add(sRdl);
 
             var rs = new ReferenceSource(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "rs1", ShortName = "1", Container = sRdl };
             var rs2 = new ReferenceSource(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "rs2", ShortName = "2", Container = sRdl };
@@ -202,6 +224,32 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.ReferenceSources.Count(x => x.ContainerRdl == "test") == 2);
+        }
+
+        [Test]
+        public void VerifyThatAddedReferenceSourceFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var referenceSource = new ReferenceSource(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(referenceSource, EventKind.Added);
+
+            Assert.IsFalse(this.browser.ReferenceSources.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsReferenceSources()
+        {
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var referenceSource = new ReferenceSource(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "rs", ShortName = "rs", Container = rdl };
+            rdl.ReferenceSource.Add(referenceSource);
+
+            Assert.IsFalse(this.browser.ReferenceSources.Any(x => x.Thing.Iid == referenceSource.Iid));
+
+            this.siteDirectory.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.browser.ReferenceSources.Count(x => x.Thing.Iid == referenceSource.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/RulesBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/RulesBrowserViewModelTestFixture.cs
@@ -51,6 +51,7 @@ namespace BasicRdl.Tests.ViewModels
         private Mock<ISession> session;
         private Mock<IPermissionService> permissionService;
         private SiteDirectory siteDir;
+        private SiteReferenceDataLibrary siteRdl;
         private Uri uri;
         private Person person;
         private RulesBrowserViewModel RulesViewModel;
@@ -73,12 +74,14 @@ namespace BasicRdl.Tests.ViewModels
             this.siteDir = new SiteDirectory(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "site directory" };
             this.person = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "John", Surname = "Doe" };
 
-            var siteReferenceDataLibrary = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
-            this.siteDir.SiteReferenceDataLibrary.Add(siteReferenceDataLibrary);
+            this.siteRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "test RDL", ShortName = "testRDL", Container = this.siteDir };
+            this.siteDir.SiteReferenceDataLibrary.Add(this.siteRdl);
 
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDir.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
 
             this.RulesViewModel = new RulesBrowserViewModel(this.session.Object, this.siteDir, null, null, null, null);
         }
@@ -110,7 +113,8 @@ namespace BasicRdl.Tests.ViewModels
             var binaryRelationshipRule = new BinaryRelationshipRule(Guid.NewGuid(), this.assembler.Cache, this.uri)
             {
                 Name = "simple rule name",
-                ShortName = "simpleruleshortname"
+                ShortName = "simpleruleshortname",
+                Container = this.siteRdl
             };
 
             this.messageBus.SendObjectChangeEvent(binaryRelationshipRule, EventKind.Added);
@@ -120,6 +124,25 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(binaryRelationshipRule, EventKind.Removed);
             Assert.IsFalse(this.RulesViewModel.Rules.Any(x => x.Thing == binaryRelationshipRule));
+        }
+
+        [Test]
+        public void VerifyThatRuleRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var iid = Guid.NewGuid();
+
+            var rule = new BinaryRelationshipRule(iid, this.assembler.Cache, this.uri) { Name = "r", ShortName = "r", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(rule, EventKind.Added);
+
+            var reInstantiatedRule = new BinaryRelationshipRule(iid, this.assembler.Cache, this.uri) { Name = "r", ShortName = "r", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedRule, EventKind.Added);
+
+            Assert.AreEqual(1, this.RulesViewModel.Rules.Count(x => x.Thing.Iid == iid));
+
+            var removedRule = new BinaryRelationshipRule(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedRule, EventKind.Removed);
+
+            Assert.IsFalse(this.RulesViewModel.Rules.Any(x => x.Thing.Iid == iid));
         }
 
         [Test]
@@ -153,6 +176,7 @@ namespace BasicRdl.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDir;
+            this.siteDir.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new BinaryRelationshipRule(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new BinaryRelationshipRule(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -166,6 +190,32 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.Rules.Count(x => x.ContainerRdl == "test") == 2);
+        }
+
+        [Test]
+        public void VerifyThatAddedRuleFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDir };
+            var rule = new BinaryRelationshipRule(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "r", ShortName = "r", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(rule, EventKind.Added);
+
+            Assert.AreEqual(0, this.RulesViewModel.Rules.Count);
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsRules()
+        {
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDir };
+            var rule = new BinaryRelationshipRule(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "r", ShortName = "r", Container = rdl };
+            rdl.Rule.Add(rule);
+
+            Assert.IsFalse(this.RulesViewModel.Rules.Any(x => x.Thing.Iid == rule.Iid));
+
+            this.siteDir.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.RulesViewModel.Rules.Count(x => x.Thing.Iid == rule.Iid));
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/UnitPrefixBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/UnitPrefixBrowserViewModelTestFixture.cs
@@ -95,6 +95,9 @@ namespace BasicRDL.Tests.ViewModels
             this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
 
+            // every SiteReferenceDataLibrary added to the SiteDirectory is treated as open in these tests
+            this.session.Setup(x => x.OpenReferenceDataLibraries).Returns(() => this.siteDirectory.SiteReferenceDataLibrary.Cast<ReferenceDataLibrary>().ToList());
+
             this.browser = new UnitPrefixBrowserViewModel(this.session.Object, this.siteDirectory, this.dialogNavigation.Object, this.navigation.Object, null, null);
         }
 
@@ -128,6 +131,25 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(unitPrefix, EventKind.Removed);
             Assert.AreEqual(0, this.browser.UnitPrefixes.Count);
+        }
+
+        [Test]
+        public void VerifyThatUnitPrefixRowIsNotDuplicatedAndIsRemovedAcrossCacheReopen()
+        {
+            var iid = Guid.NewGuid();
+
+            var unitPrefix = new UnitPrefix(iid, this.assembler.Cache, this.uri) { Name = "up", ShortName = "up", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(unitPrefix, EventKind.Added);
+
+            var reInstantiatedUnitPrefix = new UnitPrefix(iid, this.assembler.Cache, this.uri) { Name = "up", ShortName = "up", Container = this.siteRdl };
+            this.messageBus.SendObjectChangeEvent(reInstantiatedUnitPrefix, EventKind.Added);
+
+            Assert.AreEqual(1, this.browser.UnitPrefixes.Count(x => x.Thing.Iid == iid));
+
+            var removedUnitPrefix = new UnitPrefix(iid, this.assembler.Cache, this.uri);
+            this.messageBus.SendObjectChangeEvent(removedUnitPrefix, EventKind.Removed);
+
+            Assert.IsFalse(this.browser.UnitPrefixes.Any(x => x.Thing.Iid == iid));
         }
 
         [Test]
@@ -186,6 +208,7 @@ namespace BasicRDL.Tests.ViewModels
 
             var sRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
             sRdl.Container = this.siteDirectory;
+            this.siteDirectory.SiteReferenceDataLibrary.Add(sRdl);
 
             var cat = new UnitPrefix(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat1", ShortName = "1", Container = sRdl };
             var cat2 = new UnitPrefix(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "cat2", ShortName = "2", Container = sRdl };
@@ -199,6 +222,32 @@ namespace BasicRDL.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.UnitPrefixes.Count(x => x.ContainerRdl == "test") == 2);
+        }
+
+        [Test]
+        public void VerifyThatAddedUnitPrefixFromClosedReferenceDataLibraryIsIgnored()
+        {
+            var closedRdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var unitPrefix = new UnitPrefix(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "up", ShortName = "up", Container = closedRdl };
+
+            this.messageBus.SendObjectChangeEvent(unitPrefix, EventKind.Added);
+
+            Assert.IsFalse(this.browser.UnitPrefixes.Any());
+        }
+
+        [Test]
+        public void VerifyThatOpeningAReferenceDataLibraryPopulatesItsUnitPrefixes()
+        {
+            var rdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteDirectory };
+            var unitPrefix = new UnitPrefix(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "up", ShortName = "up", Container = rdl };
+            rdl.UnitPrefix.Add(unitPrefix);
+
+            Assert.IsFalse(this.browser.UnitPrefixes.Any(x => x.Thing.Iid == unitPrefix.Iid));
+
+            this.siteDirectory.SiteReferenceDataLibrary.Add(rdl);
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.RdlOpened));
+
+            Assert.AreEqual(1, this.browser.UnitPrefixes.Count(x => x.Thing.Iid == unitPrefix.Iid));
         }
     }
 }

--- a/BasicRdl/ViewModels/CategoryBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/CategoryBrowserViewModel.cs
@@ -147,7 +147,15 @@ namespace BasicRdl.ViewModels
         protected override void Initialize()
         {
             base.Initialize();
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+            this.PopulateCategories();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="Category"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateCategories()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
                          .Where(x => openDataLibrariesIids.Contains(x.Iid)))
@@ -240,6 +248,13 @@ namespace BasicRdl.ViewModels
                 .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateCategories());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -248,7 +263,12 @@ namespace BasicRdl.ViewModels
         /// <param name="category">The associated <see cref="Category"/></param>
         private void AddCategoryRowViewModel(Category category)
         {
-            if (this.Categories.Any(x => x.Thing == category))
+            if (this.Categories.Any(x => x.Thing.Iid == category.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(category))
             {
                 return;
             }
@@ -265,9 +285,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveCategoryRowViewModel(Category category)
         {
-            var row = this.Categories.SingleOrDefault(rowViewModel => rowViewModel.Thing == category);
+            var rows = this.Categories.Where(rowViewModel => rowViewModel.Thing.Iid == category.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.Categories.RemoveAndDispose(row);
             }

--- a/BasicRdl/ViewModels/ConstantsBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ConstantsBrowserViewModel.cs
@@ -161,7 +161,15 @@ namespace BasicRdl.ViewModels
         {
             base.Initialize();
 
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+            this.PopulateConstants();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="Constant"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateConstants()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
                          .Where(x => openDataLibrariesIids.Contains(x.Iid)))
@@ -226,6 +234,13 @@ namespace BasicRdl.ViewModels
                     .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateConstants());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -236,7 +251,12 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void AddConstantRowViewModel(Constant constant)
         {
-            if (this.Constants.Any(x => x.Thing == constant))
+            if (this.Constants.Any(x => x.Thing.Iid == constant.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(constant))
             {
                 return;
             }
@@ -253,9 +273,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveConstantRowViewModel(Constant constant)
         {
-            var row = this.Constants.SingleOrDefault(rowViewModel => rowViewModel.Thing == constant);
+            var rows = this.Constants.Where(rowViewModel => rowViewModel.Thing.Iid == constant.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.Constants.RemoveAndDispose(row);
             }

--- a/BasicRdl/ViewModels/FileTypeBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/FileTypeBrowserViewModel.cs
@@ -150,6 +150,13 @@ namespace BasicRdl.ViewModels
                     .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateFileTypes());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -160,7 +167,12 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void AddFileTypeRowViewModel(FileType filetype)
         {
-            if (this.FileTypes.Any(x => x.Thing == filetype))
+            if (this.FileTypes.Any(x => x.Thing.Iid == filetype.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(filetype))
             {
                 return;
             }
@@ -177,9 +189,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveFileTypeRowViewModel(FileType filetype)
         {
-            var row = this.FileTypes.SingleOrDefault(rowViewModel => rowViewModel.Thing == filetype);
+            var rows = this.FileTypes.Where(rowViewModel => rowViewModel.Thing.Iid == filetype.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.FileTypes.RemoveAndDispose(row);
             }
@@ -214,7 +226,18 @@ namespace BasicRdl.ViewModels
         {
             base.Initialize();
             this.FileTypes = new DisposableReactiveList<FileTypeRowViewModel>();
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+
+            this.PopulateFileTypes();
+
+            this.CreateCommand = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<FileType>(), this.WhenAnyValue(x => x.CanWriteFileType));
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="FileType"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateFileTypes()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
                          .Where(x => openDataLibrariesIids.Contains(x.Iid)))
@@ -224,8 +247,6 @@ namespace BasicRdl.ViewModels
                     this.AddFileTypeRowViewModel(filetype);
                 }
             }
-
-            this.CreateCommand = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<FileType>(), this.WhenAnyValue(x => x.CanWriteFileType));
         }
 
         /// <summary>

--- a/BasicRdl/ViewModels/GlossaryBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/GlossaryBrowserViewModel.cs
@@ -183,6 +183,13 @@ namespace BasicRdl.ViewModels
                     .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateGlossaries());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -191,7 +198,12 @@ namespace BasicRdl.ViewModels
         /// <param name="glossary">The associated <see cref="Glossary"/></param>
         private void AddGlossaryRowViewModel(Glossary glossary)
         {
-            if (this.Glossaries.Any(rowViewModel => rowViewModel.Thing == glossary))
+            if (this.Glossaries.Any(rowViewModel => rowViewModel.Thing.Iid == glossary.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(glossary))
             {
                 return;
             }
@@ -206,9 +218,9 @@ namespace BasicRdl.ViewModels
         /// <param name="glossary">The associated <see cref="Glossary"/></param>
         private void RemoveGlossaryRowViewModel(Glossary glossary)
         {
-            var row = this.Glossaries.SingleOrDefault(x => x.Thing == glossary);
+            var rows = this.Glossaries.Where(x => x.Thing.Iid == glossary.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.Glossaries.RemoveAndDispose(row);
             }
@@ -244,7 +256,15 @@ namespace BasicRdl.ViewModels
             base.Initialize();
             this.Glossaries = new DisposableReactiveList<GlossaryRowViewModel>();
 
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+            this.PopulateGlossaries();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="Glossary"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateGlossaries()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
                          .Where(x => openDataLibrariesIids.Contains(x.Iid)))

--- a/BasicRdl/ViewModels/MeasurementScalesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/MeasurementScalesBrowserViewModel.cs
@@ -180,6 +180,13 @@ namespace BasicRdl.ViewModels
                     .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateMeasurementScales());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -190,6 +197,16 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void AddMeasurementScaleRowViewModel(MeasurementScale scale)
         {
+            if (this.MeasurementScales.Any(x => x.Thing.Iid == scale.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(scale))
+            {
+                return;
+            }
+
             var row = new MeasurementScaleRowViewModel(scale, this.Session, this);
             this.MeasurementScales.Add(row);
         }
@@ -202,9 +219,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveMeasurementScaleRowViewModel(MeasurementScale scale)
         {
-            var row = this.MeasurementScales.SingleOrDefault(rowViewModel => rowViewModel.Thing == scale);
+            var rows = this.MeasurementScales.Where(rowViewModel => rowViewModel.Thing.Iid == scale.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.MeasurementScales.RemoveAndDispose(row);
             }
@@ -239,7 +256,15 @@ namespace BasicRdl.ViewModels
         {
             base.Initialize();
 
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+            this.PopulateMeasurementScales();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="MeasurementScale"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateMeasurementScales()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
                          .Where(x => openDataLibrariesIids.Contains(x.Iid)))

--- a/BasicRdl/ViewModels/MeasurementUnitsBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/MeasurementUnitsBrowserViewModel.cs
@@ -175,6 +175,13 @@ namespace BasicRdl.ViewModels
                     .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateMeasurementUnits());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -183,6 +190,16 @@ namespace BasicRdl.ViewModels
         /// <param name="measurementUnit">The associated <see cref="MeasurementUnit"/></param>
         private void AddMeasurementUnitRowViewModel(MeasurementUnit measurementUnit)
         {
+            if (this.MeasurementUnits.Any(x => x.Thing.Iid == measurementUnit.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(measurementUnit))
+            {
+                return;
+            }
+
             var row = new MeasurementUnitRowViewModel(measurementUnit, this.Session, this);
             this.MeasurementUnits.Add(row);
         }
@@ -195,9 +212,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveMeasurementUnitRowViewModel(MeasurementUnit measurementUnit)
         {
-            var row = this.MeasurementUnits.SingleOrDefault(rowViewModel => rowViewModel.Thing == measurementUnit);
+            var rows = this.MeasurementUnits.Where(rowViewModel => rowViewModel.Thing.Iid == measurementUnit.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.MeasurementUnits.RemoveAndDispose(row);
             }
@@ -296,7 +313,16 @@ namespace BasicRdl.ViewModels
         protected override void Initialize()
         {
             base.Initialize();
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+
+            this.PopulateMeasurementUnits();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="MeasurementUnit"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateMeasurementUnits()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
                          .Where(x => openDataLibrariesIids.Contains(x.Iid)))

--- a/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
@@ -271,6 +271,14 @@ namespace BasicRdl.ViewModels
                 this.favoritesService.SubscribeToChanges(this.Session, typeof(ParameterType), this.RefreshFavorites);
 
             this.Disposables.Add(favoritesListener);
+
+            var rdlOpenedListener =
+                this.CDPMessageBus.Listen<SessionEvent>()
+                    .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                    .ObserveOn(RxApp.MainThreadScheduler)
+                    .Subscribe(_ => this.PopulateParameterTypes());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -496,6 +504,16 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void AddParameterTypeRowViewModel(ParameterType parameterType)
         {
+            if (this.ParameterTypes.Any(x => x.Thing.Iid == parameterType.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(parameterType))
+            {
+                return;
+            }
+
             var row = new ParameterTypeRowViewModel(parameterType, this.Session, this);
 
             if (this.FavoriteParameterTypeIids != null)
@@ -514,9 +532,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveParameterTypeRowViewModel(ParameterType parameterType)
         {
-            var row = this.ParameterTypes.SingleOrDefault(rowViewModel => rowViewModel.Thing == parameterType);
+            var rows = this.ParameterTypes.Where(rowViewModel => rowViewModel.Thing.Iid == parameterType.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.ParameterTypes.RemoveAndDispose(row);
             }
@@ -551,7 +569,15 @@ namespace BasicRdl.ViewModels
         {
             base.Initialize();
 
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+            this.PopulateParameterTypes();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="ParameterType"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateParameterTypes()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries()
                          .Where(x => openDataLibrariesIids.Contains(x.Iid)))

--- a/BasicRdl/ViewModels/ReferenceSourceBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ReferenceSourceBrowserViewModel.cs
@@ -145,7 +145,15 @@ namespace BasicRdl.ViewModels
             base.Initialize();
             this.ReferenceSources = new DisposableReactiveList<ReferenceSourceRowViewModel>();
 
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(x => x.Iid);
+            this.PopulateReferenceSources();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="ReferenceSource"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateReferenceSources()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(x => x.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
@@ -205,6 +213,13 @@ namespace BasicRdl.ViewModels
                     .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateReferenceSources());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -215,7 +230,14 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void AddReferenceSourceRowViewModel(ReferenceSource referenceSource)
         {
-            if (this.ReferenceSources.Any(x => x.Thing == referenceSource))
+            if (this.ReferenceSources.Any(x => x.Thing.Iid == referenceSource.Iid))
+            {
+                return;
+            }
+
+            // Only show ReferenceSources that reside in a currently open ReferenceDataLibrary. A reload re-reads the
+            // SiteDirectory deeply and re-adds Things from closed RDLs to the cache; without this guard those would reappear.
+            if (!this.IsInOpenReferenceDataLibrary(referenceSource))
             {
                 return;
             }
@@ -232,9 +254,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveReferenceSourceRowViewModel(ReferenceSource referenceSource)
         {
-            var row = this.ReferenceSources.SingleOrDefault(rowViewModel => rowViewModel.Thing == referenceSource);
+            var rows = this.ReferenceSources.Where(rowViewModel => rowViewModel.Thing.Iid == referenceSource.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.ReferenceSources.RemoveAndDispose(row);
             }

--- a/BasicRdl/ViewModels/RulesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/RulesBrowserViewModel.cs
@@ -160,6 +160,13 @@ namespace BasicRdl.ViewModels
                     .Subscribe(this.RefreshContainerName);
 
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateRules());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -170,6 +177,16 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void AddRuleRowViewModel(Rule rule)
         {
+            if (this.Rules.Any(x => x.Thing.Iid == rule.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(rule))
+            {
+                return;
+            }
+
             var row = new RuleRowViewModel(rule, this.Session, this);
             this.Rules.Add(row);
         }
@@ -182,9 +199,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveRuleRowViewModel(Rule rule)
         {
-            var row = this.Rules.SingleOrDefault(rowViewModel => rowViewModel.Thing == rule);
+            var rows = this.Rules.Where(rowViewModel => rowViewModel.Thing.Iid == rule.Iid).ToList();
 
-            if (row != null)
+            foreach (var row in rows)
             {
                 this.Rules.RemoveAndDispose(row);
             }
@@ -260,7 +277,15 @@ namespace BasicRdl.ViewModels
         {
             base.Initialize();
 
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid);
+            this.PopulateRules();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="Rule"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateRules()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(y => y.Iid).ToList();
 
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {

--- a/BasicRdl/ViewModels/UnitPrefixBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/UnitPrefixBrowserViewModel.cs
@@ -135,7 +135,16 @@ namespace BasicRdl.ViewModels
             base.Initialize();
             this.UnitPrefixes = new DisposableReactiveList<UnitPrefixRowViewModel>();
 
-            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(x => x.Iid);
+            this.PopulateUnitPrefixes();
+        }
+
+        /// <summary>
+        /// Adds a row for every <see cref="UnitPrefix"/> contained in the currently open <see cref="ReferenceDataLibrary"/>s.
+        /// </summary>
+        private void PopulateUnitPrefixes()
+        {
+            var openDataLibrariesIids = this.Session.OpenReferenceDataLibraries.Select(x => x.Iid).ToList();
+
             foreach (var referenceDataLibrary in this.Thing.AvailableReferenceDataLibraries().Where(x => openDataLibrariesIids.Contains(x.Iid)))
             {
                 foreach (var unitPrefix in referenceDataLibrary.UnitPrefix)
@@ -190,6 +199,13 @@ namespace BasicRdl.ViewModels
                     .ObserveOn(RxApp.MainThreadScheduler)
                     .Subscribe(this.RefreshContainerName);
             this.Disposables.Add(rdlUpdateListener);
+
+            var rdlOpenedListener = this.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.RdlOpened)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.PopulateUnitPrefixes());
+
+            this.Disposables.Add(rdlOpenedListener);
         }
 
         /// <summary>
@@ -200,7 +216,12 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void AddUnitPrefixRowViewModel(UnitPrefix unitPrefix)
         {
-            if (this.UnitPrefixes.Any(x => x.Thing == unitPrefix))
+            if (this.UnitPrefixes.Any(x => x.Thing.Iid == unitPrefix.Iid))
+            {
+                return;
+            }
+
+            if (!this.IsInOpenReferenceDataLibrary(unitPrefix))
             {
                 return;
             }
@@ -217,8 +238,9 @@ namespace BasicRdl.ViewModels
         /// </param>
         private void RemoveUnitPrefixRowViewModel(UnitPrefix unitPrefix)
         {
-            var row = this.UnitPrefixes.SingleOrDefault(rowViewModel => rowViewModel.Thing == unitPrefix);
-            if (row != null)
+            var rows = this.UnitPrefixes.Where(rowViewModel => rowViewModel.Thing.Iid == unitPrefix.Iid).ToList();
+
+            foreach (var row in rows)
             {
                 this.UnitPrefixes.RemoveAndDispose(row);
             }

--- a/CDP4Composition/Mvvm/BrowserViewModelBase.cs
+++ b/CDP4Composition/Mvvm/BrowserViewModelBase.cs
@@ -824,6 +824,22 @@ namespace CDP4Composition.Mvvm
         }
 
         /// <summary>
+        /// Asserts whether the <paramref name="thing"/> is contained in a <see cref="ReferenceDataLibrary"/> that is currently
+        /// open in the associated <see cref="ISession"/>.
+        /// </summary>
+        /// <param name="thing">
+        /// The <see cref="Thing"/> to check.
+        /// </param>
+        /// <returns>
+        /// True if the <paramref name="thing"/>'s container is an open <see cref="ReferenceDataLibrary"/>, otherwise false.
+        /// </returns>
+        protected bool IsInOpenReferenceDataLibrary(Thing thing)
+        {
+            return thing.Container is ReferenceDataLibrary referenceDataLibrary
+                   && this.Session.OpenReferenceDataLibraries.Any(openRdl => openRdl.Iid == referenceDataLibrary.Iid);
+        }
+
+        /// <summary>
         /// Executes the <see cref="ChangeFocusCommand"/>
         /// </summary>
         protected virtual void ExecuteChangeFocusCommand()

--- a/CDP4ShellDialogs/ViewModels/ModelClosingDialogViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelClosingDialogViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="ModelClosingDialogViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2022 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerenï¿½, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Thï¿½ate, Omar Elebiary
 //
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -139,7 +139,7 @@ namespace CDP4ShellDialogs.ViewModels
                     var modelSetup = (EngineeringModelSetup)modelrow.Thing.Container;
                     await session.CloseIterationSetup((IterationSetup)iteration.Thing);
 
-                    if (session.OpenIterations.Keys.Count(it => it.IterationSetup.Container == modelSetup) == 1)
+                    if (session.OpenIterations.Keys.All(it => it.IterationSetup.Container != modelSetup))
                     {
                         var modelRdl = modelSetup.RequiredRdl.Single();
                         await session.CloseModelRdl(modelRdl);

--- a/CDP4ShellDialogsTestFixture/ViewModels/ModelClosingDialogViewModelTestFixture.cs
+++ b/CDP4ShellDialogsTestFixture/ViewModels/ModelClosingDialogViewModelTestFixture.cs
@@ -62,7 +62,11 @@ namespace CDP4ShellDialogs.Tests
         private EngineeringModelSetup model1;
         private EngineeringModelSetup model2;
         private IterationSetup iterationSetup11;
+        private IterationSetup iterationSetup12;
         private IterationSetup iterationSetup21;
+        private Iteration iteration11;
+        private Iteration iteration12;
+        private Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>> openIterations;
         private Person person;
         private Participant participant;
         private DomainOfExpertise domain;
@@ -97,8 +101,10 @@ namespace CDP4ShellDialogs.Tests
             this.model2 = new EngineeringModelSetup(Guid.NewGuid(), null, this.uri) { Name = "model2" };
             this.model2.RequiredRdl.Add(model2RDL);
             this.iterationSetup11 = new IterationSetup(Guid.NewGuid(), null, this.uri);
+            this.iterationSetup12 = new IterationSetup(Guid.NewGuid(), null, this.uri);
             this.iterationSetup21 = new IterationSetup(Guid.NewGuid(), null, this.uri);
             this.iterationSetup11.IterationIid = Guid.NewGuid();
+            this.iterationSetup12.IterationIid = Guid.NewGuid();
             this.person = new Person(Guid.NewGuid(), null, this.uri) { GivenName = "testPerson" };
             this.domain = new DomainOfExpertise(Guid.NewGuid(), null, this.uri) { Name = "domaintest" };
 
@@ -113,6 +119,7 @@ namespace CDP4ShellDialogs.Tests
             this.model2.Participant.Add(this.participant);
 
             this.model1.IterationSetup.Add(this.iterationSetup11);
+            this.model1.IterationSetup.Add(this.iterationSetup12);
             this.model2.IterationSetup.Add(this.iterationSetup21);
 
             this.iterationSetup21.IterationIid = Guid.NewGuid();
@@ -126,20 +133,45 @@ namespace CDP4ShellDialogs.Tests
             var lazysiteDirectory = new Lazy<Thing>(() => this.siteDirectory);
             this.assembler.Cache.GetOrAdd(new CacheKey(lazysiteDirectory.Value.Iid, null), lazysiteDirectory);
 
-            var iteration11 = new Iteration(Guid.NewGuid(), null, this.uri) { IterationSetup = this.iterationSetup11 };
-            var lazyiteration = new Lazy<Thing>(() => iteration11);
+            this.iteration11 = new Iteration(Guid.NewGuid(), null, this.uri) { IterationSetup = this.iterationSetup11 };
+            var lazyiteration = new Lazy<Thing>(() => this.iteration11);
             this.assembler.Cache.GetOrAdd(new CacheKey(lazyiteration.Value.Iid, null), lazyiteration);
 
-            this.iterationSetup11.IterationIid = iteration11.Iid;
+            this.iterationSetup11.IterationIid = this.iteration11.Iid;
             var lazyiterationSetup11 = new Lazy<Thing>(() => this.iterationSetup11);
             this.assembler.Cache.GetOrAdd(new CacheKey(lazyiterationSetup11.Value.Iid, null), lazyiterationSetup11);
+
+            this.iteration12 = new Iteration(Guid.NewGuid(), null, this.uri) { IterationSetup = this.iterationSetup12 };
+            var lazyiteration12 = new Lazy<Thing>(() => this.iteration12);
+            this.assembler.Cache.GetOrAdd(new CacheKey(lazyiteration12.Value.Iid, null), lazyiteration12);
+
+            this.iterationSetup12.IterationIid = this.iteration12.Iid;
+            var lazyiterationSetup12 = new Lazy<Thing>(() => this.iterationSetup12);
+            this.assembler.Cache.GetOrAdd(new CacheKey(lazyiterationSetup12.Value.Iid, null), lazyiterationSetup12);
+
+            this.openIterations = new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>();
 
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDirectory);
             this.session.Setup(x => x.ActivePerson).Returns(this.person);
             this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
-            this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>());
+            this.session.Setup(x => x.OpenIterations).Returns(() => this.openIterations);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+
+            this.session.Setup(x => x.CloseIterationSetup(It.IsAny<IterationSetup>()))
+                .Returns(Task.CompletedTask)
+                .Callback<IterationSetup>(
+                    closedSetup =>
+                    {
+                        var openIteration = this.openIterations.Keys.FirstOrDefault(it => it.IterationSetup == closedSetup);
+
+                        if (openIteration != null)
+                        {
+                            this.openIterations.Remove(openIteration);
+                        }
+                    });
+
+            this.session.Setup(x => x.CloseModelRdl(It.IsAny<ModelReferenceDataLibrary>())).Returns(Task.CompletedTask);
         }
 
         [TearDown]
@@ -160,10 +192,7 @@ namespace CDP4ShellDialogs.Tests
             Assert.AreEqual("Iteration Selection", viewmodel.DialogTitle);
             Assert.IsTrue(((ICommand)viewmodel.CloseCommand).CanExecute(null));
 
-            var iteration = new Iteration(this.iterationSetup11.IterationIid, this.assembler.Cache, this.uri);
-            iteration.IterationSetup = this.iterationSetup11;
-
-            this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>> { { iteration, null } });
+            this.openIterations.Add(this.iteration11, null);
             await viewmodel.CloseCommand.Execute();
 
             var res = viewmodel.DialogResult;
@@ -172,6 +201,39 @@ namespace CDP4ShellDialogs.Tests
 
             this.session.Verify(x => x.CloseIterationSetup(It.IsAny<IterationSetup>()));
             this.session.Verify(x => x.CloseModelRdl(It.IsAny<ModelReferenceDataLibrary>()));
+        }
+
+        [Test]
+        public async Task VerifyThatClosingLastOpenIterationClosesTheModelRdl()
+        {
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelClosingDialogViewModel(sessions);
+
+            this.openIterations.Add(this.iteration11, null);
+
+            viewmodel.SelectedIterations.Add(new ModelSelectionIterationSetupRowViewModel(this.iterationSetup11, this.participant, this.session.Object));
+
+            await viewmodel.CloseCommand.Execute();
+
+            this.session.Verify(x => x.CloseIterationSetup(this.iterationSetup11), Times.Once);
+            this.session.Verify(x => x.CloseModelRdl(this.model1.RequiredRdl.Single()), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyThatClosingNonLastOpenIterationDoesNotCloseTheModelRdl()
+        {
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelClosingDialogViewModel(sessions);
+
+            this.openIterations.Add(this.iteration11, null);
+            this.openIterations.Add(this.iteration12, null);
+
+            viewmodel.SelectedIterations.Add(new ModelSelectionIterationSetupRowViewModel(this.iterationSetup11, this.participant, this.session.Object));
+
+            await viewmodel.CloseCommand.Execute();
+
+            this.session.Verify(x => x.CloseIterationSetup(this.iterationSetup11), Times.Once);
+            this.session.Verify(x => x.CloseModelRdl(It.IsAny<ModelReferenceDataLibrary>()), Times.Never);
         }
 
         [Test]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

fixes: #973 and #1348 : 
The RDL browsers now react correctly to closing/reopening an Iteration, Model, or SiteRDL. Closing the last Iteration of a Model now closes its ModelReferenceDataLibrary and the BasicRdl browsers dedupe rows by Iid and remove by Iid so re-instantiated cache POCOs no longer duplicate or crash the remove subscription.

Each browser also ignores Added events for Things whose ReferenceDataLibrary isn't open and repopulates on SessionStatus.RdlOpened, so a reload after closing no longer re-shows data from closed libraries while still showing it immediately on (re)open.



