### PR TITLE
Made a table for showing categories and supercategories fixes #72 and #1043

### DIFF
--- a/BasicRdl.Tests/ViewModels/Dialogs/CategoryDialogViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Dialogs/CategoryDialogViewModelTestFixture.cs
@@ -209,7 +209,12 @@ namespace BasicRdl.Tests.ViewModels
             this.transaction = new ThingTransaction(transactionContext, clonerdl);
 
             vm = new CategoryDialogViewModel(cat31.Clone(false), this.transaction, this.session.Object, true, ThingDialogKind.Update, null, clonerdl);
-            Assert.AreEqual(10, vm.PossibleSuperCategories.Count);
+            Assert.AreEqual(6, vm.PossibleSuperCategories.Count);
+            Assert.That(vm.PossibleSuperCategories.All(c => c.Iid != cat31.Iid), Is.True, "a Category may not be a super-category of itself");
+            Assert.That(
+                vm.PossibleSuperCategories.Any(c => c.Iid == cat311.Iid || c.Iid == cat312.Iid || c.Iid == cat3111.Iid),
+                Is.False,
+                "a Category may not be a super-category of one of its own descendants");
         }
 
         [Test]

--- a/BasicRdl.Tests/ViewModels/Dialogs/CategoryDialogViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Dialogs/CategoryDialogViewModelTestFixture.cs
@@ -1,10 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CategoryDialogViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/BasicRdl/ViewModels/Dialogs/CategoryDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/CategoryDialogViewModel.cs
@@ -178,19 +178,19 @@ namespace BasicRdl.ViewModels
             }
 
             var allPossibleSuperCategories = new List<Category>(rdlContainer.DefinedCategory);
-            allPossibleSuperCategories.Remove(this.Thing);
 
             foreach (var rdl in rdlContainer.GetRequiredRdls())
             {
                 allPossibleSuperCategories.AddRange(rdl.DefinedCategory);
             }
 
-            var possibleSuperCategories = allPossibleSuperCategories.ToList();
+            var possibleSuperCategories = allPossibleSuperCategories.Where(c => c.Iid != this.Thing.Iid).ToList();
 
             // TODO Deal with Update of Category, what happens when container is changed?? is it allowed?
             if (this.dialogKind != ThingDialogKind.Create)
             {
-                possibleSuperCategories = possibleSuperCategories.Except(this.GetRdlSubCategories(this.Thing)).ToList();
+                var subCategoryIids = this.GetRdlSubCategories(this.Thing).Select(c => c.Iid).ToList();
+                possibleSuperCategories = possibleSuperCategories.Where(c => !subCategoryIids.Contains(c.Iid)).ToList();
             }
 
             return possibleSuperCategories.OrderBy(c => c.ShortName);
