### PR TITLE
Fixed issue #760 IME Exception when drag and dropping categories

### DIFF
--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionTreeRows/ParameterRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionTreeRows/ParameterRowViewModelTestFixture.cs
@@ -1,10 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterRowViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -433,6 +433,23 @@ namespace CDP4EngineeringModel.Tests.ViewModels.ElementDefinitionTreeRows
             row.CreateCloneAndWrite(ParameterSwitchKind.REFERENCE, "Switch");
 
             this.session.Verify(x => x.Write(It.Is<OperationContainer>(op => ((CDP4Common.DTO.ParameterValueSet)op.Operations.Single().ModifiedThing).ValueSwitch == ParameterSwitchKind.REFERENCE)));
+        }
+
+        [Test]
+        public void VerifyThatUpdatePropertiesDoesNotThrowWhenTheIterationIsNotOpen()
+        {
+             this.parameter.ParameterSubscription.Add(new ParameterSubscription(Guid.NewGuid(), this.assembler.Cache, this.uri) { Owner = this.someotherDomain });
+
+            var row = new ParameterRowViewModel(this.parameter, this.session.Object, null, false);
+
+            // OpenIterations is empty (see Setup), so when the row reacts to the update of its parameter the iteration
+            // cannot be resolved and the owner tuple is null
+            var revision = typeof(Thing).GetProperty("RevisionNumber");
+            revision.SetValue(this.parameter, 10);
+
+            Assert.DoesNotThrow(() => this.messageBus.SendObjectChangeEvent(this.parameter, EventKind.Updated));
+
+            row.Dispose();
         }
 
         [Test]

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionTreeRows/ParameterOrOverrideBaseRowViewModel.cs
@@ -1,10 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOrOverrideBaseRowViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -257,7 +257,12 @@ namespace CDP4EngineeringModel.ViewModels
             this.SetOwnerValue();
 
             // refresh the container row if this is replaced by a subscription
-            this.Session.OpenIterations.TryGetValue(this.Thing.GetContainerOfType<Iteration>(), out var tuple);
+            var iteration = this.Thing.GetContainerOfType<Iteration>();
+
+            if (iteration == null || !this.Session.OpenIterations.TryGetValue(iteration, out var tuple) || tuple == null)
+            {
+                return;
+            }
 
             if (this.Thing.ParameterSubscription.Any(x => x.Owner == tuple.Item1))
             {

--- a/ProductTree.Tests/ProductTreeRows/ParameterOrOverrideBaseRowViewModelTestFixture.cs
+++ b/ProductTree.Tests/ProductTreeRows/ParameterOrOverrideBaseRowViewModelTestFixture.cs
@@ -1,10 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOrOverrideBaseRowViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET-IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -593,6 +593,26 @@ namespace CDP4ProductTree.Tests.ProductTreeRows
             vm.DragOver(dropinfo.Object);
 
             this.thingCreator.Verify(x => x.CreateBinaryRelationshipForRequirementVerification(It.IsAny<ISession>(), It.IsAny<Iteration>(), It.IsAny<ParameterOrOverrideBase>(), It.IsAny<RelationalExpression>()), Times.Never);
+        }
+
+        [Test]
+        public void VerifyThatSetUsageDoesNotThrowWhenTheIterationIsNotOpen()
+        {
+            var published = new ValueArray<string>(new List<string> { "manual" }, this.valueset);
+            var actual = new ValueArray<string>(new List<string> { "manual" }, this.valueset);
+
+            this.valueset.Published = published;
+            this.valueset.Manual = actual;
+            this.valueset.ValueSwitch = ParameterSwitchKind.MANUAL;
+            this.parameter1.ValueSet.Add(this.valueset);
+
+            var subscription = new ParameterSubscription(Guid.NewGuid(), this.cache, this.uri) { Owner = this.domain };
+            this.parameter1.ParameterSubscription.Add(subscription);
+
+            // OpenIterations is empty (see Setup), so the iteration cannot be resolved and the owner tuple is null
+            ParameterRowViewModel row = null;
+            Assert.DoesNotThrow(() => row = new ParameterRowViewModel(this.parameter1, this.option, this.session.Object, null));
+            Assert.AreEqual(ParameterUsageKind.Unused, row.Usage);
         }
 
         [Test]

--- a/ProductTree/ViewModels/ProductTreeRows/ParameterOrOverrideBaseRowViewModel.cs
+++ b/ProductTree/ViewModels/ProductTreeRows/ParameterOrOverrideBaseRowViewModel.cs
@@ -1,10 +1,10 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterOrOverrideBaseRowViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -425,7 +425,12 @@ namespace CDP4ProductTree.ViewModels
         /// </summary>
         private void SetUsage()
         {
-            this.Session.OpenIterations.TryGetValue(this.Thing.GetContainerOfType<Iteration>(), out var tuple);
+            var iteration = this.Thing.GetContainerOfType<Iteration>();
+
+            if (iteration == null || !this.Session.OpenIterations.TryGetValue(iteration, out var tuple) || tuple == null)
+            {
+               return;
+            }
 
             var subscribeTo = this.Thing.ParameterSubscription.Any(x => x.Owner == tuple.Item1);
             var subscribedByOthers = this.Thing.ParameterSubscription.Any(x => x.Owner != tuple.Item1);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

What caused the error SetUsage() / UpdateProperties() read Session.OpenIterations.TryGetValue(iteration, out var tuple) and then dereferenced tuple.Item1, but tuple is null whenever the iteration isn't open. During a category drag-and-drop the Assembler briefly swaps in a new Iteration revision that isn't yet the dictionary key, so tuple is null. It only NRE'd when the parameter had a ParameterSubscription (the .Any(predicate) short-circuits on an empty collection), which is why it was intermittent and never caught by tests.

What changed Guarded both row view-models (CDP4ProductTree and CDP4EngineeringModel ParameterOrOverrideBaseRowViewModel) to bail out cleanly when the iteration is null or not in OpenIterations, instead of dereferencing the null tuple. 
