### PR TITLE
Possible fix #78 added a tab to show parameters and parameterGroups directly in elementdefinitiondialog

### DIFF
--- a/EngineeringModel.Tests/Dialogs/ElementDefinitionDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/ElementDefinitionDialogViewModelTestFixture.cs
@@ -291,6 +291,28 @@ namespace CDP4EngineeringModel.Tests.Dialogs
         }
 
         [Test]
+        public void VerifyThatUsedParameterTypesAreExcludedFromTheAddList()
+        {
+            this.elementDefinition.Owner = this.domainOfExpertise;
+
+            var elementDefinitionDialogViewModel = new ElementDefinitionDialogViewModel(this.elementDefinition, this.thingTransaction, this.session.Object, true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            Assert.That(elementDefinitionDialogViewModel.PossibleParameterTypesToAdd, Does.Contain(this.parameterType));
+
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = this.parameterType,
+                Owner = this.domainOfExpertise
+            };
+
+            this.elementDefinition.Parameter.Add(parameter);
+
+            var dialogWithUsedType = new ElementDefinitionDialogViewModel(this.elementDefinition, this.thingTransaction, this.session.Object, true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            Assert.That(dialogWithUsedType.PossibleParameterTypesToAdd, Does.Not.Contain(this.parameterType));
+        }
+
+        [Test]
         public async Task VerifyThatDeleteParameterRemovesItFromTheTree()
         {
             this.elementDefinition.Owner = this.domainOfExpertise;

--- a/EngineeringModel.Tests/Dialogs/ElementDefinitionDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/ElementDefinitionDialogViewModelTestFixture.cs
@@ -1,8 +1,9 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ElementDefinitionDialogViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
 //
 //    This file is part of COMET-IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -74,6 +75,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
         private ElementDefinition elementDefinition;
         private CDPMessageBus messageBus;
+        private Assembler assembler;
+        private SimpleQuantityKind parameterType;
 
         [SetUp]
         public void SetUp()
@@ -82,22 +85,31 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             this.messageBus = new CDPMessageBus();
             this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+            this.assembler = new Assembler(this.uri, this.messageBus);
 
-            this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();            
+            this.thingDialogNavigationService = new Mock<IThingDialogNavigationService>();
             this.session = new Mock<ISession>();
             this.permissionService = new Mock<IPermissionService>();
+            this.permissionService.Setup(x => x.CanRead(It.IsAny<Thing>())).Returns(true);
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
             
             this.domainOfExpertise = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "system", ShortName = "SYS" };
 
-            var participant = new Participant(Guid.NewGuid(), this.cache, this.uri);
+            var person = new Person(Guid.NewGuid(), this.cache, this.uri);
+            this.session.Setup(x => x.ActivePerson).Returns(person);
+
+            var participant = new Participant(Guid.NewGuid(), this.cache, this.uri) { Person = person };
             participant.Domain.Add(domainOfExpertise);
 
             var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), this.cache, this.uri);
+            engineeringModelSetup.Participant.Add(participant);
             engineeringModelSetup.ActiveDomain.Add(this.domainOfExpertise);
             var srdl = new SiteReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri) { Name = "testRDL", ShortName = "test" };
             var category = new Category(Guid.NewGuid(), this.cache, this.uri) { Name = "test Category", ShortName = "testCategory" };
             category.PermissibleClass.Add(ClassKind.ElementDefinition);
             srdl.DefinedCategory.Add(category);
+            this.parameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { Name = "mass", ShortName = "m" };
+            srdl.ParameterType.Add(this.parameterType);
             var mrdl = new ModelReferenceDataLibrary(Guid.NewGuid(), this.cache, this.uri) { RequiredRdl = srdl };
             engineeringModelSetup.RequiredRdl.Add(mrdl);
             srdl.DefinedCategory.Add(new Category(Guid.NewGuid(), this.cache, this.uri));
@@ -123,6 +135,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             this.session.Setup(x => x.OpenIterations).Returns(openIterations);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+            this.session.Setup(x => x.Assembler).Returns(this.assembler);
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
 
             dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());
         }
@@ -195,6 +209,143 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             await elementDefinitionDialogViewModel.OkCommand.Execute();
 
             this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()));