@@ -204,12 +204,15 @@ namespace BasicRdl.ViewModels
         private IEnumerable<Category> GetRdlSubCategories(Category category)
         {
             var subCategories = new List<Category>();
-            var rdl = (ReferenceDataLibrary)category.Container;
+
+            if (!(category.Container is ReferenceDataLibrary rdl))
+            {
+                return subCategories;
+            }
 
             foreach (var cat in rdl.DefinedCategory)
             {
-                // Get the sub-categories for the current sub-category
-                if (!cat.SuperCategory.Contains(category))
+                if (cat.SuperCategory.All(superCategory => superCategory.Iid != category.Iid))
                 {
                     continue;
                 }

--- a/BasicRdl/ViewModels/Dialogs/CategoryDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/CategoryDialogViewModel.cs
@@ -1,19 +1,19 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CategoryDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 // 
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 // 
-//    This file is part of COMET-IME Community Edition.
-//    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 // 
-//    The COMET-IME Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or any later version.
 // 
-//    The COMET-IME Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //    GNU Affero General Public License for more details.

--- a/BasicRdl/Views/Dialogs/CategoryDialog.xaml
+++ b/BasicRdl/Views/Dialogs/CategoryDialog.xaml
@@ -9,6 +9,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
              xmlns:converters="clr-namespace:CDP4Composition.Converters;assembly=CDP4Composition"
+             xmlns:behaviours="clr-namespace:CDP4Composition.Mvvm.Behaviours;assembly=CDP4Composition"
              Height="300"
              d:DesignWidth="571"
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"
@@ -16,7 +17,6 @@
     <dx:DXWindow.Resources>
         <ResourceDictionary>
             <converters:ReactiveClassKindToObjectListConverter x:Key="ReactiveClassKindToObjectListConverter" />
-            <converters:ReactiveCategoryToObjectListConverter x:Key="ReactiveCategoryToObjectListConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/CDP4Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
@@ -63,20 +63,9 @@
             </lc:LayoutGroup>
             <lc:LayoutGroup Header="Super Categories" Orientation="Vertical">
                 <lc:LayoutItem>
-                    <dxe:ListBoxEdit Name="SuperCategoriesList"
-                                     MaxHeight="250"
-                                     Margin="10"
-                                     DisplayMember="Name"
-                                     IsReadOnly="{Binding IsReadOnly}"
-                                     EditValue="{Binding SuperCategory,
-                                                         Converter={StaticResource ReactiveCategoryToObjectListConverter},
-                                                         UpdateSourceTrigger=PropertyChanged}"
-                                     ItemsSource="{Binding PossibleSuperCategories}"
-                                     SelectionMode="Multiple">
-                        <dxe:ListBoxEdit.StyleSettings>
-                            <dxe:CheckedListBoxEditStyleSettings ItemContainerStyle="{StaticResource ListBoxEditItemStyleDeprecated}" />
-                        </dxe:ListBoxEdit.StyleSettings>
-                    </dxe:ListBoxEdit>
+                    <items:CategorySelectionGrid behaviours:CategorySelectionGridProperties.PossibleCategories="{Binding PossibleSuperCategories}"
+                                                 behaviours:CategorySelectionGridProperties.SelectedCategories="{Binding SuperCategory}"
+                                                 behaviours:CategorySelectionGridProperties.IsReadOnly="{Binding IsReadOnly}" />
                 </lc:LayoutItem>
             </lc:LayoutGroup>
 

--- a/CDP4Composition.Tests/CommonView/ViewModels/CategorySelectionRowViewModelTestFixture.cs
+++ b/CDP4Composition.Tests/CommonView/ViewModels/CategorySelectionRowViewModelTestFixture.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="CategorySelectionRowViewModelTestFixture.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition.Tests/CommonView/ViewModels/CategorySelectionRowViewModelTestFixture.cs
+++ b/CDP4Composition.Tests/CommonView/ViewModels/CategorySelectionRowViewModelTestFixture.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionRowViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition.Tests/CommonView/ViewModels/CategorySelectionRowViewModelTestFixture.cs
+++ b/CDP4Composition.Tests/CommonView/ViewModels/CategorySelectionRowViewModelTestFixture.cs
@@ -1,0 +1,163 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategorySelectionRowViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Tests.CommonView.ViewModels
+{
+    using System;
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4CommonView.ViewModels;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="CategorySelectionRowViewModel"/> that backs the category selection grid
+    /// (GitHub issues #72 and #1043).
+    /// </summary>
+    [TestFixture]
+    public class CategorySelectionRowViewModelTestFixture
+    {
+        private SiteReferenceDataLibrary siteReferenceDataLibrary;
+
+        private Category superCategory;
+
+        private Category category;
+
+        private Category deprecatedCategory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.siteReferenceDataLibrary = new SiteReferenceDataLibrary { ShortName = "GENERIC" };
+
+            this.superCategory = new Category { Name = "Product", ShortName = "PROD" };
+            this.siteReferenceDataLibrary.DefinedCategory.Add(this.superCategory);
+
+            this.category = new Category { Name = "Element Definition Category", ShortName = "ED_CAT" };
+            this.category.SuperCategory.Add(this.superCategory);
+            this.category.Definition.Add(new Definition { LanguageCode = "en-GB", Content = "the definition" });
+            this.siteReferenceDataLibrary.DefinedCategory.Add(this.category);
+
+            this.deprecatedCategory = new Category { Name = "Deprecated Category", ShortName = "DEP_CAT", IsDeprecated = true };
+            this.siteReferenceDataLibrary.DefinedCategory.Add(this.deprecatedCategory);
+        }
+
+        [Test]
+        public void VerifyThatPropertiesAreSetWhenRowViewModelIsConstructed()
+        {
+            var row = new CategorySelectionRowViewModel(this.category);
+
+            Assert.That(row.Category, Is.EqualTo(this.category));
+            Assert.That(row.Name, Is.EqualTo("Element Definition Category"));
+            Assert.That(row.ShortName, Is.EqualTo("ED_CAT"));
+            Assert.That(row.SuperCategory, Is.EqualTo("PROD"));
+            Assert.That(row.ContainerRdl, Is.EqualTo("GENERIC"));
+            Assert.That(row.Definition, Is.EqualTo("the definition"));
+            Assert.That(row.IsDeprecated, Is.False);
+        }
+
+        [Test]
+        public void VerifyThatSuperCategoryAndDefinitionAreEmptyWhenNotSet()
+        {
+            var row = new CategorySelectionRowViewModel(this.superCategory);
+
+            Assert.That(row.SuperCategory, Is.Empty);
+            Assert.That(row.Definition, Is.Empty);
+        }
+
+        [Test]
+        public void VerifyThatConstructorThrowsOnNullCategory()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CategorySelectionRowViewModel(null));
+        }
+
+        [Test]
+        public void VerifyThatNonDeprecatedCategoryIsSelectable()
+        {
+            var row = new CategorySelectionRowViewModel(this.category);
+
+            Assert.That(row.IsSelectable, Is.True);
+        }
+
+        [Test]
+        public void VerifyThatUnassignedDeprecatedCategoryIsNotSelectable()
+        {
+            var row = new CategorySelectionRowViewModel(this.deprecatedCategory) { IsSelected = false };
+
+            Assert.That(row.IsSelectable, Is.False);
+        }
+
+        [Test]
+        public void VerifyThatAssignedDeprecatedCategoryIsSelectableSoItCanBeDeselected()
+        {
+            var row = new CategorySelectionRowViewModel(this.deprecatedCategory) { IsSelected = true };
+
+            Assert.That(row.IsSelectable, Is.True);
+        }
+
+        [Test]
+        public void VerifyThatReadOnlyRowIsNotSelectable()
+        {
+            var row = new CategorySelectionRowViewModel(this.category) { IsReadOnly = true };
+
+            Assert.That(row.IsSelectable, Is.False);
+        }
+
+        [Test]
+        public void VerifyThatChangingSelectionRaisesIsSelectableNotification()
+        {
+            var row = new CategorySelectionRowViewModel(this.deprecatedCategory);
+            var raised = false;
+            row.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(CategorySelectionRowViewModel.IsSelectable))
+                {
+                    raised = true;
+                }
+            };
+
+            row.IsSelected = true;
+
+            Assert.That(raised, Is.True);
+        }
+
+        [Test]
+        public void VerifyThatRowsAreOrderedBySelectionThenName()
+        {
+            var alpha = new CategorySelectionRowViewModel(new Category { Name = "Alpha", ShortName = "A" }) { IsSelected = false };
+            var zeta = new CategorySelectionRowViewModel(new Category { Name = "Zeta", ShortName = "Z" }) { IsSelected = true };
+            var beta = new CategorySelectionRowViewModel(new Category { Name = "Beta", ShortName = "B" }) { IsSelected = false };
+            var gamma = new CategorySelectionRowViewModel(new Category { Name = "Gamma", ShortName = "G" }) { IsSelected = true };
+
+            var ordered = CategorySelectionRowViewModel.OrderBySelectionThenName(new[] { alpha, zeta, beta, gamma }).ToList();
+
+            Assert.That(ordered, Is.EqualTo(new[] { gamma, zeta, alpha, beta }));
+        }
+    }
+}

--- a/CDP4Composition.Tests/Mvvm/Behaviours/CategorySelectionFilterTestFixture.cs
+++ b/CDP4Composition.Tests/Mvvm/Behaviours/CategorySelectionFilterTestFixture.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionFilterTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition.Tests/Mvvm/Behaviours/CategorySelectionFilterTestFixture.cs
+++ b/CDP4Composition.Tests/Mvvm/Behaviours/CategorySelectionFilterTestFixture.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="CategorySelectionFilterTestFixture.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml
+++ b/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml
@@ -2,59 +2,18 @@
                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                  xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
                   xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
-                  xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                  xmlns:items="clr-namespace:CDP4CommonView.Items"
                   xmlns:behaviours="clr-namespace:CDP4Composition.Mvvm.Behaviours"
