### PR TITLE
fix #477 Show a name for parametricConstraint when creating a binary relationship

### DIFF
--- a/CDP4Composition.Tests/Converters/ThingToFriendlyNameConverterTestFixture.cs
+++ b/CDP4Composition.Tests/Converters/ThingToFriendlyNameConverterTestFixture.cs
@@ -1,0 +1,124 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ThingToFriendlyNameConverterTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Tests.Converters
+{
+    using System;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Converters;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ThingToFriendlyNameConverter"/> class
+    /// </summary>
+    [TestFixture]
+    public class ThingToFriendlyNameConverterTestFixture
+    {
+        private ThingToFriendlyNameConverter converter;
+
+        private ElementDefinition elementDefinition;
+
+        private ParametricConstraint parametricConstraint;
+
+        private ParametricConstraint emptyParametricConstraint;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.converter = new ThingToFriendlyNameConverter();
+
+            this.elementDefinition = new ElementDefinition
+            {
+                Name = "Battery",
+                ShortName = "BAT"
+            };
+
+            var relationalExpression = new RelationalExpression
+            {
+                ParameterType = new SimpleQuantityKind { ShortName = "mass" }
+            };
+
+            this.parametricConstraint = new ParametricConstraint();
+            this.parametricConstraint.Expression.Add(relationalExpression);
+
+            this.emptyParametricConstraint = new ParametricConstraint();
+        }
+
+        [Test]
+        public void Verify_that_a_ParametricConstraint_is_converted_to_its_expression_string()
+        {
+            var result = this.converter.Convert(this.parametricConstraint, null, null, null) as string;
+
+            Assert.That(result, Does.Contain("mass"));
+            Assert.That(result, Does.Not.Contain("not implemented"));
+        }
+
+        [Test]
+        public void Verify_that_a_ParametricConstraint_is_prefixed_with_the_owning_Requirement_shortname()
+        {
+            var requirement = new Requirement { ShortName = "REQ1" };
+            requirement.ParametricConstraint.Add(this.parametricConstraint);
+
+            var result = this.converter.Convert(this.parametricConstraint, null, null, null) as string;
+
+            Assert.That(result, Does.StartWith("REQ1:"));
+            Assert.That(result, Does.Contain("mass"));
+        }
+
+        [Test]
+        public void Verify_that_an_empty_ParametricConstraint_falls_back_to_its_ClassKind()
+        {
+            Assert.AreEqual("ParametricConstraint", this.converter.Convert(this.emptyParametricConstraint, null, null, null));
+        }
+
+        [Test]
+        public void Verify_that_a_ShortNamedThing_is_converted_to_its_UserFriendlyShortName()
+        {
+            Assert.AreEqual(this.elementDefinition.UserFriendlyShortName, this.converter.Convert(this.elementDefinition, null, null, null));
+        }
+
+        [Test]
+        public void Verify_that_the_Name_parameter_yields_the_UserFriendlyName()
+        {
+            Assert.AreEqual(this.elementDefinition.UserFriendlyName, this.converter.Convert(this.elementDefinition, null, "Name", null));
+        }
+
+        [Test]
+        public void Verify_that_a_null_value_is_converted_to_an_empty_string()
+        {
+            Assert.AreEqual(string.Empty, this.converter.Convert(null, null, null, null));
+        }
+
+        [Test]
+        public void Verify_that_ConvertBack_is_not_supported()
+        {
+            Assert.Throws<NotSupportedException>(() => this.converter.ConvertBack(null, null, null, null));
+        }
+    }
+}