+        }
+
+        [Test]
+        public void VerifyThatParameterRowsShowsGroupsAndParametersButNotUsages()
+        {
+            this.elementDefinition.Owner = this.domainOfExpertise;
+
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = this.parameterType,
+                Owner = this.domainOfExpertise
+            };
+
+            this.elementDefinition.Parameter.Add(parameter);
+
+            var parameterGroup = new ParameterGroup(Guid.NewGuid(), this.cache, this.uri) { Name = "group" };
+            this.elementDefinition.ParameterGroup.Add(parameterGroup);
+
+            var referencedElementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "ref", ShortName = "ref", Owner = this.domainOfExpertise };
+            this.engineeringModel.Iteration.First().Element.Add(referencedElementDefinition);
+
+            var elementUsage = new ElementUsage(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Name = "usage",
+                ShortName = "usage",
+                Owner = this.domainOfExpertise,
+                ElementDefinition = referencedElementDefinition
+            };
+
+            this.elementDefinition.ContainedElement.Add(elementUsage);
+
+            var elementDefinitionDialogViewModel = new ElementDefinitionDialogViewModel(this.elementDefinition, this.thingTransaction, this.session.Object, true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            var rowThings = elementDefinitionDialogViewModel.ParameterRows.Select(x => x.Thing).ToList();
+
+            Assert.That(rowThings, Does.Contain(parameter));
+            Assert.That(rowThings, Does.Contain(parameterGroup));
+            Assert.That(rowThings, Does.Not.Contain(elementUsage));
+        }
+
+        [Test]
+        public void VerifyThatAParameterIsNestedUnderItsGroup()
+        {
+            this.elementDefinition.Owner = this.domainOfExpertise;
+
+            var parameterGroup = new ParameterGroup(Guid.NewGuid(), this.cache, this.uri) { Name = "group" };
+            this.elementDefinition.ParameterGroup.Add(parameterGroup);
+
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = this.parameterType,
+                Owner = this.domainOfExpertise,
+                Group = parameterGroup
+            };
+
+            this.elementDefinition.Parameter.Add(parameter);
+
+            var elementDefinitionDialogViewModel = new ElementDefinitionDialogViewModel(this.elementDefinition, this.thingTransaction, this.session.Object, true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            var groupRow = elementDefinitionDialogViewModel.ParameterRows.Single(x => Equals(x.Thing, parameterGroup));
+
+            Assert.That(elementDefinitionDialogViewModel.ParameterRows.Select(x => x.Thing), Does.Not.Contain(parameter));
+            Assert.That(groupRow.ContainedRows.Select(x => x.Thing), Does.Contain(parameter));
+        }
+
+        [Test]
+        public async Task VerifyThatCreateParameterStagesAParameterAndShowsItInTheTree()
+        {
+            this.elementDefinition.Owner = this.domainOfExpertise;
+
+            var elementDefinitionDialogViewModel = new ElementDefinitionDialogViewModel(this.elementDefinition, this.thingTransaction, this.session.Object, true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            Assert.That(elementDefinitionDialogViewModel.SelectedParameterTypeToAdd, Is.EqualTo(this.parameterType));
+
+            await elementDefinitionDialogViewModel.CreateParameterTreeCommand.Execute();
+
+            Assert.That(this.elementDefinition.Parameter, Has.Count.EqualTo(1));
+            Assert.That(this.elementDefinition.Parameter.Single().ParameterType, Is.EqualTo(this.parameterType));
+            Assert.That(elementDefinitionDialogViewModel.ParameterRows.Select(x => x.Thing), Does.Contain(this.elementDefinition.Parameter.Single()));
+        }
+
+        [Test]
+        public async Task VerifyThatDeleteParameterRemovesItFromTheTree()
+        {
+            this.elementDefinition.Owner = this.domainOfExpertise;
+
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = this.parameterType,
+                Owner = this.domainOfExpertise
+            };
+
+            this.elementDefinition.Parameter.Add(parameter);
+
+            var elementDefinitionDialogViewModel = new ElementDefinitionDialogViewModel(this.elementDefinition, this.thingTransaction, this.session.Object, true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            elementDefinitionDialogViewModel.SelectedParameterTreeRow = elementDefinitionDialogViewModel.ParameterRows.Single(x => Equals(x.Thing, parameter));
+
+            await elementDefinitionDialogViewModel.DeleteParameterTreeCommand.Execute();
+
+            Assert.That(this.elementDefinition.Parameter, Does.Not.Contain(parameter));
+            Assert.That(elementDefinitionDialogViewModel.ParameterRows.Select(x => x.Thing), Does.Not.Contain(parameter));
+        }
+
+        [Test]
+        public async Task VerifyThatEditParameterTreeCommandEditsWithinTheDialogTransaction()
+        {
+            this.elementDefinition.Owner = this.domainOfExpertise;
+
+            var parameter = new Parameter(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = this.parameterType,
+                Owner = this.domainOfExpertise
+            };
+
+            this.elementDefinition.Parameter.Add(parameter);
+
+            IThingTransaction usedTransaction = null;
+
+            this.thingDialogNavigationService
+                .Setup(x => x.Navigate(It.IsAny<Thing>(), It.IsAny<IThingTransaction>(), It.IsAny<ISession>(), false, ThingDialogKind.Update, It.IsAny<IThingDialogNavigationService>(), It.IsAny<Thing>(), It.IsAny<IEnumerable<Thing>>()))
+                .Callback<Thing, IThingTransaction, ISession, bool, ThingDialogKind, IThingDialogNavigationService, Thing, IEnumerable<Thing>>((t, tr, s, r, k, n, c, ch) => usedTransaction = tr)
+                .Returns(true);
+
+            var elementDefinitionDialogViewModel = new ElementDefinitionDialogViewModel(this.elementDefinition, this.thingTransaction, this.session.Object, true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.iterationClone);
+
+            elementDefinitionDialogViewModel.SelectedParameterTreeRow = elementDefinitionDialogViewModel.ParameterRows.Single(row => Equals(row.Thing, parameter));
+
+            await elementDefinitionDialogViewModel.EditParameterTreeCommand.Execute();
+
+            // the edit is routed through the child dialog as a non-root (isRoot = false) navigation, so the change
+            // is part of this dialog's transaction chain rather than an independent live write.
+            this.thingDialogNavigationService.Verify(
+                x => x.Navigate(It.IsAny<Thing>(), It.IsAny<IThingTransaction>(), It.IsAny<ISession>(), false, ThingDialogKind.Update, It.IsAny<IThingDialogNavigationService>(), It.IsAny<Thing>(), It.IsAny<IEnumerable<Thing>>()),
+                Times.Once);
+
+            Assert.That(usedTransaction, Is.Not.Null);
         }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/ElementDefinitionDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ElementDefinitionDialogViewModel.cs
@@ -183,7 +183,9 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
-        /// Gets the possible <see cref="ParameterType"/>s that a new <see cref="Parameter"/> can be created from.
+        /// Gets the <see cref="ParameterType"/>s from which a new <see cref="Parameter"/> can be created.
+        /// <see cref="ParameterType"/>s that are already used by a <see cref="Parameter"/> of this <see cref="ElementDefinition"/>
+        /// are excluded, as the same <see cref="ParameterType"/> may not be applied twice.
         /// </summary>
         public ReactiveList<ParameterType> PossibleParameterTypesToAdd { get; private set; }
 
@@ -197,7 +199,7 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
-        /// Gets the command to create a <see cref="Parameter"/> as part of this dialog's transaction.
+        /// Gets the command to create a <see cref="Parameter"/> of the <see cref="SelectedParameterTypeToAdd"/> as part of this dialog's transaction.
         /// </summary>
         public ReactiveCommand<Unit, Unit> CreateParameterTreeCommand { get; private set; }
 
@@ -235,8 +237,8 @@ namespace CDP4EngineeringModel.ViewModels
 
             this.PopulatePossibleCategories();
             this.PopulatePossibleOrganizations();
-            this.PopulatePossibleParameterTypesToAdd();
             this.PopulateParameterRows();
+            this.PopulatePossibleParameterTypesToAdd();
         }
 
         /// <summary>