-                  xmlns:converters="clr-namespace:CDP4Composition.Converters"
-                  xmlns:themes="http://schemas.devexpress.com/winfx/2008/xaml/editors/themekeys"
                   Header="Category"
                   Orientation="Vertical"
                   mc:Ignorable="d"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch">
-    <dxlc:LayoutGroup.Resources>
-        <ResourceDictionary>
-            <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/CDP4Styles.xaml" />
-            </ResourceDictionary.MergedDictionaries>
-            <converters:ReactiveCategoryToObjectListConverter x:Key="ReactiveCategoryToObjectListConverter" />
-            <converters:CategoryVisibilityConverter x:Key="CategoryVisibilityConverter" />
-            <converters:NotConverter x:Key="NotConverter" />
-        </ResourceDictionary>
-    </dxlc:LayoutGroup.Resources>
-    <dxlc:LayoutItem HorizontalAlignment="Left">
-        <CheckBox x:Name="SelectAllCategoriesCheckBox"
-                  Content="Select All"
-                  Margin="10,0,0,0"
-                  VerticalAlignment="Center"
-                  IsEnabled="{Binding IsReadOnly, Converter={StaticResource NotConverter}}" />
-    </dxlc:LayoutItem>
     <dxlc:LayoutItem>
-        <dxe:ListBoxEdit Name="CategoriesList"
-                         MaxHeight="350"
-                         VerticalAlignment="Stretch"
-                         HorizontalAlignment="Stretch"
-                        Margin="10"
-                        IsReadOnly="{Binding IsReadOnly}"
-                        DisplayMember="Name"
-                        EditValue="{Binding Category,
-                                            Converter={StaticResource ReactiveCategoryToObjectListConverter},
-                                            UpdateSourceTrigger=PropertyChanged}"
-                        SelectionMode="Multiple">
-            <dxmvvm:Interaction.Behaviors>
-                <behaviours:CategorySelectAllBehavior SelectAllCheckBox="{Binding ElementName=SelectAllCategoriesCheckBox}" />
-            </dxmvvm:Interaction.Behaviors>
-            <dxe:ListBoxEdit.ItemsSource>
-                <MultiBinding Converter="{StaticResource CategoryVisibilityConverter}" Mode="OneTime">
-                    <Binding Path="PossibleCategory" />
-                    <Binding Path="Category" />
-                </MultiBinding>
-            </dxe:ListBoxEdit.ItemsSource>
-            <dxe:ListBoxEdit.StyleSettings>
-                <dxe:CheckedListBoxEditStyleSettings ShowSelectAllItem="False" ItemContainerStyle="{StaticResource ListBoxEditItemStyleDeprecatedNotSelectable}" />
-            </dxe:ListBoxEdit.StyleSettings>
-        </dxe:ListBoxEdit>
+        <items:CategorySelectionGrid behaviours:CategorySelectionGridProperties.PossibleCategories="{Binding PossibleCategory}"
+                                     behaviours:CategorySelectionGridProperties.SelectedCategories="{Binding Category}"
+                                     behaviours:CategorySelectionGridProperties.IsReadOnly="{Binding IsReadOnly}" />
     </dxlc:LayoutItem>
 </dxlc:LayoutGroup>

--- a/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml.cs
+++ b/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategoryLayoutGroup.cs" company="Starion Group S.A.">
-//   Copyright (c) 2015 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 

--- a/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml.cs
+++ b/CDP4Composition/CommonView/Items/CategoryLayoutGroup.xaml.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="CategoryLayoutGroup.xaml.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition/CommonView/Items/CategorySelectionGrid.xaml
+++ b/CDP4Composition/CommonView/Items/CategorySelectionGrid.xaml
@@ -1,0 +1,101 @@
+﻿<UserControl x:Class="CDP4CommonView.Items.CategorySelectionGrid"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
+             xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:behaviours="clr-namespace:CDP4Composition.Mvvm.Behaviours"
+             xmlns:converters="clr-namespace:CDP4Composition.Converters"
+             x:Name="RootControl"
+             mc:Ignorable="d"
+             HorizontalAlignment="Stretch"
+             VerticalAlignment="Stretch">
+    <UserControl.Resources>
+        <converters:NotConverter x:Key="NotConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <DockPanel Grid.Row="0" Margin="10,0,10,0">
+            <Button x:Name="ColumnChooserButton"
+                    DockPanel.Dock="Right"
+                    Content="Column Chooser"
+                    Padding="3"
+                    VerticalAlignment="Center"
+                    ToolTip="Show or hide columns (e.g. Container RDL and Definition)">
+                <dxmvvm:Interaction.Behaviors>
+                    <behaviours:ColumnChooserBehavior View="{Binding ElementName=CategoriesGridView}" />
+                </dxmvvm:Interaction.Behaviors>
+            </Button>
+            <CheckBox x:Name="SelectAllCategoriesCheckBox"
+                      Content="Select All"
+                      HorizontalAlignment="Left"
+                      VerticalAlignment="Center"
+                      IsEnabled="{Binding Path=(behaviours:CategorySelectionGridProperties.IsReadOnly), ElementName=RootControl, Converter={StaticResource NotConverter}}" />
+        </DockPanel>
+        <dxg:GridControl Grid.Row="1"
+                         Name="CategoriesGrid"
+                         MaxHeight="350"
+                         MaxWidth="700"
+                         Margin="10"
+                         VerticalAlignment="Stretch"
+                         HorizontalAlignment="Stretch"
+                         AllowLiveDataShaping="False">
+            <dxmvvm:Interaction.Behaviors>
+                <behaviours:CategoryGridSelectionBehavior PossibleCategories="{Binding Path=(behaviours:CategorySelectionGridProperties.PossibleCategories), ElementName=RootControl}"
+                                                          SelectedCategories="{Binding Path=(behaviours:CategorySelectionGridProperties.SelectedCategories), ElementName=RootControl}"
+                                                          IsReadOnly="{Binding Path=(behaviours:CategorySelectionGridProperties.IsReadOnly), ElementName=RootControl}"
+                                                          SelectAllCheckBox="{Binding ElementName=SelectAllCategoriesCheckBox}" />
+            </dxmvvm:Interaction.Behaviors>
+            <dxg:GridControl.View>
+                <dxg:TableView Name="CategoriesGridView"
+                               HorizontalAlignment="Stretch"
+                               VerticalAlignment="Stretch"
+                               AllowEditing="True"
+                               AllowGrouping="False"
+                               AutoWidth="True"
+                               NavigationStyle="Cell"
+                               ShowGroupPanel="False"
+                               ShowFilterPanelMode="Never"
+                               IsDetailButtonVisibleBinding="{x:Null}">
+                    <dxg:TableView.RowStyle>
+                        <Style TargetType="{x:Type dxg:RowControl}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Row.IsDeprecated}" Value="True">
+                                    <Setter Property="Foreground" Value="Gray" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </dxg:TableView.RowStyle>
+                </dxg:TableView>
+            </dxg:GridControl.View>
+            <dxg:GridControl.Columns>
+                <dxg:GridColumn Header=""
+                                Width="30"
+                                FixedWidth="True"
+                                AllowEditing="True"
+                                AllowAutoFilter="False"
+                                AllowColumnFiltering="False"
+                                AllowSorting="False">
+                    <dxg:GridColumn.CellTemplate>
+                        <DataTemplate>
+                            <dxe:CheckEdit HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           IsChecked="{Binding RowData.Row.IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                           IsEnabled="{Binding RowData.Row.IsSelectable}" />
+                        </DataTemplate>
+                    </dxg:GridColumn.CellTemplate>
+                </dxg:GridColumn>
+                <dxg:GridColumn FieldName="Name" Header="Name" ReadOnly="True" />
+                <dxg:GridColumn FieldName="ShortName" Header="Short Name" ReadOnly="True" />
+                <dxg:GridColumn FieldName="SuperCategory" Header="Super Category" ReadOnly="True" />
+                <dxg:GridColumn FieldName="ContainerRdl" Header="Container RDL" ReadOnly="True" Visible="False" />
+                <dxg:GridColumn FieldName="Definition" Header="Definition" ReadOnly="True" Visible="False" />
+            </dxg:GridControl.Columns>
+        </dxg:GridControl>
+    </Grid>
+</UserControl>