--- a/CDP4Composition/Converters/ThingToFriendlyNameConverter.cs
+++ b/CDP4Composition/Converters/ThingToFriendlyNameConverter.cs
@@ -1,0 +1,89 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ThingToFriendlyNameConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Converters
+{
+    using System;
+    using System.Globalization;
+    using System.Windows.Data;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Composition.Extensions;
+
+    /// <summary>
+    /// The purpose of the <see cref="ThingToFriendlyNameConverter"/> is to convert a <see cref="Thing"/> to a
+    /// human-readable display string. It exists because some <see cref="Thing"/>s do not implement
+    /// <see cref="Thing.UserFriendlyName"/> / <see cref="Thing.UserFriendlyShortName"/> and would otherwise render the
+    /// SDK fallback text (e.g. "User-friendly short-name not implemented."). A <see cref="ParametricConstraint"/> has no
+    /// name or short-name, so its tree of <see cref="BooleanExpression"/>s is shown instead.
+    /// </summary>
+    public class ThingToFriendlyNameConverter : IValueConverter
+    {
+        /// <summary>
+        /// Converts a <see cref="Thing"/> to a human-readable display string.
+        /// </summary>
+        /// <param name="value">The <see cref="Thing"/> to convert.</param>
+        /// <param name="targetType">The parameter is not used.</param>
+        /// <param name="parameter">
+        /// When equal to "Name" (case-insensitive) the <see cref="Thing.UserFriendlyName"/> is used for non
+        /// <see cref="ParametricConstraint"/> things; otherwise the <see cref="Thing.UserFriendlyShortName"/> is used.
+        /// </param>
+        /// <param name="culture">The parameter is not used.</param>
+        /// <returns>
+        /// A <see cref="string"/> that represents the <see cref="Thing"/>.
+        /// </returns>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is ParametricConstraint parametricConstraint)
+            {
+                return parametricConstraint.GetDisplayName();
+            }
+
+            if (value is Thing thing)
+            {
+                return string.Equals(parameter as string, "Name", StringComparison.OrdinalIgnoreCase)
+                    ? thing.UserFriendlyName
+                    : thing.UserFriendlyShortName;
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// not supported
+        /// </summary>
+        /// <param name="value">The parameter is not used.</param>
+        /// <param name="targetType">The parameter is not used.</param>
+        /// <param name="parameter">The parameter is not used.</param>
+        /// <param name="culture">The parameter is not used.</param>
+        /// <returns>a <see cref="NotSupportedException"/> is thrown</returns>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/CDP4Composition/Extensions/ParametricConstraintDisplayExtensions.cs
+++ b/CDP4Composition/Extensions/ParametricConstraintDisplayExtensions.cs
@@ -1,0 +1,69 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParametricConstraintDisplayExtensions.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Extensions
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.Extensions;
+
+    /// <summary>
+    /// Extension methods for <see cref="ParametricConstraint"/> that produce a human-readable display string. A
+    /// <see cref="ParametricConstraint"/> has no name or short-name (its <see cref="CDP4Common.CommonData.Thing.UserFriendlyName"/>
+    /// and <see cref="CDP4Common.CommonData.Thing.UserFriendlyShortName"/> fall back to the SDK "not implemented" text), so its tree
+    /// of <see cref="BooleanExpression"/>s is shown instead, prefixed with the short-name of the owning <see cref="Requirement"/>
+    /// to disambiguate similar expressions.
+    /// </summary>
+    public static class ParametricConstraintDisplayExtensions
+    {
+        /// <summary>
+        /// Gets a human-readable display string for the <paramref name="parametricConstraint"/>.
+        /// </summary>
+        /// <param name="parametricConstraint">The <see cref="ParametricConstraint"/> to represent.</param>
+        /// <returns>
+        /// The expression tree of the <see cref="ParametricConstraint"/> (or its <see cref="CDP4Common.CommonData.ClassKind"/> when
+        /// it has no expressions), prefixed with the short-name of the owning <see cref="Requirement"/> when available.
+        /// </returns>
+        public static string GetDisplayName(this ParametricConstraint parametricConstraint)
+        {
+            if (parametricConstraint == null)
+            {
+                return string.Empty;
+            }
+
+            var expression = parametricConstraint.ToExpressionString();
+
+            var display = string.IsNullOrWhiteSpace(expression)
+                ? parametricConstraint.ClassKind.ToString()
+                : expression;
+
+            if (parametricConstraint.Container is Requirement requirement && !string.IsNullOrWhiteSpace(requirement.ShortName))
+            {
+                display = $"{requirement.ShortName}: {display}";
+            }
+
+            return display;
+        }
+    }
+}

--- a/EngineeringModel.Tests/ViewModels/RelationshipBrowser/BinaryRelationshipBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/RelationshipBrowser/BinaryRelationshipBrowserViewModelTestFixture.cs
@@ -294,6 +294,38 @@ namespace CDP4EngineeringModel.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatParametricConstraintSourceShowsItsExpressionInsteadOfNotImplemented()
+        {
+            var requirementsSpecification = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { Name = "RS", ShortName = "RS" };
+            var requirement = new Requirement(Guid.NewGuid(), this.cache, this.uri) { Name = "Requirement", ShortName = "REQ1" };
+            requirementsSpecification.Requirement.Add(requirement);
+            this.iteration.RequirementsSpecification.Add(requirementsSpecification);
+
+            var relationalExpression = new RelationalExpression(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { ShortName = "mass" }
+            };
+
+            var parametricConstraint = new ParametricConstraint(Guid.NewGuid(), this.cache, this.uri);
+            parametricConstraint.Expression.Add(relationalExpression);
+            requirement.ParametricConstraint.Add(parametricConstraint);
+
+            var viewmodel = new BinaryRelationshipBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
+
+            var relationship = new BinaryRelationship(Guid.NewGuid(), this.cache, this.uri) { Source = parametricConstraint, Target = this.elementDefinition1, Owner = this.domain };
+            this.iteration.Relationship.Add(relationship);
+
+            this.revision.SetValue(this.iteration, 1);
+            this.messageBus.SendObjectChangeEvent(this.iteration, EventKind.Updated);
+
+            var row = (BinaryRelationshipRowViewModel)viewmodel.Relationships[0];
+            
+            Assert.That(row.SourceName, Does.Contain("REQ1"));
+            Assert.That(row.SourceName, Does.Contain("mass"));
+            Assert.That(row.SourceName, Does.Not.Contain("not implemented"));
+        }
+
+        [Test]
         public void VerifyThatBrowserIsCreated()
         {
             var viewmodel = new BinaryRelationshipBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);

--- a/EngineeringModel.Tests/ViewModels/RelationshipBrowser/BinaryRelationshipBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/RelationshipBrowser/BinaryRelationshipBrowserViewModelTestFixture.cs
@@ -326,6 +326,42 @@ namespace CDP4EngineeringModel.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatSourceNameRefreshesWhenParametricConstraintExpressionChanges()
+        {
+            var requirementsSpecification = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri) { Name = "RS", ShortName = "RS" };
+            var requirement = new Requirement(Guid.NewGuid(), this.cache, this.uri) { Name = "Requirement", ShortName = "REQ1" };
+            requirementsSpecification.Requirement.Add(requirement);
+            this.iteration.RequirementsSpecification.Add(requirementsSpecification);
+
+            var parametricConstraint = new ParametricConstraint(Guid.NewGuid(), this.cache, this.uri);
+            requirement.ParametricConstraint.Add(parametricConstraint);
+
+            var viewmodel = new BinaryRelationshipBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
+
+            var relationship = new BinaryRelationship(Guid.NewGuid(), this.cache, this.uri) { Source = parametricConstraint, Target = this.elementDefinition1, Owner = this.domain };
+            this.iteration.Relationship.Add(relationship);
+
+            this.revision.SetValue(this.iteration, 1);
+            this.messageBus.SendObjectChangeEvent(this.iteration, EventKind.Updated);
+
+            var row = (BinaryRelationshipRowViewModel)viewmodel.Relationships[0];
+
+            Assert.That(row.SourceName, Does.Not.Contain("mass"));
+
+           var relationalExpression = new RelationalExpression(Guid.NewGuid(), this.cache, this.uri)
+            {
+                ParameterType = new SimpleQuantityKind(Guid.NewGuid(), this.cache, this.uri) { ShortName = "mass" }
+            };
+
+            parametricConstraint.Expression.Add(relationalExpression);
+
+            this.revision.SetValue(relationalExpression, 1);
+            this.messageBus.SendObjectChangeEvent(relationalExpression, EventKind.Updated);
+
+            Assert.That(row.SourceName, Does.Contain("mass"));
+        }
+
+        [Test]
         public void VerifyThatBrowserIsCreated()
         {
             var viewmodel = new BinaryRelationshipBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);

--- a/EngineeringModel/ViewModels/RelationshipBrowser/BinaryRelationshipRowViewModel.cs
+++ b/EngineeringModel/ViewModels/RelationshipBrowser/BinaryRelationshipRowViewModel.cs
@@ -33,6 +33,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation.Interfaces;
 
@@ -220,6 +221,11 @@ namespace CDP4EngineeringModel.ViewModels
             if (thing is BooleanExpression booleanExpression)
             {
                 return booleanExpression.StringValue;
+            }
+
+            if (thing is ParametricConstraint parametricConstraint)
+            {
+                return parametricConstraint.GetDisplayName();
             }
 
             return thing is INamedThing namedThing

--- a/EngineeringModel/ViewModels/RelationshipBrowser/BinaryRelationshipRowViewModel.cs
+++ b/EngineeringModel/ViewModels/RelationshipBrowser/BinaryRelationshipRowViewModel.cs
@@ -99,6 +99,16 @@ namespace CDP4EngineeringModel.ViewModels
         private IDisposable targetSubscription;
 
         /// <summary>
+        /// Subscription on the <see cref="BooleanExpression"/>s of the source when it is a <see cref="ParametricConstraint"/>
+        /// </summary>
+        private IDisposable sourceExpressionSubscription;
+
+        /// <summary>
+        /// Subscription on the <see cref="BooleanExpression"/>s of the target when it is a <see cref="ParametricConstraint"/>
+        /// </summary>
+        private IDisposable targetExpressionSubscription;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BinaryRelationshipRowViewModel"/> class
         /// </summary>
         /// <param name="relationship">The <see cref="BinaryRelationship"/> associated with this row</param>
@@ -144,6 +154,8 @@ namespace CDP4EngineeringModel.ViewModels
                     .Subscribe(_ => this.UpdateProperties());
 
                 this.Disposables.Add(this.sourceSubscription);
+
+                this.SetExpressionSubscription(this.Thing.Source, ref this.sourceExpressionSubscription);
             }
 
             if (this.oldTarget != this.Thing.Target)