@@ -252,7 +254,7 @@ namespace CDP4EngineeringModel.ViewModels
             var canInspectSelected = this.WhenAnyValue(vm => vm.SelectedParameterTreeRow).Select(row => row != null);
 
             this.CreateParameterTreeCommand = ReactiveCommandCreator.Create(this.CreateParameter, canCreateParameter);
-            this.CreateParameterGroupTreeCommand = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<ParameterGroup>(this.PopulateParameterRows), canCreateGroup);
+            this.CreateParameterGroupTreeCommand = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<ParameterGroup>(this.RefreshParameterTree), canCreateGroup);
             this.EditParameterTreeCommand = ReactiveCommandCreator.Create(() => this.ExecuteEditCommand(this.SelectedParameterTreeRow.Thing, this.PopulateParameterRows), canModifySelected);
             this.DeleteParameterTreeCommand = ReactiveCommandCreator.Create(this.DeleteSelectedParameterTreeRow, canModifySelected);
             this.InspectParameterTreeCommand = ReactiveCommandCreator.Create(() => this.ExecuteInspectCommand(this.SelectedParameterTreeRow.Thing), canInspectSelected);
@@ -275,7 +277,16 @@ namespace CDP4EngineeringModel.ViewModels
             this.Thing.Parameter.Add(parameter);
             this.transaction.Create(parameter);
 
+            this.RefreshParameterTree();
+        }
+
+        /// <summary>
+        /// Rebuilds the parameter tree and the list of <see cref="ParameterType"/>s that are still available for creation.
+        /// </summary>
+        private void RefreshParameterTree()
+        {
             this.PopulateParameterRows();
+            this.PopulatePossibleParameterTypesToAdd();
         }
 
         /// <summary>
@@ -297,11 +308,12 @@ namespace CDP4EngineeringModel.ViewModels
                     break;
             }
 
