### PR TITLE
Fix #478 : cannot create a binary relationship with same source as target

### DIFF
--- a/CDP4RelationshipEditor/ViewModels/RelationshipEditorViewModel.cs
+++ b/CDP4RelationshipEditor/ViewModels/RelationshipEditorViewModel.cs
@@ -455,8 +455,13 @@ namespace CDP4RelationshipEditor.ViewModels
 
             if (beginItemContent == null || endItemContent == null)
             {
-                // connector was drawn with either the source or target missing
-                // remove the dummy connector
+                this.Behavior.RemoveItem(connector);
+                this.Behavior.ResetTool();
+                return;
+            }
+
+            if (beginItemContent.Thing == endItemContent.Thing)
+            {
                 this.Behavior.RemoveItem(connector);
                 this.Behavior.ResetTool();
                 return;

--- a/EngineeringModel.Tests/Dialogs/BinaryRelationshipDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/BinaryRelationshipDialogViewModelTestFixture.cs
@@ -132,6 +132,9 @@ namespace CDP4EngineeringModel.Tests
 
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDir);
             var assembler = new Assembler(this.uri, this.messageBus);
+            assembler.Cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
+            assembler.Cache.TryAdd(new CacheKey(this.req1.Iid, this.iteration.Iid), new Lazy<Thing>(() => this.req1));
+            assembler.Cache.TryAdd(new CacheKey(this.req2.Iid, this.iteration.Iid), new Lazy<Thing>(() => this.req2));
             this.session.Setup(x => x.Assembler).Returns(assembler);
 
             var dal = new Mock<IDal>();
@@ -153,30 +156,31 @@ namespace CDP4EngineeringModel.Tests
                 true, ThingDialogKind.Create, this.dialogNavigationService.Object, clone);
 
             Assert.AreEqual(1, vm.PossibleCategory.Count);
-            Assert.AreEqual(0, vm.PossibleSource.Count);
-            Assert.AreEqual(0, vm.PossibleTarget.Count);
             Assert.AreEqual(null, vm.Name);
 
-            vm.PossibleSource.Add(this.req1);
-            vm.PossibleTarget.Add(this.req2);
-
             vm.Category = new ReactiveList<Category> { this.relationshipCat };
-            Assert.AreEqual(1, vm.PossibleSource.Count);
-            Assert.AreEqual(1, vm.PossibleTarget.Count);
 
-            Assert.IsTrue(vm.PossibleSource.Contains(this.req1));
-            vm.SelectedSource = this.req1;
-            Assert.IsTrue(vm.PossibleTarget.Contains(this.req2));
-            vm.SelectedTarget = this.req2;
-
-            Assert.IsFalse(vm.PossibleTarget.Contains(this.req1));
-            Assert.IsFalse(vm.PossibleSource.Contains(this.req2));
-
+            // the possible sources and targets are populated for the selected (defaulted) class kinds from the cache
             vm.SelectedSourceClasskind = this.req1.ClassKind;
             vm.SelectedTargetClasskind = this.req2.ClassKind;
 
             Assert.AreEqual(this.req1.ClassKind, vm.SelectedSourceClasskind);
             Assert.AreEqual(this.req2.ClassKind, vm.SelectedTargetClasskind);
+
+            Assert.IsTrue(vm.PossibleSource.Contains(this.req1));
+            Assert.IsTrue(vm.PossibleTarget.Contains(this.req1));
+            Assert.IsTrue(vm.PossibleTarget.Contains(this.req2));
+
+            vm.SelectedSource = this.req1;
+
+            // the selected source can no longer be chosen as target
+            Assert.IsFalse(vm.PossibleTarget.Contains(this.req1));
+            Assert.IsTrue(vm.PossibleTarget.Contains(this.req2));
+
+            vm.SelectedTarget = this.req2;
+
+            // the selected target can no longer be chosen as source
+            Assert.IsFalse(vm.PossibleSource.Contains(this.req2));
 
             Assert.IsTrue(vm.PossibleOwner.Contains(this.domain));
             vm.SelectedOwner = this.domain;
@@ -184,6 +188,35 @@ namespace CDP4EngineeringModel.Tests
             Assert.IsTrue(((ICommand)vm.OkCommand).CanExecute(null));
             Assert.IsTrue(((ICommand)vm.CancelCommand).CanExecute(null));
             Assert.IsTrue(vm.OkCanExecute);