@@ -162,6 +174,8 @@ namespace CDP4EngineeringModel.ViewModels
                     .Subscribe(_ => this.UpdateProperties());
 
                 this.Disposables.Add(this.targetSubscription);
+
+                this.SetExpressionSubscription(this.Thing.Target, ref this.targetExpressionSubscription);
             }
 
             this.Categories = string.Join(" ", this.Thing.Category.Select(x => x.ShortName));
@@ -171,6 +185,36 @@ namespace CDP4EngineeringModel.ViewModels
             this.TargetClassKind = this.Thing.Target?.ClassKind.ToString();
 
             this.UpdateName();
+        }
+
+        /// <summary>
+        /// Sets the subscription that listens for changes on the <see cref="BooleanExpression"/>s of the given
+        /// <paramref name="thing"/> when it is a <see cref="ParametricConstraint"/>. This is required because the
+        /// displayed name of a <see cref="ParametricConstraint"/> is derived from its expressions, and changing an
+        /// expression does not raise an update on the <see cref="ParametricConstraint"/> itself.
+        /// </summary>
+        /// <param name="thing">The source or target <see cref="Thing"/> of the <see cref="BinaryRelationship"/>.</param>
+        /// <param name="subscription">The subscription field to (re)assign.</param>
+        private void SetExpressionSubscription(Thing thing, ref IDisposable subscription)
+        {
+            if (subscription != null)
+            {
+                this.Disposables.Remove(subscription);
+                subscription.Dispose();
+                subscription = null;
+            }
+
+            if (!(thing is ParametricConstraint parametricConstraint))
+            {
+                return;
+            }
+
+            subscription = this.CDPMessageBus.Listen<ObjectChangedEvent>(typeof(BooleanExpression))
+                .Where(objectChange => objectChange.EventKind == EventKind.Updated && objectChange.ChangedThing.Container != null && objectChange.ChangedThing.Container.Iid == parametricConstraint.Iid)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.UpdateProperties());
+
+            this.Disposables.Add(subscription);
         }
 
         /// <summary>