-            this.PopulateParameterRows();
+            this.RefreshParameterTree();
         }
 
         /// <summary>
-        /// Populates the <see cref="PossibleParameterTypesToAdd"/> from the model reference data libraries.
+        /// Populates the <see cref="PossibleParameterTypesToAdd"/> from the model reference data libraries, excluding the
+        /// <see cref="ParameterType"/>s that are already used by a <see cref="Parameter"/> of this <see cref="ElementDefinition"/>.
         /// </summary>
         private void PopulatePossibleParameterTypesToAdd()
         {
@@ -313,7 +325,12 @@ namespace CDP4EngineeringModel.ViewModels
             var parameterTypes = new List<ParameterType>(mrdl.ParameterType);
             parameterTypes.AddRange(mrdl.GetRequiredRdls().SelectMany(rdl => rdl.ParameterType).Except(parameterTypes));
 
-            this.PossibleParameterTypesToAdd.AddRange(parameterTypes.OrderBy(p => p.ShortName));
+            var usedParameterTypeIids = this.Thing.Parameter.Select(p => p.ParameterType.Iid).ToList();
+
+            this.PossibleParameterTypesToAdd.AddRange(parameterTypes
+                .Where(p => !usedParameterTypeIids.Contains(p.Iid))
+                .OrderBy(p => p.ShortName));
+
             this.SelectedParameterTypeToAdd = this.PossibleParameterTypesToAdd.FirstOrDefault();
         }
 

--- a/EngineeringModel/ViewModels/Dialogs/ElementDefinitionDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ElementDefinitionDialogViewModel.cs
@@ -1,8 +1,9 @@
 ﻿// -------------------------------------------------------------------------------------------------
 // <copyright file="ElementDefinitionDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
 //
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -28,20 +29,22 @@ namespace CDP4EngineeringModel.ViewModels
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reactive;
+    using System.Reactive.Linq;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
-    
+
     using CDP4Dal.Operations;
-    
+
     using CDP4Composition.Attributes;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
 
     using CDP4Dal;
-    
+
     using ReactiveUI;
 
     /// <summary>
@@ -69,6 +72,16 @@ namespace CDP4EngineeringModel.ViewModels
         /// Backing field for see <see cref="AreOrganizationsVisible"/>
         /// </summary>
         private bool areOrganizationsVisible;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedParameterTreeRow"/>