+        }
+
+        [Test]
+        public void VerifyThatSourceAndTargetCannotBeTheSameThing()
+        {
+            var clone = this.iteration.Clone(false);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(this.iteration);
+            var transaction = new ThingTransaction(transactionContext, clone);
+
+            var vm = new BinaryRelationshipDialogViewModel(new BinaryRelationship(), transaction, this.session.Object,
+                true, ThingDialogKind.Create, this.dialogNavigationService.Object, clone);
+
+            vm.SelectedSourceClasskind = this.req1.ClassKind;
+            vm.SelectedTargetClasskind = this.req2.ClassKind;
+
+            vm.SelectedSource = this.req1;
+            vm.SelectedTarget = this.req2;
+            vm.SelectedOwner = this.domain;
+
+            Assert.IsTrue(vm.OkCanExecute);
+
+            // re-selecting the source as the target is not allowed
+            vm.SelectedTarget = this.req1;
+
+            Assert.IsFalse(vm.OkCanExecute);
+
+            // and the source is excluded from the list of possible targets
+            Assert.IsFalse(vm.PossibleTarget.Contains(this.req1));
         }
 
         [Test]

--- a/EngineeringModel.Tests/ViewModels/RelationshipBrowser/BinaryRelationshipBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/RelationshipBrowser/BinaryRelationshipBrowserViewModelTestFixture.cs
@@ -215,6 +215,35 @@ namespace CDP4EngineeringModel.Tests.ViewModels
         }
 
         [Test]
+        public async Task VerifyThatBinaryRelationshipFromThingToItselfCannotBeCreated()
+        {
+            var viewmodel = new BinaryRelationshipBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);
+            var creator = viewmodel.RelationshipCreator.BinaryRelationshipCreator;
+
+            var dropinfo = new Mock<IDropInfo>();
+            dropinfo.Setup(x => x.Payload).Returns(this.elementDefinition1);
+            dropinfo.SetupProperty(x => x.Effects);
+
+            await creator.SourceViewModel.Drop(dropinfo.Object);
+
+            var dropinfo2 = new Mock<IDropInfo>();
+            dropinfo2.Setup(x => x.Payload).Returns(this.elementDefinition1);
+            await creator.TargetViewModel.Drop(dropinfo2.Object);
+
+            Assert.AreSame(creator.SourceViewModel.RelatedThing, creator.TargetViewModel.RelatedThing);
+            Assert.IsFalse(creator.CanCreate);
+            Assert.IsTrue(creator.IsSourceAndTargetSame);
+            Assert.IsFalse(((ICommand)viewmodel.RelationshipCreator.CreateRelationshipCommand).CanExecute(null));
+
+            var dropinfo3 = new Mock<IDropInfo>();
+            dropinfo3.Setup(x => x.Payload).Returns(this.elementDefinition2);
+            await creator.TargetViewModel.Drop(dropinfo3.Object);
+
+            Assert.IsFalse(creator.IsSourceAndTargetSame);
+            Assert.IsTrue(creator.CanCreate);
+        }
+
+        [Test]
         public void VerifyThatBinaryRelationshipNameUsesNameWhenSetAndPathOtherwise()
         {
             var viewmodel = new BinaryRelationshipBrowserViewModel(this.iteration, this.session.Object, this.thingDialogNavigationService.Object, this.panelNavigationService.Object, null, null);

--- a/EngineeringModel/ViewModels/Dialogs/BinaryRelationshipDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/BinaryRelationshipDialogViewModel.cs
@@ -173,8 +173,19 @@ namespace CDP4EngineeringModel.ViewModels
 
             this.WhenAnyValue(x => x.SelectedSourceClasskind).Subscribe(x => { this.PopulatePossibleSource(); });
             this.WhenAnyValue(x => x.SelectedTargetClasskind).Subscribe(x => { this.PopulatePossibleTarget(); });
-            this.WhenAnyValue(x => x.SelectedSource).Subscribe(x => this.UpdateOkCanExecute());
-            this.WhenAnyValue(x => x.SelectedTarget).Subscribe(x => this.UpdateOkCanExecute());
+
+            this.WhenAnyValue(x => x.SelectedSource).Subscribe(x =>
+            {
+                this.PopulatePossibleTarget();
+                this.UpdateOkCanExecute();
+            });
+
+            this.WhenAnyValue(x => x.SelectedTarget).Subscribe(x =>
+            {
+                this.PopulatePossibleSource();
+                this.UpdateOkCanExecute();
+            });
+            
             this.WhenAnyValue(x => x.SelectedOwner).Subscribe(x => this.UpdateOkCanExecute());
         }
 