--- a/EngineeringModel/Views/Dialogs/BinaryRelationshipDialog.xaml
+++ b/EngineeringModel/Views/Dialogs/BinaryRelationshipDialog.xaml
@@ -18,6 +18,7 @@
         <ResourceDictionary>
             <converters:ReactiveClassKindToObjectListConverter x:Key="ReactiveClassKindToObjectListConverter" />
             <converters:NotConverter x:Key="NotConverter" />
+            <converters:ThingToFriendlyNameConverter x:Key="ThingToFriendlyNameConverter" />
         </ResourceDictionary>
     </dx:DXWindow.Resources>
     <lc:LayoutControl Margin="5"
@@ -49,21 +50,23 @@
                         </Grid.ColumnDefinitions>
                         <dxe:ComboBoxEdit Name="Source"
                                           DisplayMember="UserFriendlyShortName"
+                                          ApplyItemTemplateToSelectedItem="True"
                                           EditValue="{Binding Path=SelectedSource,
                                                               Mode=TwoWay,
                                                               UpdateSourceTrigger=PropertyChanged}"
                                           IsEnabled="{Binding IsReadOnly, Converter={StaticResource NotConverter}, Mode=OneWay}"
                                           IsReadOnly="{Binding IsReadOnly}"
-                                          IsTextEditable="True"
-                                          AutoComplete="True"
+                                          IsTextEditable="False"
+                                          IncrementalSearch="True"
                                           ItemsSource="{Binding Path=PossibleSource}"
                                           ShowCustomItems="false"