+        /// </summary>
+        private IRowViewModelBase<Thing> selectedParameterTreeRow;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedParameterTypeToAdd"/>
+        /// </summary>
+        private ParameterType selectedParameterTypeToAdd;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ElementDefinitionDialogViewModel"/> class.
@@ -155,6 +168,60 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
+        /// Gets the <see cref="ParameterGroup"/> and <see cref="Parameter"/> rows shown on the Parameters tab.
+        /// The rows are reused from the Element Definition browser so that the same hierarchy and properties are displayed.
+        /// </summary>
+        public ReactiveList<IRowViewModelBase<Thing>> ParameterRows { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the row that is selected in the Parameters tree.
+        /// </summary>
+        public IRowViewModelBase<Thing> SelectedParameterTreeRow
+        {
+            get { return this.selectedParameterTreeRow; }
+            set { this.RaiseAndSetIfChanged(ref this.selectedParameterTreeRow, value); }
+        }
+
+        /// <summary>
+        /// Gets the possible <see cref="ParameterType"/>s that a new <see cref="Parameter"/> can be created from.
+        /// </summary>
+        public ReactiveList<ParameterType> PossibleParameterTypesToAdd { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ParameterType"/> selected for the creation of a new <see cref="Parameter"/>.
+        /// </summary>
+        public ParameterType SelectedParameterTypeToAdd
+        {
+            get { return this.selectedParameterTypeToAdd; }
+            set { this.RaiseAndSetIfChanged(ref this.selectedParameterTypeToAdd, value); }
+        }
+
+        /// <summary>
+        /// Gets the command to create a <see cref="Parameter"/> as part of this dialog's transaction.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> CreateParameterTreeCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command to create a <see cref="ParameterGroup"/> as part of this dialog's transaction.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> CreateParameterGroupTreeCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command to edit the selected parameter or parameter group as part of this dialog's transaction.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> EditParameterTreeCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command to delete the selected parameter or parameter group as part of this dialog's transaction.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> DeleteParameterTreeCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the command to inspect the selected parameter or parameter group.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> InspectParameterTreeCommand { get; private set; }
+
+        /// <summary>
         /// Initialize the dialog
         /// </summary>
         protected override void Initialize()
@@ -163,9 +230,145 @@ namespace CDP4EngineeringModel.ViewModels
 
             this.PossibleOrganizations = new List<Organization>();
             this.SelectedOrganizations = new ReactiveList<Organization>();
+            this.ParameterRows = new ReactiveList<IRowViewModelBase<Thing>>();
+            this.PossibleParameterTypesToAdd = new ReactiveList<ParameterType>();
 
             this.PopulatePossibleCategories();
             this.PopulatePossibleOrganizations();
+            this.PopulatePossibleParameterTypesToAdd();
+            this.PopulateParameterRows();
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="ReactiveCommand"/>s of this dialog
+        /// </summary>
+        protected override void InitializeCommands()
+        {
+            base.InitializeCommands();
+
+            var canCreateParameter = this.WhenAnyValue(vm => vm.SelectedParameterTypeToAdd, vm => vm.IsReadOnly, (parameterType, readOnly) => parameterType != null && !readOnly);
+            var canCreateGroup = this.WhenAnyValue(vm => vm.IsReadOnly, readOnly => !readOnly);
+            var canModifySelected = this.WhenAnyValue(vm => vm.SelectedParameterTreeRow, vm => vm.IsReadOnly, (row, readOnly) => row != null && !readOnly);
+            var canInspectSelected = this.WhenAnyValue(vm => vm.SelectedParameterTreeRow).Select(row => row != null);
+
+            this.CreateParameterTreeCommand = ReactiveCommandCreator.Create(this.CreateParameter, canCreateParameter);
+            this.CreateParameterGroupTreeCommand = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<ParameterGroup>(this.PopulateParameterRows), canCreateGroup);
+            this.EditParameterTreeCommand = ReactiveCommandCreator.Create(() => this.ExecuteEditCommand(this.SelectedParameterTreeRow.Thing, this.PopulateParameterRows), canModifySelected);
+            this.DeleteParameterTreeCommand = ReactiveCommandCreator.Create(this.DeleteSelectedParameterTreeRow, canModifySelected);
+            this.InspectParameterTreeCommand = ReactiveCommandCreator.Create(() => this.ExecuteInspectCommand(this.SelectedParameterTreeRow.Thing), canInspectSelected);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Parameter"/> of the <see cref="SelectedParameterTypeToAdd"/> as part of this dialog's
+        /// transaction. A blank Parameter cannot be created through the Parameter dialog (it requires a ParameterType),
+        /// so the Parameter is staged directly on the transaction, mirroring how the browser creates one.
+        /// </summary>
+        private void CreateParameter()
+        {
+            var parameter = new Parameter(Guid.NewGuid(), this.Thing.Cache, this.Thing.IDalUri)
+            {
+                Owner = this.SelectedOwner,
+                ParameterType = this.SelectedParameterTypeToAdd,
+                Scale = (this.SelectedParameterTypeToAdd as QuantityKind)?.DefaultScale
+            };
+
+            this.Thing.Parameter.Add(parameter);
+            this.transaction.Create(parameter);
+
+            this.PopulateParameterRows();
+        }
+
+        /// <summary>
+        /// Deletes the selected <see cref="Parameter"/> or <see cref="ParameterGroup"/> as part of this dialog's
+        /// transaction and refreshes the tree.
+        /// </summary>
+        private void DeleteSelectedParameterTreeRow()
+        {
+            var thing = this.SelectedParameterTreeRow.Thing;
+            this.transaction.Delete(thing.Clone(false), this.Thing);
+
+            switch (thing)
+            {
+                case Parameter parameter:
+                    this.Thing.Parameter.Remove(parameter);
+                    break;
+                case ParameterGroup parameterGroup:
+                    this.Thing.ParameterGroup.Remove(parameterGroup);
+                    break;
+            }
+
+            this.PopulateParameterRows();
+        }
+
+        /// <summary>
+        /// Populates the <see cref="PossibleParameterTypesToAdd"/> from the model reference data libraries.
+        /// </summary>
+        private void PopulatePossibleParameterTypesToAdd()
+        {
+            this.PossibleParameterTypesToAdd.Clear();
+
+            var model = (EngineeringModel)this.Container.Container;
+            var mrdl = model.EngineeringModelSetup.RequiredRdl.Single();
+
+            var parameterTypes = new List<ParameterType>(mrdl.ParameterType);
+            parameterTypes.AddRange(mrdl.GetRequiredRdls().SelectMany(rdl => rdl.ParameterType).Except(parameterTypes));
+
+            this.PossibleParameterTypesToAdd.AddRange(parameterTypes.OrderBy(p => p.ShortName));
+            this.SelectedParameterTypeToAdd = this.PossibleParameterTypesToAdd.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Builds the parameter / parameter-group tree shown on the Parameters tab. The rows are reused from the Element
+        /// Definition browser (so the same properties are shown), but the nesting is built here, keyed by <see cref="Thing.Iid"/>
+        /// so that it survives the cloning performed by the transaction, and it reflects the parameters and groups that are
+        /// currently staged on this dialog's <see cref="Thing"/>.
+        /// </summary>
+        private void PopulateParameterRows()
+        {
+            foreach (var row in this.ParameterRows)
+            {
+                row.Dispose();
+            }
+
+            this.ParameterRows.Clear();
+
+            var currentDomain = this.Session.QuerySelectedDomainOfExpertise((Iteration)this.Container);
+
+            var groupRowByIid = new Dictionary<Guid, ParameterGroupRowViewModel>();
+            var groups = this.Thing.ParameterGroup.ToList();
+
+            foreach (var group in groups)
+            {
+                groupRowByIid[group.Iid] = new ParameterGroupRowViewModel(group, currentDomain, this.Session, this);
+            }
+
+            foreach (var group in groups)
+            {
+                var groupRow = groupRowByIid[group.Iid];
+
+                if (group.ContainingGroup != null && groupRowByIid.TryGetValue(group.ContainingGroup.Iid, out var parentRow))
+                {
+                    parentRow.ContainedRows.Add(groupRow);
+                }
+                else
+                {
+                    this.ParameterRows.Add(groupRow);
+                }
+            }
+
+            foreach (var parameter in this.Thing.Parameter)
+            {
+                var parameterRow = new ParameterRowViewModel(parameter, this.Session, this, true);
+
+                if (parameter.Group != null && groupRowByIid.TryGetValue(parameter.Group.Iid, out var groupRow))
+                {
+                    groupRow.ContainedRows.Add(parameterRow);
+                }
+                else
+                {
+                    this.ParameterRows.Add(parameterRow);
+                }
+            }
         }
 
         /// <summary>
@@ -289,6 +492,25 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.UpdateOkCanExecute();
             this.OkCanExecute = this.OkCanExecute && this.SelectedOwner != null;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// a value indicating whether the class is being disposed of
+        /// </param>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                foreach (var row in this.ParameterRows)
+                {
+                    row.Dispose();
+                }
+            }
         }
     }
 }