--- a/CDP4Composition/CommonView/Items/CategorySelectionGrid.xaml.cs
+++ b/CDP4Composition/CommonView/Items/CategorySelectionGrid.xaml.cs
@@ -1,0 +1,51 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4CommonView.Items
+{
+    using System.Windows.Controls;
+
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Interaction logic for <see cref="CategorySelectionGrid"/>, the reusable grid that lets a user select
+    /// <see cref="Category"/>s (showing short name, name, super categories and the optional Container RDL and Definition
+    /// columns) with check boxes, a "Select All" toggle and a "Column Chooser" button. It is used both for assigning
+    /// <see cref="Category"/>s to a categorizable thing and for selecting the super categories of a <see cref="Category"/>.
+    /// The grid is parameterized through the CDP4Composition.Mvvm.Behaviours.CategorySelectionGridProperties attached
+    /// properties so that no parameters or logic have to live in this code-behind.
+    /// </summary>
+    public partial class CategorySelectionGrid : UserControl
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CategorySelectionGrid"/> class.
+        /// </summary>
+        public CategorySelectionGrid()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/CDP4Composition/CommonView/Items/CategorySelectionGrid.xaml.cs
+++ b/CDP4Composition/CommonView/Items/CategorySelectionGrid.xaml.cs
@@ -1,11 +1,10 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition/CommonView/ViewModels/CategorySelectionRowViewModel.cs
+++ b/CDP4Composition/CommonView/ViewModels/CategorySelectionRowViewModel.cs
@@ -1,0 +1,152 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategorySelectionRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4CommonView.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// A row-view-model that represents a single <see cref="Category"/> in the category selection grid shown when
+    /// assigning <see cref="Category"/>s to a <see cref="CDP4Common.CommonData.ICategorizableThing"/>. It exposes the
+    /// <see cref="Category"/>'s short name, name, super categories, container <see cref="ReferenceDataLibrary"/> and
+    /// first <see cref="Definition"/> (GitHub issues #72 and #1043) and a <see cref="IsSelected"/> flag driving the
+    /// check box.
+    /// </summary>
+    public class CategorySelectionRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="IsSelected"/>.
+        /// </summary>
+        private bool isSelected;
+
+        /// <summary>
+        /// Backing field for <see cref="IsReadOnly"/>.
+        /// </summary>
+        private bool isReadOnly;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CategorySelectionRowViewModel"/> class.
+        /// </summary>
+        /// <param name="category">
+        /// The <see cref="Category"/> that is represented by this row-view-model.
+        /// </param>
+        public CategorySelectionRowViewModel(Category category)
+        {
+            this.Category = category ?? throw new ArgumentNullException(nameof(category));
+            this.SuperCategory = category.SuperCategory.Count == 0 ? string.Empty : string.Join(", ", category.SuperCategory.Select(x => x.ShortName));
+            this.ContainerRdl = category.Container is ReferenceDataLibrary containerRdl ? containerRdl.ShortName : string.Empty;
+            this.Definition = category.Definition.FirstOrDefault()?.Content ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/> represented by this row-view-model.
+        /// </summary>
+        public Category Category { get; private set; }
+
+        /// <summary>
+        /// Gets the name of the <see cref="Category"/>.
+        /// </summary>
+        public string Name => this.Category.Name;
+
+        /// <summary>
+        /// Gets the short name of the <see cref="Category"/>.
+        /// </summary>
+        public string ShortName => this.Category.ShortName;
+
+        /// <summary>
+        /// Gets the comma-separated short names of the super categories of the <see cref="Category"/>.
+        /// </summary>
+        public string SuperCategory { get; private set; }
+
+        /// <summary>
+        /// Gets the short name of the container <see cref="ReferenceDataLibrary"/> of the <see cref="Category"/>.
+        /// </summary>
+        public string ContainerRdl { get; private set; }
+
+        /// <summary>
+        /// Gets the content of the first <see cref="CDP4Common.CommonData.Definition"/> of the <see cref="Category"/>.
+        /// </summary>
+        public string Definition { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the represented <see cref="Category"/> is deprecated.
+        /// </summary>
+        public bool IsDeprecated => this.Category.IsDeprecated;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the represented <see cref="Category"/> is assigned to the
+        /// categorizable thing.
+        /// </summary>
+        public bool IsSelected
+        {
+            get => this.isSelected;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.isSelected, value);
+                this.RaisePropertyChanged(nameof(this.IsSelectable));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the category selection grid is read-only.
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get => this.isReadOnly;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref this.isReadOnly, value);
+                this.RaisePropertyChanged(nameof(this.IsSelectable));
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the check box of this row can be toggled. A deprecated <see cref="Category"/>
+        /// that is not already assigned cannot be selected (but an assigned one can still be de-selected), and nothing
+        /// can be toggled while the grid is read-only.
+        /// </summary>
+        public bool IsSelectable => !this.IsReadOnly && (!this.IsDeprecated || this.IsSelected);
+
+        /// <summary>
+        /// Orders the supplied <paramref name="rows"/> showing the selected (assigned) <see cref="Category"/>s first and
+        /// then the remaining ones in alphabetical order of their <see cref="Name"/> (GitHub issues #72 and #1043).
+        /// </summary>
+        /// <param name="rows">The rows to order.</param>
+        /// <returns>The ordered rows.</returns>
+        public static IEnumerable<CategorySelectionRowViewModel> OrderBySelectionThenName(IEnumerable<CategorySelectionRowViewModel> rows)
+        {
+            return (rows ?? Enumerable.Empty<CategorySelectionRowViewModel>())
+                .OrderByDescending(row => row.IsSelected)
+                .ThenBy(row => row.Name, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/CDP4Composition/CommonView/ViewModels/CategorySelectionRowViewModel.cs
+++ b/CDP4Composition/CommonView/ViewModels/CategorySelectionRowViewModel.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionRowViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition/CommonView/ViewModels/CategorySelectionRowViewModel.cs
+++ b/CDP4Composition/CommonView/ViewModels/CategorySelectionRowViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="CategorySelectionRowViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition/Mvvm/Behaviours/CategoryGridSelectionBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategoryGridSelectionBehavior.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategoryGridSelectionBehavior.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition/Mvvm/Behaviours/CategoryGridSelectionBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategoryGridSelectionBehavior.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="CategoryGridSelectionBehavior.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition/Mvvm/Behaviours/CategoryGridSelectionBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategoryGridSelectionBehavior.cs
@@ -1,0 +1,436 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategoryGridSelectionBehavior.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm.Behaviours
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.ComponentModel;
+    using System.Linq;
+    using System.Windows;
+    using System.Windows.Controls;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Services;
+
+    using CDP4CommonView.ViewModels;
+
+    using CommonServiceLocator;
+
+    using DevExpress.Mvvm.UI.Interactivity;
+    using DevExpress.Xpf.Grid;
+
+    /// <summary>
+    /// A <see cref="Behavior{T}"/> that populates the category selection <see cref="GridControl"/> with
+    /// <see cref="CategorySelectionRowViewModel"/>s and keeps the selected (assigned) <see cref="Category"/>s in sync
+    /// with the bound <see cref="SelectedCategories"/>. It applies the same deprecation rules as the rest of the
+    /// application (deprecated <see cref="Category"/>s are only shown when deprecated things are globally visible or when
+    /// already assigned) and drives a custom "Select All" <see cref="CheckBox"/>. The grid is initially ordered showing
+    /// the assigned <see cref="Category"/>s first and then the rest alphabetically by name (GitHub issues #72 and #1043).
+    /// </summary>
+    public class CategoryGridSelectionBehavior : Behavior<GridControl>
+    {
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> for the <see cref="PossibleCategories"/>.
+        /// </summary>
+        public static readonly DependencyProperty PossibleCategoriesProperty =
+            DependencyProperty.Register(
+                nameof(PossibleCategories),
+                typeof(IEnumerable),
+                typeof(CategoryGridSelectionBehavior),
+                new PropertyMetadata(null, OnSourceChanged));
+
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> for the <see cref="SelectedCategories"/>.
+        /// </summary>
+        public static readonly DependencyProperty SelectedCategoriesProperty =
+            DependencyProperty.Register(
+                nameof(SelectedCategories),
+                typeof(IList),
+                typeof(CategoryGridSelectionBehavior),
+                new PropertyMetadata(null, OnSourceChanged));
+
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> for the <see cref="IsReadOnly"/>.
+        /// </summary>
+        public static readonly DependencyProperty IsReadOnlyProperty =
+            DependencyProperty.Register(
+                nameof(IsReadOnly),
+                typeof(bool),
+                typeof(CategoryGridSelectionBehavior),
+                new PropertyMetadata(false, OnSourceChanged));
+
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> for the <see cref="SelectAllCheckBox"/>.
+        /// </summary>
+        public static readonly DependencyProperty SelectAllCheckBoxProperty =
+            DependencyProperty.Register(
+                nameof(SelectAllCheckBox),
+                typeof(CheckBox),
+                typeof(CategoryGridSelectionBehavior),
+                new PropertyMetadata(null));
+
+        /// <summary>
+        /// The rows that are bound to the <see cref="GridControl"/>.
+        /// </summary>
+        private ObservableCollection<CategorySelectionRowViewModel> rows;
+
+        /// <summary>
+        /// A value indicating whether the "Select All" <see cref="CheckBox"/> events have been hooked.
+        /// </summary>
+        private bool isHooked;
+
+        /// <summary>
+        /// A value indicating whether the selection is being updated programmatically, used to guard against re-entrancy.
+        /// </summary>
+        private bool isUpdatingSelection;
+
+        /// <summary>
+        /// A value indicating whether the "Select All" <see cref="CheckBox"/> state is being updated programmatically,
+        /// used to guard against re-entrancy.
+        /// </summary>
+        private bool isUpdatingCheckBox;
+
+        /// <summary>
+        /// Gets or sets the possible <see cref="Category"/>s that can be assigned.
+        /// </summary>
+        public IEnumerable PossibleCategories
+        {
+            get => (IEnumerable)this.GetValue(PossibleCategoriesProperty);
+            set => this.SetValue(PossibleCategoriesProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the list of selected (assigned) <see cref="Category"/>s that is kept in sync with the grid.
+        /// </summary>
+        public IList SelectedCategories
+        {
+            get => (IList)this.GetValue(SelectedCategoriesProperty);
+            set => this.SetValue(SelectedCategoriesProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the selection is read-only.
+        /// </summary>
+        public bool IsReadOnly
+        {
+            get => (bool)this.GetValue(IsReadOnlyProperty);
+            set => this.SetValue(IsReadOnlyProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the "Select All" <see cref="CheckBox"/> that this behavior drives.
+        /// </summary>
+        public CheckBox SelectAllCheckBox
+        {
+            get => (CheckBox)this.GetValue(SelectAllCheckBoxProperty);
+            set => this.SetValue(SelectAllCheckBoxProperty, value);
+        }
+
+        /// <summary>
+        /// Executes when this behavior is attached to its <see cref="GridControl"/>.
+        /// </summary>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            this.AssociatedObject.Loaded += this.OnLoaded;
+        }
+
+        /// <summary>
+        /// Executes when this behavior is detached from its <see cref="GridControl"/>.
+        /// </summary>
+        protected override void OnDetaching()
+        {
+            this.AssociatedObject.Loaded -= this.OnLoaded;
+
+            if (this.SelectAllCheckBox != null && this.isHooked)
+            {
+                this.SelectAllCheckBox.Checked -= this.OnSelectAllChecked;
+                this.SelectAllCheckBox.Unchecked -= this.OnSelectAllUnchecked;
+                this.isHooked = false;
+            }
+
+            this.UnsubscribeRows();
+
+            base.OnDetaching();
+        }
+
+        /// <summary>
+        /// Handles the <see cref="FrameworkElement.Loaded"/> event to build the rows (the bindings are resolved by now)
+        /// and to hook and initialize the "Select All" <see cref="CheckBox"/>.
+        /// </summary>
+        /// <param name="sender">The <see cref="GridControl"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            this.BuildRows();
+
+            if (this.SelectAllCheckBox != null && !this.isHooked)
+            {
+                this.SelectAllCheckBox.Checked += this.OnSelectAllChecked;
+                this.SelectAllCheckBox.Unchecked += this.OnSelectAllUnchecked;
+                this.isHooked = true;
+            }
+
+            this.UpdateSelectAllCheckBoxState();
+        }
+
+        /// <summary>
+        /// Rebuilds the rows when one of the bound source <see cref="DependencyProperty"/>s changes (the bindings may be
+        /// delivered after the behavior is attached, so the rows cannot rely on <see cref="OnLoaded"/> alone).
+        /// </summary>
+        /// <param name="d">The <see cref="DependencyObject"/>.</param>
+        /// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/>.</param>
+        private static void OnSourceChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is CategoryGridSelectionBehavior behavior && behavior.AssociatedObject != null)
+            {
+                behavior.BuildRows();
+                behavior.UpdateSelectAllCheckBoxState();
+            }
+        }
+
+        /// <summary>
+        /// Builds the <see cref="CategorySelectionRowViewModel"/>s from the <see cref="PossibleCategories"/>, applying
+        /// the deprecation visibility rules, marking the assigned ones as selected and ordering them, then assigns them
+        /// as the items source of the <see cref="GridControl"/>.
+        /// </summary>
+        private void BuildRows()
+        {
+            if (this.AssociatedObject == null)
+            {
+                return;
+            }
+
+            this.UnsubscribeRows();
+
+            var showDeprecatedThings = GetShowDeprecatedThings();
+            var selected = ToCategoryList(this.SelectedCategories);
+
+            var built = ToCategoryList(this.PossibleCategories)
+                .Where(category => CategorySelectionFilter.IsVisible(category, showDeprecatedThings, selected))
+                .Select(category => new CategorySelectionRowViewModel(category)
+                {
+                    IsSelected = selected.Contains(category),
+                    IsReadOnly = this.IsReadOnly
+                });
+
+            var ordered = CategorySelectionRowViewModel.OrderBySelectionThenName(built).ToList();
+
+            this.rows = new ObservableCollection<CategorySelectionRowViewModel>(ordered);
+
+            foreach (var row in this.rows)
+            {
+                row.PropertyChanged += this.OnRowPropertyChanged;
+            }
+
+            this.AssociatedObject.ItemsSource = this.rows;
+        }
+
+        /// <summary>
+        /// Handles a property change of a row to write the selection back and to keep the "Select All"
+        /// <see cref="CheckBox"/> in sync.
+        /// </summary>
+        /// <param name="sender">The <see cref="CategorySelectionRowViewModel"/>.</param>
+        /// <param name="e">The <see cref="PropertyChangedEventArgs"/>.</param>
+        private void OnRowPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (this.isUpdatingSelection || e.PropertyName != nameof(CategorySelectionRowViewModel.IsSelected))
+            {
+                return;
+            }
+
+            this.WriteBackSelection();
+            this.UpdateSelectAllCheckBoxState();
+        }
+
+        /// <summary>
+        /// Handles the checking of the "Select All" <see cref="CheckBox"/>.
+        /// </summary>
+        /// <param name="sender">The <see cref="CheckBox"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnSelectAllChecked(object sender, RoutedEventArgs e)
+        {
+            if (this.isUpdatingCheckBox || this.rows == null)
+            {
+                return;
+            }
+
+            var result = CategorySelectionFilter.GetSelectAllSelection(this.GetRowCategories(), this.GetSelectedCategories());
+            this.ApplySelection(result);
+        }
+
+        /// <summary>
+        /// Handles the unchecking of the "Select All" <see cref="CheckBox"/>.
+        /// </summary>
+        /// <param name="sender">The <see cref="CheckBox"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnSelectAllUnchecked(object sender, RoutedEventArgs e)
+        {
+            if (this.isUpdatingCheckBox || this.rows == null)
+            {
+                return;
+            }
+
+            var result = CategorySelectionFilter.GetDeselectAllSelection(this.GetSelectedCategories());
+            this.ApplySelection(result);
+        }
+
+        /// <summary>
+        /// Applies the supplied selection to the rows, writes it back and refreshes the "Select All"
+        /// <see cref="CheckBox"/> state.
+        /// </summary>
+        /// <param name="result">The <see cref="Category"/>s that should be selected.</param>
+        private void ApplySelection(IReadOnlyList<Category> result)
+        {
+            this.isUpdatingSelection = true;
+
+            try
+            {
+                foreach (var row in this.rows)
+                {
+                    row.IsSelected = result.Contains(row.Category);
+                }
+            }
+            finally
+            {
+                this.isUpdatingSelection = false;
+            }
+
+            this.WriteBackSelection();
+            this.UpdateSelectAllCheckBoxState();
+        }
+
+        /// <summary>
+        /// Writes the current selection of the rows back into the bound <see cref="SelectedCategories"/> list.
+        /// </summary>
+        private void WriteBackSelection()
+        {
+            if (this.SelectedCategories == null || this.rows == null)
+            {
+                return;
+            }
+
+            this.SelectedCategories.Clear();
+
+            foreach (var row in this.rows.Where(r => r.IsSelected))
+            {
+                this.SelectedCategories.Add(row.Category);
+            }
+        }
+
+        /// <summary>
+        /// Updates the checked state of the "Select All" <see cref="CheckBox"/> to reflect whether all selectable
+        /// categories are selected.
+        /// </summary>
+        private void UpdateSelectAllCheckBoxState()
+        {
+            if (this.SelectAllCheckBox == null || this.rows == null)
+            {
+                return;
+            }
+
+            var allSelected = CategorySelectionFilter.AreAllSelectableCategoriesSelected(this.GetRowCategories(), this.GetSelectedCategories());
+
+            this.isUpdatingCheckBox = true;
+
+            try
+            {
+                this.SelectAllCheckBox.IsChecked = allSelected;
+            }
+            finally
+            {
+                this.isUpdatingCheckBox = false;
+            }
+        }
+
+        /// <summary>
+        /// Unsubscribes from the property-changed events of the current rows.
+        /// </summary>
+        private void UnsubscribeRows()
+        {
+            if (this.rows == null)
+            {
+                return;
+            }
+
+            foreach (var row in this.rows)
+            {
+                row.PropertyChanged -= this.OnRowPropertyChanged;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/>s of all the rows.
+        /// </summary>
+        /// <returns>The <see cref="Category"/>s currently shown in the grid.</returns>
+        private IReadOnlyList<Category> GetRowCategories()
+        {
+            return this.rows.Select(row => row.Category).ToList();
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Category"/>s of the selected rows.
+        /// </summary>
+        /// <returns>The currently selected <see cref="Category"/>s.</returns>
+        private IReadOnlyList<Category> GetSelectedCategories()
+        {
+            return this.rows.Where(row => row.IsSelected).Select(row => row.Category).ToList();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether deprecated things are globally visible.
+        /// </summary>
+        /// <returns>True if deprecated things are shown; otherwise false (also the default when no service is available).</returns>
+        private static bool GetShowDeprecatedThings()
+        {
+            if (!ServiceLocator.IsLocationProviderSet)
+            {
+                return false;
+            }
+
+            return ServiceLocator.Current.GetInstance<IFilterStringService>().ShowDeprecatedThings;
+        }
+
+        /// <summary>
+        /// Converts a value into a list of <see cref="Category"/>.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The <see cref="Category"/>s contained in <paramref name="value"/>.</returns>
+        private static IReadOnlyList<Category> ToCategoryList(object value)
+        {
+            if (value is IEnumerable enumerable && !(value is string))
+            {
+                return enumerable.OfType<Category>().ToList();
+            }
+
+            return new List<Category>();
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectAllBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectAllBehavior.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectAllBehavior.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectAllBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectAllBehavior.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="CategorySelectAllBehavior.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectionFilter.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectionFilter.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="CategorySelectionFilter.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectionFilter.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectionFilter.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionFilter.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectionGridProperties.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectionGridProperties.cs
@@ -1,0 +1,131 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CategorySelectionGridProperties.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm.Behaviours
+{
+    using System.Collections;
+    using System.Windows;
+
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Provides the attached properties that parameterize the reusable category selection grid
+    /// (CDP4CommonView.Items.CategorySelectionGrid) so that its parameters do not have to live in the view's code-behind.
+    /// </summary>
+    public static class CategorySelectionGridProperties
+    {
+        /// <summary>
+        /// The attached <see cref="DependencyProperty"/> holding the possible <see cref="Category"/>s that can be selected.
+        /// </summary>
+        public static readonly DependencyProperty PossibleCategoriesProperty =
+            DependencyProperty.RegisterAttached(
+                "PossibleCategories",
+                typeof(IEnumerable),
+                typeof(CategorySelectionGridProperties),
+                new PropertyMetadata(null));
+
+        /// <summary>
+        /// The attached <see cref="DependencyProperty"/> holding the selected (assigned) <see cref="Category"/>s that is
+        /// kept in sync with the grid.
+        /// </summary>
+        public static readonly DependencyProperty SelectedCategoriesProperty =
+            DependencyProperty.RegisterAttached(
+                "SelectedCategories",
+                typeof(IList),
+                typeof(CategorySelectionGridProperties),
+                new PropertyMetadata(null));
+
+        /// <summary>
+        /// The attached <see cref="DependencyProperty"/> indicating whether the selection is read-only.
+        /// </summary>
+        public static readonly DependencyProperty IsReadOnlyProperty =
+            DependencyProperty.RegisterAttached(
+                "IsReadOnly",
+                typeof(bool),
+                typeof(CategorySelectionGridProperties),
+                new PropertyMetadata(false));
+
+        /// <summary>
+        /// Sets the value of the <see cref="PossibleCategoriesProperty"/> attached property on the supplied <paramref name="element"/>.
+        /// </summary>
+        /// <param name="element">The <see cref="DependencyObject"/> on which to set the value.</param>
+        /// <param name="value">The possible <see cref="Category"/>s.</param>
+        public static void SetPossibleCategories(DependencyObject element, IEnumerable value)
+        {
+            element.SetValue(PossibleCategoriesProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the value of the <see cref="PossibleCategoriesProperty"/> attached property from the supplied <paramref name="element"/>.
+        /// </summary>
+        /// <param name="element">The <see cref="DependencyObject"/> from which to read the value.</param>
+        /// <returns>The possible <see cref="Category"/>s.</returns>
+        public static IEnumerable GetPossibleCategories(DependencyObject element)
+        {
+            return (IEnumerable)element.GetValue(PossibleCategoriesProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the <see cref="SelectedCategoriesProperty"/> attached property on the supplied <paramref name="element"/>.
+        /// </summary>
+        /// <param name="element">The <see cref="DependencyObject"/> on which to set the value.</param>
+        /// <param name="value">The selected <see cref="Category"/>s.</param>
+        public static void SetSelectedCategories(DependencyObject element, IList value)
+        {
+            element.SetValue(SelectedCategoriesProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the value of the <see cref="SelectedCategoriesProperty"/> attached property from the supplied <paramref name="element"/>.
+        /// </summary>
+        /// <param name="element">The <see cref="DependencyObject"/> from which to read the value.</param>
+        /// <returns>The selected <see cref="Category"/>s.</returns>
+        public static IList GetSelectedCategories(DependencyObject element)
+        {
+            return (IList)element.GetValue(SelectedCategoriesProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the <see cref="IsReadOnlyProperty"/> attached property on the supplied <paramref name="element"/>.
+        /// </summary>
+        /// <param name="element">The <see cref="DependencyObject"/> on which to set the value.</param>
+        /// <param name="value">A value indicating whether the selection is read-only.</param>
+        public static void SetIsReadOnly(DependencyObject element, bool value)
+        {
+            element.SetValue(IsReadOnlyProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the value of the <see cref="IsReadOnlyProperty"/> attached property from the supplied <paramref name="element"/>.
+        /// </summary>
+        /// <param name="element">The <see cref="DependencyObject"/> from which to read the value.</param>
+        /// <returns>A value indicating whether the selection is read-only.</returns>
+        public static bool GetIsReadOnly(DependencyObject element)
+        {
+            return (bool)element.GetValue(IsReadOnlyProperty);
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/Behaviours/CategorySelectionGridProperties.cs
+++ b/CDP4Composition/Mvvm/Behaviours/CategorySelectionGridProperties.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="CategorySelectionGridProperties.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
-//
-//    This file is part of COMET-IME Community Edition.
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//             
+//    This file is part of COMET-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //

--- a/CDP4Composition/Mvvm/Behaviours/ColumnChooserBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/ColumnChooserBehavior.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+// <copyright file="ColumnChooserBehavior.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt

--- a/CDP4Composition/Mvvm/Behaviours/ColumnChooserBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/ColumnChooserBehavior.cs
@@ -1,0 +1,131 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ColumnChooserBehavior.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2024 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
+//
+//    This file is part of COMET-IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Mvvm.Behaviours
+{
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Media.Imaging;
+
+    using DevExpress.Mvvm.UI.Interactivity;
+    using DevExpress.Xpf.Grid;
+
+    /// <summary>
+    /// A <see cref="Behavior{T}"/> that turns a <see cref="Button"/> into a "Column Chooser" button for a bound
+    /// <see cref="DataViewBase"/>: clicking it shows the grid's column chooser (the same dialog reachable from the grid's
+    /// right-click header menu) and the button is given the same glyph that the menu item uses. Keeping this logic in a
+    /// behavior avoids placing code in the view's code-behind.
+    /// </summary>
+    public class ColumnChooserBehavior : Behavior<Button>
+    {
+        /// <summary>
+        /// The name of the embedded resource in the DevExpress grid assembly that holds the column-chooser glyph used by
+        /// the grid's right-click header menu.
+        /// </summary>
+        private const string ColumnChooserImageResourceName = "DevExpress.Xpf.Grid.Images.ItemColumnChooser.png";
+
+        /// <summary>
+        /// The <see cref="DependencyProperty"/> for the <see cref="View"/>.
+        /// </summary>
+        public static readonly DependencyProperty ViewProperty =
+            DependencyProperty.Register(
+                nameof(View),
+                typeof(DataViewBase),
+                typeof(ColumnChooserBehavior),
+                new PropertyMetadata(null));
+
+        /// <summary>
+        /// Gets or sets the <see cref="DataViewBase"/> whose column chooser is shown when the <see cref="Button"/> is clicked.
+        /// </summary>
+        public DataViewBase View
+        {
+            get => (DataViewBase)this.GetValue(ViewProperty);
+            set => this.SetValue(ViewProperty, value);
+        }
+
+        /// <summary>
+        /// Executes when this behavior is attached to its <see cref="Button"/>.
+        /// </summary>
+        protected override void OnAttached()
+        {
+            base.OnAttached();
+
+            this.SetColumnChooserGlyph();
+            this.AssociatedObject.Click += this.OnClick;
+        }
+
+        /// <summary>
+        /// Executes when this behavior is detached from its <see cref="Button"/>.
+        /// </summary>
+        protected override void OnDetaching()
+        {
+            this.AssociatedObject.Click -= this.OnClick;
+
+            base.OnDetaching();
+        }
+
+        /// <summary>
+        /// Handles the click of the <see cref="Button"/> by showing the column chooser of the bound <see cref="View"/>.
+        /// </summary>
+        /// <param name="sender">The <see cref="Button"/>.</param>
+        /// <param name="e">The <see cref="RoutedEventArgs"/>.</param>
+        private void OnClick(object sender, RoutedEventArgs e)
+        {
+            this.View?.ShowColumnChooser();
+        }
+
+        /// <summary>
+        /// Replaces the textual content of the <see cref="Button"/> with the same glyph that the grid's right-click header
+        /// menu uses. The textual content is kept as a fallback if the glyph cannot be loaded.
+        /// </summary>
+        private void SetColumnChooserGlyph()
+        {
+            try
+            {
+                using (var stream = typeof(GridControl).Assembly.GetManifestResourceStream(ColumnChooserImageResourceName))
+                {
+                    if (stream == null)
+                    {
+                        return;
+                    }
+
+                    var bitmap = new BitmapImage();
+                    bitmap.BeginInit();
+                    bitmap.CacheOption = BitmapCacheOption.OnLoad;
+                    bitmap.StreamSource = stream;
+                    bitmap.EndInit();
+                    bitmap.Freeze();
+
+                    this.AssociatedObject.Content = new Image { Source = bitmap, Width = 16, Height = 16 };
+                }
+            }
+            catch
+            {
+                // keep the textual fallback content if the glyph cannot be loaded
+            }
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/Behaviours/ColumnChooserBehavior.cs
+++ b/CDP4Composition/Mvvm/Behaviours/ColumnChooserBehavior.cs
@@ -1,11 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ColumnChooserBehavior.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+// <copyright file="CategorySelectionGrid.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
-//              Rowan de Voogt
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Fixes #72 and #1043: 
Replaces the category tab's name-only list box with a reusable grid (CategorySelectionGrid) showing short name, name and super categories and plus hidden Container RDL/Definition columns reachable via a Column Chooser button with check-box selection, deprecation rules, Select-All, and an initial sort of applied-first then alphabetical by name.

Reuses the same grid for the Category dialog's Super Categories tab, and fixes that tab so a category can no longer be selected as a super-category of itself or of one of its own descendants.
All selection/column-chooser logic lives in behaviours and an attached-property class;