-                                          ToolTip="{Binding ElementName=Source, Path=EditValue.UserFriendlyName, UpdateSourceTrigger=PropertyChanged}">
-                            <dxe:ComboBoxEdit.ItemContainerStyle>
-                                <Style TargetType="dxe:ComboBoxEditItem">
-                                    <Setter Property="ToolTip" Value="{Binding UserFriendlyName}"/>
-                                </Style>
-                            </dxe:ComboBoxEdit.ItemContainerStyle>
+                                          ToolTip="{Binding ElementName=Source, Path=EditValue, Converter={StaticResource ThingToFriendlyNameConverter}, ConverterParameter=Name, UpdateSourceTrigger=PropertyChanged}">
+                            <dxe:ComboBoxEdit.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={StaticResource ThingToFriendlyNameConverter}}"
+                                               ToolTip="{Binding Converter={StaticResource ThingToFriendlyNameConverter}, ConverterParameter=Name}"/>
+                                </DataTemplate>
+                            </dxe:ComboBoxEdit.ItemTemplate>
                         </dxe:ComboBoxEdit>
                         <Button Grid.Column="1"
                                 Width="25"
@@ -105,21 +108,23 @@
                         </Grid.ColumnDefinitions>
                         <dxe:ComboBoxEdit Name="Target"
                                           DisplayMember="UserFriendlyShortName"
+                                          ApplyItemTemplateToSelectedItem="True"
                                           IsEnabled="{Binding IsReadOnly, Converter={StaticResource NotConverter}, Mode=OneWay}"
                                           EditValue="{Binding Path=SelectedTarget,
                                                               Mode=TwoWay,
                                                               UpdateSourceTrigger=PropertyChanged}"
                                           IsReadOnly="{Binding IsReadOnly}"
-                                          IsTextEditable="True"
-                                          AutoComplete="True"
+                                          IsTextEditable="False"
+                                          IncrementalSearch="True"
                                           ItemsSource="{Binding Path=PossibleTarget}"
                                           ShowCustomItems="false"
-                                          ToolTip="{Binding ElementName=Target, Path=EditValue.UserFriendlyName, UpdateSourceTrigger=PropertyChanged}">
-                            <dxe:ComboBoxEdit.ItemContainerStyle>
-                                <Style TargetType="dxe:ComboBoxEditItem">
-                                    <Setter Property="ToolTip" Value="{Binding UserFriendlyName}"/>
-                                </Style>
-                            </dxe:ComboBoxEdit.ItemContainerStyle>
+                                          ToolTip="{Binding ElementName=Target, Path=EditValue, Converter={StaticResource ThingToFriendlyNameConverter}, ConverterParameter=Name, UpdateSourceTrigger=PropertyChanged}">
+                            <dxe:ComboBoxEdit.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={StaticResource ThingToFriendlyNameConverter}}"
+                                               ToolTip="{Binding Converter={StaticResource ThingToFriendlyNameConverter}, ConverterParameter=Name}"/>
+                                </DataTemplate>
+                            </dxe:ComboBoxEdit.ItemTemplate>
                         </dxe:ComboBoxEdit>
                         <Button Grid.Column="1"
                                 Width="25"

--- a/EngineeringModel/Views/Dialogs/BinaryRelationshipDialog.xaml.cs
+++ b/EngineeringModel/Views/Dialogs/BinaryRelationshipDialog.xaml.cs
@@ -1,12 +1,31 @@
-﻿// ------------------------------------------------------------------------------------------------
+﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="BinaryRelationshipDialog.xaml.cs" company="Starion Group S.A.">
-//   Copyright (c) 2015 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 // </copyright>
-// ------------------------------------------------------------------------------------------------
-
+// --------------------------------------------------------------------------------------------------------------------
 namespace CDP4EngineeringModel.Views
 {
     using CDP4Common.CommonData;
+
     using CDP4Composition.Attributes;
     using CDP4Composition.Navigation.Interfaces;
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fixes #477 

It displays the constraint's expression tree prefixed with the owning Requirement's short-name (e.g. `REQ1: (mass = 100)`) via a convertor and extension.