--- a/EngineeringModel/Views/Dialogs/ElementDefinitionDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ElementDefinitionDialog.xaml
@@ -1,14 +1,20 @@
-﻿<dx:DXWindow x:Class="CDP4EngineeringModel.Views.ElementDefinitionDialog"
+<dx:DXWindow x:Class="CDP4EngineeringModel.Views.ElementDefinitionDialog"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
+             xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
+             xmlns:dynamic="clr-namespace:System.Dynamic;assembly=System.Core"
              xmlns:items="clr-namespace:CDP4CommonView.Items;assembly=CDP4Composition"
              xmlns:lc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
              xmlns:converters="clr-namespace:CDP4Composition.Converters;assembly=CDP4Composition"
+             xmlns:viewModels="clr-namespace:CDP4EngineeringModel.ViewModels"
+             xmlns:selectors="clr-namespace:CDP4EngineeringModel.Selectors"
              Width="600"
              Height="450"
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"
@@ -20,6 +26,13 @@
             </ResourceDictionary.MergedDictionaries>
             <converters:NotConverter x:Key="NotConverter" />
             <converters:ReactiveOrganizationToObjectListConverter x:Key="ReactiveOrganizationToObjectListConverter" />
+            <selectors:ElementDefinitionTreeListNodeImageSelector x:Key="ElementDefinitionTreeListNodeSelector" />
+
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:ParameterGroupRowViewModel}" ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}" />
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:ParameterOrOverrideBaseRowViewModel}" ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}" />
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:ParameterSubscriptionRowViewModel}" ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}" />
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:ParameterOptionRowViewModel}" ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}" />
+            <HierarchicalDataTemplate DataType="{x:Type viewModels:ParameterStateRowViewModel}" ItemsSource="{Binding ContainedRows, UpdateSourceTrigger=PropertyChanged}" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
     <lc:LayoutControl Margin="5"
@@ -42,7 +55,7 @@
                                    IsReadOnly="{Binding IsReadOnly}" />
                 </lc:LayoutItem>
                 <lc:LayoutItem Label="Model Code: ">
-                    <dxe:TextEdit Name="ModelCode" 
+                    <dxe:TextEdit Name="ModelCode"
                                   Text="{Binding Path=ModelCode, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
                                   IsReadOnly="True"/>
                 </lc:LayoutItem>
@@ -62,6 +75,105 @@
                             <dxe:CheckedTokenComboBoxStyleSettings />
                         </dxe:ComboBoxEdit.StyleSettings>
                     </dxe:ComboBoxEdit>