@@ -246,7 +257,7 @@ namespace CDP4EngineeringModel.ViewModels
             base.UpdateOkCanExecute();
 
             this.OkCanExecute = this.OkCanExecute && (this.SelectedSource != null) && (this.SelectedTarget != null) &&
-                                (this.SelectedOwner != null);
+                                (this.SelectedOwner != null) && (this.SelectedSource != this.SelectedTarget);
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/RelationshipBrowser/Creator/BinaryRelationshipCreatorViewModel.cs
+++ b/EngineeringModel/ViewModels/RelationshipBrowser/Creator/BinaryRelationshipCreatorViewModel.cs
@@ -75,6 +75,11 @@ namespace CDP4EngineeringModel.ViewModels
         private bool canCreate;
 
         /// <summary>
+        /// Backing field for <see cref="IsSourceAndTargetSame" />
+        /// </summary>
+        private bool isSourceAndTargetSame;
+
+        /// <summary>
         /// Backing field for <see cref="Name" />
         /// </summary>
         private string name;
@@ -96,7 +101,7 @@ namespace CDP4EngineeringModel.ViewModels
             this.PossibleCategories = new ReactiveList<Category>();
             this.SourceViewModel = new RelatedThingViewModel(session.CDPMessageBus);
             this.TargetViewModel = new RelatedThingViewModel(session.CDPMessageBus);
-            var relatedThingChangedSubscriber = this.WhenAnyValue(x => x.TargetViewModel.RelatedThing, y => y.SourceViewModel.RelatedThing).Subscribe(x => this.CanCreate = this.SourceViewModel.RelatedThing != null && this.TargetViewModel.RelatedThing != null);
+            var relatedThingChangedSubscriber = this.WhenAnyValue(x => x.TargetViewModel.RelatedThing, y => y.SourceViewModel.RelatedThing).Subscribe(_ => this.UpdateCanCreate());
             this.Subscriptions.Add(relatedThingChangedSubscriber);
 
             this.InitializeRequiredRdlSubscription();
@@ -153,9 +158,32 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
+        /// Gets a value indicating whether the selected source and target are the same <see cref="Thing" />.
+        /// A <see cref="BinaryRelationship" /> from a <see cref="Thing" /> to itself is not allowed.
+        /// </summary>
+        public bool IsSourceAndTargetSame
+        {
+            get => this.isSourceAndTargetSame;
+            private set => this.RaiseAndSetIfChanged(ref this.isSourceAndTargetSame, value);
+        }
+
+        /// <summary>
         /// Gets the type of the <see cref="Relationship" /> to create
         /// </summary>
         public string CreatorKind => "Binary Relationship";
+
+        /// <summary>
+        /// Updates the <see cref="CanCreate" /> and <see cref="IsSourceAndTargetSame" /> properties based on the
+        /// currently selected source and target.
+        /// </summary>
+        private void UpdateCanCreate()
+        {
+            var source = this.SourceViewModel.RelatedThing;
+            var target = this.TargetViewModel.RelatedThing;
+
+            this.IsSourceAndTargetSame = (source != null) && (source == target);
+            this.CanCreate = (source != null) && (target != null) && (source != target);
+        }
 
         /// <summary>
         /// Re-initializes the view-model

--- a/EngineeringModel/Views/RelationshipBrowser/BinaryRelationshipBrowser.xaml
+++ b/EngineeringModel/Views/RelationshipBrowser/BinaryRelationshipBrowser.xaml
@@ -156,6 +156,14 @@
                             </TextBox>
                         </dxlc:LayoutGroup>
 
+                        <dxlc:LayoutItem Label="Error: "
+                                         Visibility="{Binding IsSourceAndTargetSame, Converter={dx:BooleanToVisibilityConverter}}">
+                            <TextBox Margin="5"
+                                     Text="The source and target cannot be the same Thing."
+                                     IsReadOnly="True"
+                                     TextWrapping="Wrap" />
+                        </dxlc:LayoutItem>
+
                         <dxlc:LayoutItem Label="Categories: ">
                             <dxe:ComboBoxEdit DisplayMember="Name"
                                               SeparatorString=", "


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #478 disallow binary relationships from a Thing to itself

Block self-relationships for the "Create a Binary Relationship" panel and the diagram-editor self-loop now refuse equal source/target, and the edit dialog re-filters the opposite list on selection change with a hard guard on OK.

The creator panel shows an explanatory "Error:" message, so the disabled Save button is explained.