+                </lc:LayoutItem>
+            </lc:LayoutGroup>
+            <lc:LayoutGroup Header="Parameters" Orientation="Vertical">
+                <lc:LayoutItem Label="New Parameter Type: ">
+                    <dxe:ComboBoxEdit Name="ParameterTypeToAdd"
+                                      MaxWidth="250"
+                                      HorizontalAlignment="Left"
+                                      DisplayMember="Name"
+                                      EditValue="{Binding SelectedParameterTypeToAdd, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      IsEnabled="{Binding IsReadOnly, Converter={StaticResource NotConverter}}"
+                                      IsTextEditable="False"
+                                      ItemsSource="{Binding PossibleParameterTypesToAdd}"
+                                      NullText="Select a Parameter Type to add..." />
+                </lc:LayoutItem>
+                <lc:LayoutItem>
+                    <dxb:ToolBarControl Height="30" Background="Transparent">
+                        <dxb:BarButtonItem x:Name="CreateParameterButton"
+                                           Command="{Binding CreateParameterTreeCommand}"
+                                           Content="Add Parameter"
+                                           Glyph="{dx:DXImage Image=Add_16x16.png}"
+                                           Hint="Create a new Parameter of the selected Parameter Type." />
+                        <dxb:BarButtonItem x:Name="CreateParameterGroupButton"
+                                           Command="{Binding CreateParameterGroupTreeCommand}"
+                                           Content="Add Group"
+                                           Glyph="{dx:DXImage Image=AddDataSource_16x16.png}"
+                                           Hint="Create a new Parameter Group." />
+                        <dxb:BarButtonItem x:Name="EditParameterButton"
+                                           Command="{Binding EditParameterTreeCommand}"
+                                           Glyph="{dx:DXImage Image=Edit_16x16.png}"
+                                           Hint="Edit the selected Parameter or Parameter Group (Ctrl+E)." />
+                        <dxb:BarButtonItem x:Name="DeleteParameterButton"
+                                           Command="{Binding DeleteParameterTreeCommand}"
+                                           Glyph="{dx:DXImage Image=Delete_16x16.png}"
+                                           Hint="Delete the selected Parameter or Parameter Group." />
+                        <dxb:BarButtonItem x:Name="InspectParameterButton"
+                                           Command="{Binding InspectParameterTreeCommand}"
+                                           Glyph="{dx:DXImage Image=Find_16x16.png}"
+                                           Hint="Inspect the selected Parameter or Parameter Group (Ctrl+I)." />
+                    </dxb:ToolBarControl>
+                </lc:LayoutItem>
+                <lc:LayoutItem>
+                    <dxg:TreeListControl MaxWidth="700"
+                                         Height="250"
+                                         ItemsSource="{Binding ParameterRows}"
+                                         SelectedItem="{Binding SelectedParameterTreeRow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         SelectionMode="Row">
+                        <dxmvvm:Interaction.Behaviors>
+                            <dxmvvm:EventToCommand Command="{Binding EditParameterTreeCommand}" EventName="RowDoubleClick" />
+                        </dxmvvm:Interaction.Behaviors>
+                        <dxg:TreeListControl.InputBindings>
+                            <KeyBinding Gesture="CTRL+E" Command="{Binding EditParameterTreeCommand}" />
+                            <KeyBinding Gesture="CTRL+I" Command="{Binding InspectParameterTreeCommand}" />
+                        </dxg:TreeListControl.InputBindings>
+                        <dxg:TreeListControl.View>
+                            <dxg:TreeListView Name="ParameterTreeView"
+                                              AllowEditing="False"
+                                              AutoWidth="False"
+                                              ExpandCollapseNodesOnNavigation="True"
+                                              ExpandStateFieldName="IsExpanded"
+                                              FixedLineWidth="0"
+                                              HorizontalScrollbarVisibility="Auto"
+                                              NavigationStyle="Cell"
+                                              NodeImageSelector="{StaticResource ElementDefinitionTreeListNodeSelector}"
+                                              NodeImageSize="22,16"
+                                              RowIndent="22"
+                                              ShowHorizontalLines="False"
+                                              ShowIndicator="False"
+                                              ShowNodeImages="True"
+                                              ShowVerticalLines="False"
+                                              TreeDerivationMode="HierarchicalDataTemplate"
+                                              TreeLineStyle="Solid"
+                                              VerticalScrollbarVisibility="Auto">
+                                <dxg:TreeListView.FocusedRow>
+                                    <dynamic:ExpandoObject />
+                                </dxg:TreeListView.FocusedRow>
+                            </dxg:TreeListView>
+                        </dxg:TreeListControl.View>
+                        <dxg:TreeListControl.Columns>
+                            <dxg:TreeListColumn FieldName="Name" Fixed="Left">
+                                <dxg:TreeListColumn.DisplayTemplate>
+                                    <ControlTemplate>
+                                        <TextBlock Margin="5,0,0,0"
+                                                   VerticalAlignment="Center"
+                                                   Text="{Binding Path=RowData.Row.Name}" />
+                                    </ControlTemplate>
+                                </dxg:TreeListColumn.DisplayTemplate>
+                            </dxg:TreeListColumn>
+                            <dxg:TreeListColumn Width="45" FieldName="OwnerShortName" Header="Owner" />
+                            <dxg:TreeListColumn FieldName="Published" Header="Published Value" />
+                            <dxg:TreeListColumn FieldName="ScaleShortName" Header="Scale" />
+                            <dxg:TreeListColumn FieldName="Switch" Header="Switch" />
+                            <dxg:TreeListColumn FieldName="Computed" Header="Computed" />
+                            <dxg:TreeListColumn FieldName="Manual" Header="Manual" />
+                            <dxg:TreeListColumn FieldName="Reference" Header="Reference" />
+                            <dxg:TreeListColumn FieldName="Formula" Header="Formula" />
+                            <dxg:TreeListColumn FieldName="DisplayCategory" Header="Category" AllowColumnFiltering="False" />
+                            <dxg:TreeListColumn FieldName="ModelCode" Header="Model Code" />
+                        </dxg:TreeListControl.Columns>
+                    </dxg:TreeListControl>
                 </lc:LayoutItem>
             </lc:LayoutGroup>
             <items:AliasLayoutGroup />

--- a/EngineeringModel/Views/Dialogs/ElementDefinitionDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/ElementDefinitionDialog.xaml
@@ -78,19 +78,22 @@
                 </lc:LayoutItem>
             </lc:LayoutGroup>
             <lc:LayoutGroup Header="Parameters" Orientation="Vertical">
-                <lc:LayoutItem Label="New Parameter Type: ">
-                    <dxe:ComboBoxEdit Name="ParameterTypeToAdd"
-                                      MaxWidth="250"
-                                      HorizontalAlignment="Left"
-                                      DisplayMember="Name"
-                                      EditValue="{Binding SelectedParameterTypeToAdd, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                      IsEnabled="{Binding IsReadOnly, Converter={StaticResource NotConverter}}"
-                                      IsTextEditable="False"
-                                      ItemsSource="{Binding PossibleParameterTypesToAdd}"
-                                      NullText="Select a Parameter Type to add..." />
-                </lc:LayoutItem>
                 <lc:LayoutItem>
+                    <StackPanel MaxWidth="700"
+                                HorizontalAlignment="Left"
+                                Orientation="Vertical">
                     <dxb:ToolBarControl Height="30" Background="Transparent">
+                        <dxb:BarEditItem x:Name="ParameterTypeToAdd"
+                                         EditValue="{Binding SelectedParameterTypeToAdd, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                         EditWidth="200"
+                                         IsEnabled="{Binding IsReadOnly, Converter={StaticResource NotConverter}}">
+                            <dxb:BarEditItem.EditSettings>
+                                <dxe:ComboBoxEditSettings DisplayMember="Name"
+                                                          IsTextEditable="False"
+                                                          ItemsSource="{Binding PossibleParameterTypesToAdd}"
+                                                          NullText="Select a Parameter Type to add..." />
+                            </dxb:BarEditItem.EditSettings>
+                        </dxb:BarEditItem>
                         <dxb:BarButtonItem x:Name="CreateParameterButton"
                                            Command="{Binding CreateParameterTreeCommand}"
                                            Content="Add Parameter"
@@ -114,10 +117,7 @@
                                            Glyph="{dx:DXImage Image=Find_16x16.png}"
                                            Hint="Inspect the selected Parameter or Parameter Group (Ctrl+I)." />
                     </dxb:ToolBarControl>
-                </lc:LayoutItem>
-                <lc:LayoutItem>
-                    <dxg:TreeListControl MaxWidth="700"
-                                         Height="250"
+                    <dxg:TreeListControl Height="250"
                                          ItemsSource="{Binding ParameterRows}"
                                          SelectedItem="{Binding SelectedParameterTreeRow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                          SelectionMode="Row">
@@ -174,6 +174,7 @@
                             <dxg:TreeListColumn FieldName="ModelCode" Header="Model Code" />
                         </dxg:TreeListControl.Columns>
                     </dxg:TreeListControl>
+                    </StackPanel>
                 </lc:LayoutItem>
             </lc:LayoutGroup>
             <items:AliasLayoutGroup />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #78 : 

Added a tab to show parameters and parametersgroup in the detailview of an elementdefinition.
It is not similar to the elementDefinitionBrowser, because I could not get that in a transactionscoped dialog. 

Missing: 
- drag and drop
- Not sure how to implement adding parameterTypes look at current 
- No inline edit 

<img width="783" height="541" alt="image" src="https://github.com/user-attachments/assets/36ed6572-8d38-4316-936a-a28b5e550b5a" />

