### PR TITLE
Feat #24 Add copy/paste of parameters and parameter groups between Element Definitions

### DIFF
--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -53,7 +53,10 @@ namespace CDP4EngineeringModel.Tests
     using CDP4Dal.Operations;
     using CDP4Dal.Permission;
 
+    using CDP4DalCommon.Protocol.Operations;
+
     using CDP4EngineeringModel.Services;
+    using CDP4EngineeringModel.Utilities;
     using CDP4EngineeringModel.ViewModels;
 
     using CommonServiceLocator;
@@ -104,6 +107,8 @@ namespace CDP4EngineeringModel.Tests
         [SetUp]
         public void Setup()
         {
+            ParameterClipboard.CopiedThing = null;
+
             this.cache = new List<Thing>();
             this.messageBus = new CDPMessageBus();
 
@@ -205,6 +210,7 @@ namespace CDP4EngineeringModel.Tests
         [TearDown]
         public void TearDown()
         {
+            ParameterClipboard.CopiedThing = null;
             this.messageBus.ClearSubscriptions();
         }
 
@@ -647,14 +653,14 @@ namespace CDP4EngineeringModel.Tests
 
             vm.SelectedThing = defRow;
             vm.PopulateContextMenu();
-            Assert.AreEqual(14, vm.ContextMenu.Count);
+            Assert.AreEqual(15, vm.ContextMenu.Count);
             vm.SelectedThing = defRow.ContainedRows[0];
             vm.PopulateContextMenu();
-            Assert.AreEqual(8, vm.ContextMenu.Count);
+            Assert.AreEqual(10, vm.ContextMenu.Count);
 
             vm.SelectedThing = defRow.ContainedRows[1];
             vm.PopulateContextMenu();
-            Assert.AreEqual(7, vm.ContextMenu.Count);
+            Assert.AreEqual(9, vm.ContextMenu.Count);
 
             var usageRow = defRow.ContainedRows[2];
             var usage2Row = defRow.ContainedRows[3];
@@ -665,7 +671,7 @@ namespace CDP4EngineeringModel.Tests
 
             vm.SelectedThing = usageRow.ContainedRows.Single();
             vm.PopulateContextMenu();
-            Assert.AreEqual(8, vm.ContextMenu.Count);
+            Assert.AreEqual(10, vm.ContextMenu.Count);
 
             vm.SelectedThing = usage2Row.ContainedRows.Single();
             vm.PopulateContextMenu();
@@ -974,6 +980,264 @@ namespace CDP4EngineeringModel.Tests
             vm.SelectedThing = defRow;
             await vm.UnsetAsTopElementDefinitionCommand.Execute();
             this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyThatCopyAndPasteParameterCreatesParameterOnTargetElementDefinition()
+        {
+            OperationContainer capturedOperationContainer = null;
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>()))
+                .Callback<OperationContainer>(oc => capturedOperationContainer = oc)
+                .Returns(Task.CompletedTask);
+
+            // the source Parameter is owned by a different domain than the one performing the paste
+            var sourceOwner = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "OtherDomain" };
+            this.sitedir.Domain.Add(sourceOwner);
+
+            var sourceDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "source", Owner = sourceOwner, Container = this.iteration };
+            var sourceParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = this.pt, Owner = sourceOwner, Container = sourceDef };
+            sourceDef.Parameter.Add(sourceParameter);
+
+            var targetDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "target", Owner = this.domain, Container = this.iteration };
+
+            this.iteration.Element.Add(sourceDef);
+            this.iteration.Element.Add(targetDef);
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => vm.SingleRunBackgroundWorker == null);
+
+            var sourceRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == sourceDef);
+            vm.SelectedThing = sourceRow.ContainedRows.Single(x => x.Thing == sourceParameter);
+            vm.ComputePermission();
+
+            Assert.IsTrue(vm.CanCopyParameterGroup);
+            await vm.CopyParameterGroupCommand.Execute();
+
+            var targetRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == targetDef);
+            vm.SelectedThing = targetRow;
+            vm.ComputePermission();
+
+            Assert.IsTrue(vm.CanPasteParameterGroup);
+            await vm.PasteParameterGroupCommand.Execute();
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+
+            Assert.IsNotNull(capturedOperationContainer);
+
+            var createdParameters = capturedOperationContainer.Operations
+                .Where(o => o.OperationKind == OperationKind.Create && o.ModifiedThing is CDP4Common.DTO.Parameter)
+                .Select(o => (CDP4Common.DTO.Parameter)o.ModifiedThing)
+                .ToList();
+
+            Assert.AreEqual(1, createdParameters.Count);
+            Assert.AreEqual(this.pt.Iid, createdParameters.Single().ParameterType);
+
+            // the copied Parameter is owned by the domain performing the paste, not the original owner
+            Assert.AreEqual(this.domain.Iid, createdParameters.Single().Owner);
+        }
+
+        [Test]
+        public async Task VerifyThatPasteParameterSkipsExistingParameterType()
+        {
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(Task.CompletedTask);
+
+            var sourceDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "source", Owner = this.domain, Container = this.iteration };
+            var sourceParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = this.pt, Owner = this.domain, Container = sourceDef };
+            sourceDef.Parameter.Add(sourceParameter);
+
+            var targetDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "target", Owner = this.domain, Container = this.iteration };
+            var existingParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = this.pt, Owner = this.domain, Container = targetDef };
+            targetDef.Parameter.Add(existingParameter);
+
+            this.iteration.Element.Add(sourceDef);
+            this.iteration.Element.Add(targetDef);
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => vm.SingleRunBackgroundWorker == null);
+
+            var sourceRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == sourceDef);
+            vm.SelectedThing = sourceRow.ContainedRows.Single(x => x.Thing == sourceParameter);
+            vm.ComputePermission();
+            await vm.CopyParameterGroupCommand.Execute();
+
+            var targetRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == targetDef);
+            vm.SelectedThing = targetRow;
+            vm.ComputePermission();
+            await vm.PasteParameterGroupCommand.Execute();
+
+            // the target already holds a Parameter of the same ParameterType so nothing is written
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
+        }
+
+        [Test]
+        public async Task VerifyThatCopyAndPasteParameterGroupCopiesGroupsAndSkipsExistingTypes()
+        {
+            OperationContainer capturedOperationContainer = null;
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>()))
+                .Callback<OperationContainer>(oc => capturedOperationContainer = oc)
+                .Returns(Task.CompletedTask);
+
+            var otherParameterType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.srdl.ParameterType.Add(otherParameterType);
+
+            var sourceDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "source", Owner = this.domain, Container = this.iteration };
+            var sourceGroup = new ParameterGroup(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "group", Container = sourceDef };
+            var sourceSubGroup = new ParameterGroup(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "subgroup", ContainingGroup = sourceGroup, Container = sourceDef };
+            sourceDef.ParameterGroup.Add(sourceGroup);
+            sourceDef.ParameterGroup.Add(sourceSubGroup);
+
+            var groupParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = this.pt, Owner = this.domain, Group = sourceGroup, Container = sourceDef };
+            var subGroupParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = otherParameterType, Owner = this.domain, Group = sourceSubGroup, Container = sourceDef };
+            sourceDef.Parameter.Add(groupParameter);
+            sourceDef.Parameter.Add(subGroupParameter);
+
+            var targetDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "target", Owner = this.domain, Container = this.iteration };
+            var existingParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = this.pt, Owner = this.domain, Container = targetDef };
+            targetDef.Parameter.Add(existingParameter);
+
+            this.iteration.Element.Add(sourceDef);
+            this.iteration.Element.Add(targetDef);
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => vm.SingleRunBackgroundWorker == null);
+
+            var sourceRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == sourceDef);
+            vm.SelectedThing = sourceRow.ContainedRows.Single(x => x.Thing == sourceGroup);
+            vm.ComputePermission();
+
+            Assert.IsTrue(vm.CanCopyParameterGroup);
+            await vm.CopyParameterGroupCommand.Execute();
+
+            var targetRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == targetDef);
+            vm.SelectedThing = targetRow;
+            vm.ComputePermission();
+            await vm.PasteParameterGroupCommand.Execute();
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+            Assert.IsNotNull(capturedOperationContainer);
+
+            var createdGroups = capturedOperationContainer.Operations
+                .Where(o => o.OperationKind == OperationKind.Create && o.ModifiedThing is CDP4Common.DTO.ParameterGroup)
+                .ToList();
+
+            var createdParameters = capturedOperationContainer.Operations
+                .Where(o => o.OperationKind == OperationKind.Create && o.ModifiedThing is CDP4Common.DTO.Parameter)
+                .Select(o => (CDP4Common.DTO.Parameter)o.ModifiedThing)
+                .ToList();
+
+            // both groups are copied
+            Assert.AreEqual(2, createdGroups.Count);
+
+            // only the parameter whose ParameterType is not yet on the target is copied
+            Assert.AreEqual(1, createdParameters.Count);
+            Assert.AreEqual(otherParameterType.Iid, createdParameters.Single().ParameterType);
+        }
+
+        [Test]
+        public async Task VerifyThatPasteSkipsParameterWhoseParameterTypeIsNotInTargetRdlChain()
+        {
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(Task.CompletedTask);
+
+            // a ParameterType that lives in a SiteReferenceDataLibrary outside the target model's RDL chain
+            var srdl2 = new SiteReferenceDataLibrary(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            this.sitedir.SiteReferenceDataLibrary.Add(srdl2);
+            var inaccessiblePt = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Inaccessible" };
+            srdl2.ParameterType.Add(inaccessiblePt);
+
+            var sourceDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "source", Owner = this.domain, Container = this.iteration };
+            var sourceParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = inaccessiblePt, Owner = this.domain, Container = sourceDef };
+            sourceDef.Parameter.Add(sourceParameter);
+
+            var targetDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "target", Owner = this.domain, Container = this.iteration };
+
+            this.iteration.Element.Add(sourceDef);
+            this.iteration.Element.Add(targetDef);
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => vm.SingleRunBackgroundWorker == null);
+
+            var sourceRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == sourceDef);
+            vm.SelectedThing = sourceRow.ContainedRows.Single(x => x.Thing == sourceParameter);
+            vm.ComputePermission();
+            await vm.CopyParameterGroupCommand.Execute();
+
+            var targetRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == targetDef);
+            vm.SelectedThing = targetRow;
+            vm.ComputePermission();
+            await vm.PasteParameterGroupCommand.Execute();
+
+            // the ParameterType is not reachable from the target model's RDL chain so nothing is written and the user is informed
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
+            Assert.That(vm.Feedback, Does.Contain("not available"));
+        }
+
+        [Test]
+        public async Task VerifyThatClipboardIsSharedAcrossBrowserInstances()
+        {
+            OperationContainer capturedOperationContainer = null;
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>()))
+                .Callback<OperationContainer>(oc => capturedOperationContainer = oc)
+                .Returns(Task.CompletedTask);
+
+            var sourceDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "source", Owner = this.domain, Container = this.iteration };
+            var sourceParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = this.pt, Owner = this.domain, Container = sourceDef };
+            sourceDef.Parameter.Add(sourceParameter);
+
+            var targetDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "target", Owner = this.domain, Container = this.iteration };
+
+            this.iteration.Element.Add(sourceDef);
+            this.iteration.Element.Add(targetDef);
+
+            // copy in one browser instance
+            var copyBrowser = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => copyBrowser.SingleRunBackgroundWorker == null);
+
+            var sourceRow = copyBrowser.ElementDefinitionRowViewModels.Single(x => x.Thing == sourceDef);
+            copyBrowser.SelectedThing = sourceRow.ContainedRows.Single(x => x.Thing == sourceParameter);
+            copyBrowser.ComputePermission();
+            await copyBrowser.CopyParameterGroupCommand.Execute();
+
+            // paste in a different browser instance
+            var pasteBrowser = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => pasteBrowser.SingleRunBackgroundWorker == null);
+
+            var targetRow = pasteBrowser.ElementDefinitionRowViewModels.Single(x => x.Thing == targetDef);
+            pasteBrowser.SelectedThing = targetRow;
+            pasteBrowser.ComputePermission();
+
+            Assert.IsTrue(pasteBrowser.CanPasteParameterGroup);
+            await pasteBrowser.PasteParameterGroupCommand.Execute();
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+
+            var createdParameters = capturedOperationContainer.Operations
+                .Where(o => o.OperationKind == OperationKind.Create && o.ModifiedThing is CDP4Common.DTO.Parameter)
+                .ToList();
+
+            Assert.AreEqual(1, createdParameters.Count);
+        }
+
+        [Test]
+        public async Task VerifyThatClipboardIsClearedWhenSessionIsClosed()
+        {
+            var sourceDef = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "source", Owner = this.domain, Container = this.iteration };
+            var sourceParameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = this.pt, Owner = this.domain, Container = sourceDef };
+            sourceDef.Parameter.Add(sourceParameter);
+            this.iteration.Element.Add(sourceDef);
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => vm.SingleRunBackgroundWorker == null);
+
+            var sourceRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == sourceDef);
+            vm.SelectedThing = sourceRow.ContainedRows.Single(x => x.Thing == sourceParameter);
+            vm.ComputePermission();
+            await vm.CopyParameterGroupCommand.Execute();
+
+            Assert.IsNotNull(ParameterClipboard.CopiedThing);
+
+            this.messageBus.SendMessage(new SessionEvent(this.session.Object, SessionStatus.Closed));
+
+            Assert.IsNull(ParameterClipboard.CopiedThing);
         }
 
         /// <summary>

--- a/EngineeringModel/Utilities/CopyParameterAndGroupCreator.cs
+++ b/EngineeringModel/Utilities/CopyParameterAndGroupCreator.cs
@@ -1,0 +1,291 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CopyParameterAndGroupCreator.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Utilities
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Operations;
+
+    /// <summary>
+    /// The class responsible for copying a <see cref="Parameter"/> or a <see cref="ParameterGroup"/> (including the
+    /// <see cref="Parameter"/>s and nested <see cref="ParameterGroup"/>s it contains) into a target <see cref="ElementDefinition"/>.
+    /// The target may live in a different <see cref="Iteration"/> or <see cref="EngineeringModel"/> than the source as long as
+    /// both are open in the same <see cref="ISession"/>.
+    /// </summary>
+    /// <remarks>
+    /// Only the definition of the <see cref="Parameter"/>s is copied; their values are reset to the default value. A
+    /// <see cref="Parameter"/> is skipped when its <see cref="ParameterType"/> already exists on the target
+    /// <see cref="ElementDefinition"/>, or when the <see cref="ParameterType"/> (or <see cref="MeasurementScale"/>) it references
+    /// is not available in the chain of <see cref="ReferenceDataLibrary"/> of the target <see cref="EngineeringModel"/>.
+    /// </remarks>
+    internal class CopyParameterAndGroupCreator
+    {
+        /// <summary>
+        /// The <see cref="ISession"/> in which the copy is performed
+        /// </summary>
+        private readonly ISession session;
+
+        /// <summary>
+        /// The <see cref="DomainOfExpertise"/> that becomes the owner of the copied <see cref="Parameter"/>s
+        /// </summary>
+        private DomainOfExpertise owner;
+
+        /// <summary>
+        /// The clone of the target <see cref="ElementDefinition"/> that the copied <see cref="Thing"/>s are added to
+        /// </summary>
+        private ElementDefinition targetElementDefinitionClone;
+
+        /// <summary>
+        /// The target <see cref="Iteration"/> that the copy is performed into
+        /// </summary>
+        private Iteration targetIteration;
+
+        /// <summary>
+        /// The <see cref="ReferenceDataLibrary"/> available in the chain of the target <see cref="EngineeringModel"/>
+        /// </summary>
+        private HashSet<ReferenceDataLibrary> availableRdls;
+
+        /// <summary>
+        /// The <see cref="Guid"/>s of the <see cref="ParameterType"/>s already present on the target <see cref="ElementDefinition"/>
+        /// </summary>
+        private HashSet<Guid> existingParameterTypeIids;
+
+        /// <summary>
+        /// The <see cref="ThingTransaction"/> the new <see cref="Thing"/>s are registered on
+        /// </summary>
+        private ThingTransaction transaction;
+
+        /// <summary>
+        /// The human-readable messages describing <see cref="Parameter"/>s that were not copied
+        /// </summary>
+        private List<string> warnings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CopyParameterAndGroupCreator"/> class
+        /// </summary>
+        /// <param name="session">The associated <see cref="ISession"/></param>
+        public CopyParameterAndGroupCreator(ISession session)
+        {
+            this.session = session;
+        }
+
+        /// <summary>
+        /// Perform the copy operation of a <see cref="Parameter"/> or a <see cref="ParameterGroup"/>
+        /// </summary>
+        /// <param name="source">
+        /// The <see cref="Parameter"/> or <see cref="ParameterGroup"/> that is to be copied
+        /// </param>
+        /// <param name="targetElementDefinition">
+        /// The <see cref="ElementDefinition"/> that the <paramref name="source"/> is to be copied into
+        /// </param>
+        /// <param name="targetGroup">
+        /// The optional <see cref="ParameterGroup"/> of the <paramref name="targetElementDefinition"/> that the copied
+        /// <see cref="Parameter"/> or top-level <see cref="ParameterGroup"/> is to be placed in. May be null to place the
+        /// copy at the root of the <paramref name="targetElementDefinition"/>.
+        /// </param>
+        /// <param name="owner">
+        /// The <see cref="DomainOfExpertise"/> that becomes the owner of the copied <see cref="Parameter"/>s. This is the
+        /// <see cref="DomainOfExpertise"/> of the user performing the paste, not the owner of the original <see cref="Parameter"/>s.
+        /// </param>
+        /// <returns>
+        /// An awaitable <see cref="Task"/> whose result is the list of human-readable messages describing the
+        /// <see cref="Parameter"/>s that could not be copied because their referenced reference data is not available in the
+        /// target <see cref="EngineeringModel"/>.
+        /// </returns>
+        public async Task<IReadOnlyList<string>> Copy(Thing source, ElementDefinition targetElementDefinition, ParameterGroup targetGroup, DomainOfExpertise owner)
+        {
+            if (targetElementDefinition == null)
+            {
+                throw new ArgumentNullException(nameof(targetElementDefinition), "The target ElementDefinition may not be null");
+            }
+
+            if (owner == null)
+            {
+                throw new ArgumentNullException(nameof(owner), "The owner DomainOfExpertise may not be null");
+            }
+
+            this.owner = owner;
+            this.targetElementDefinitionClone = targetElementDefinition.Clone(false);
+            this.targetIteration = targetElementDefinition.GetContainerOfType<Iteration>();
+            this.availableRdls = this.ComputeAvailableRdls(targetElementDefinition);
+            this.existingParameterTypeIids = new HashSet<Guid>(targetElementDefinition.Parameter.Select(p => p.ParameterType.Iid));
+            this.warnings = new List<string>();
+
+            var transactionContext = TransactionContextResolver.ResolveContext(targetElementDefinition);
+            this.transaction = new ThingTransaction(transactionContext, this.targetElementDefinitionClone);
+
+            bool hasChanges;
+
+            switch (source)
+            {
+                case ParameterGroup parameterGroup:
+                    hasChanges = this.CopyParameterGroup(parameterGroup, targetGroup);
+                    break;
+                case Parameter parameter:
+                    hasChanges = this.CopyParameter(parameter, targetGroup);
+                    break;
+                default:
+                    throw new ArgumentException("Only a Parameter or a ParameterGroup can be copied", nameof(source));
+            }
+
+            if (hasChanges)
+            {
+                await this.session.Write(this.transaction.FinalizeTransaction());
+            }
+
+            return this.warnings;
+        }
+
+        /// <summary>
+        /// Copies a <see cref="ParameterGroup"/> and its contained <see cref="ParameterGroup"/>s and <see cref="Parameter"/>s
+        /// </summary>
+        /// <param name="source">The <see cref="ParameterGroup"/> to copy</param>
+        /// <param name="targetGroup">The optional <see cref="ParameterGroup"/> to place the copied top-level group in</param>
+        /// <returns>A value indicating whether anything was registered on the transaction</returns>
+        private bool CopyParameterGroup(ParameterGroup source, ParameterGroup targetGroup)
+        {
+            var sourceGroups = new List<ParameterGroup> { source };
+            sourceGroups.AddRange(source.ContainedGroup(true));
+
+            // register the original-clone mapping so that nested containing-group references can be resolved
+            var groupMap = new Dictionary<ParameterGroup, ParameterGroup>();
+
+            foreach (var sourceGroup in sourceGroups)
+            {
+                var groupClone = new ParameterGroup(Guid.NewGuid(), null, null)
+                {
+                    Name = sourceGroup.Name
+                };
+
+                groupMap.Add(sourceGroup, groupClone);
+            }
+
+            foreach (var kvp in groupMap)
+            {
+                var sourceGroup = kvp.Key;
+                var groupClone = kvp.Value;
+
+                groupClone.ContainingGroup = sourceGroup.ContainingGroup != null && groupMap.TryGetValue(sourceGroup.ContainingGroup, out var mappedContainingGroup)
+                    ? mappedContainingGroup
+                    : targetGroup;
+
+                this.targetElementDefinitionClone.ParameterGroup.Add(groupClone);
+                this.transaction.Create(groupClone, this.targetElementDefinitionClone);
+            }
+
+            foreach (var sourceGroup in sourceGroups)
+            {
+                foreach (var parameter in sourceGroup.ContainedParameter())
+                {
+                    this.CopyParameter(parameter, groupMap[sourceGroup]);
+                }
+            }
+
+            // a copied group is always created, even if all of its parameters already exist on the target
+            return true;
+        }
+
+        /// <summary>
+        /// Copies a single <see cref="Parameter"/> when its <see cref="ParameterType"/> is not yet present on the target and
+        /// the reference data it depends on is available in the target <see cref="EngineeringModel"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="Parameter"/> to copy</param>
+        /// <param name="targetGroup">The optional <see cref="ParameterGroup"/> to place the copied <see cref="Parameter"/> in</param>
+        /// <returns>A value indicating whether a <see cref="Parameter"/> was registered on the transaction</returns>
+        private bool CopyParameter(Parameter source, ParameterGroup targetGroup)
+        {
+            if (this.existingParameterTypeIids.Contains(source.ParameterType.Iid))
+            {
+                // a Parameter with this ParameterType already exists on the target ElementDefinition
+                return false;
+            }
+
+            if (!source.RequiredRdls.All(rdl => this.availableRdls.Contains(rdl)))
+            {
+                // the ParameterType or MeasurementScale lives in a reference data library that is not available in the target model
+                this.warnings.Add($"The parameter '{source.ParameterType.Name}' was not copied because its reference data is not available in the target model.");
+                return false;
+            }
+
+            this.existingParameterTypeIids.Add(source.ParameterType.Iid);
+
+            // a Parameter is state-dependent on an ActualFiniteStateList of its own Iteration; that reference is dropped when
+            // pasting into a different Iteration that does not contain it.
+            var stateDependence = source.StateDependence != null && this.targetIteration != null && this.targetIteration.ActualFiniteStateList.Contains(source.StateDependence)
+                ? source.StateDependence
+                : null;
+
+            var parameterClone = new Parameter(Guid.NewGuid(), null, null)
+            {
+                ParameterType = source.ParameterType,
+                Scale = source.Scale,
+                Owner = this.owner,
+                IsOptionDependent = source.IsOptionDependent,
+                StateDependence = stateDependence,
+                ExpectsOverride = source.ExpectsOverride,
+                AllowDifferentOwnerOfOverride = source.AllowDifferentOwnerOfOverride,
+                Group = targetGroup
+            };
+
+            this.targetElementDefinitionClone.Parameter.Add(parameterClone);
+            this.transaction.Create(parameterClone, this.targetElementDefinitionClone);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Computes the <see cref="ReferenceDataLibrary"/> available in the chain of the <see cref="EngineeringModel"/> that
+        /// contains the <paramref name="targetElementDefinition"/>.
+        /// </summary>
+        /// <param name="targetElementDefinition">The target <see cref="ElementDefinition"/></param>
+        /// <returns>The set of available <see cref="ReferenceDataLibrary"/></returns>
+        private HashSet<ReferenceDataLibrary> ComputeAvailableRdls(ElementDefinition targetElementDefinition)
+        {
+            var availableReferenceDataLibraries = new HashSet<ReferenceDataLibrary>();
+
+            if (targetElementDefinition.TopContainer is EngineeringModel model)
+            {
+                var requiredRdl = model.EngineeringModelSetup.RequiredRdl.Single();
+                availableReferenceDataLibraries.Add(requiredRdl);
+
+                foreach (var referenceDataLibrary in requiredRdl.RequiredRdls)
+                {
+                    availableReferenceDataLibraries.Add(referenceDataLibrary);
+                }
+            }
+
+            return availableReferenceDataLibraries;
+        }
+    }
+}

--- a/EngineeringModel/Utilities/ParameterClipboard.cs
+++ b/EngineeringModel/Utilities/ParameterClipboard.cs
@@ -1,0 +1,44 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ParameterClipboard.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.Utilities
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// A process-wide clipboard that holds the <see cref="Parameter"/> or <see cref="ParameterGroup"/> that has been copied,
+    /// so that it can be pasted into an <see cref="ElementDefinition"/> in any open <see cref="Iteration"/> of the same
+    /// <see cref="CDP4Dal.ISession"/>. It is intentionally static, mirroring the way the application uses the WPF
+    /// <see cref="System.Windows.Clipboard"/>, so that a copy made in one Element Definitions browser can be pasted in another.
+    /// </summary>
+    internal static class ParameterClipboard
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Parameter"/> or <see cref="ParameterGroup"/> that has been copied and is ready to be pasted.
+        /// </summary>
+        public static Thing CopiedThing { get; set; }
+    }
+}

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -145,6 +145,16 @@ namespace CDP4EngineeringModel.ViewModels
         private bool canCreateOverride;
 
         /// <summary>
+        /// Backing field for <see cref="CanCopyParameterGroup"/>
+        /// </summary>
+        private bool canCopyParameterGroup;
+
+        /// <summary>
+        /// Backing field for <see cref="CanPasteParameterGroup"/>
+        /// </summary>
+        private bool canPasteParameterGroup;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ElementDefinitionsBrowserViewModel"/> class
         /// </summary>
         /// <param name="iteration">The associated <see cref="Iteration"/></param>
@@ -275,6 +285,24 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
+        /// Gets a value indicating whether the copy parameter or parameter group command shall be enabled
+        /// </summary>
+        public bool CanCopyParameterGroup
+        {
+            get => this.canCopyParameterGroup;
+            private set => this.RaiseAndSetIfChanged(ref this.canCopyParameterGroup, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the paste parameter or parameter group command shall be enabled
+        /// </summary>
+        public bool CanPasteParameterGroup
+        {
+            get => this.canPasteParameterGroup;
+            private set => this.RaiseAndSetIfChanged(ref this.canPasteParameterGroup, value);
+        }
+
+        /// <summary>
         /// Gets the <see cref="ReactiveCommand"/> to Copy Model Code to clipboard <see cref="ParameterRowViewModel"/>
         /// </summary>
         public ReactiveCommand<Unit, Unit> CopyModelCodeToClipboardCommand { get; private set; }
@@ -298,6 +326,16 @@ namespace CDP4EngineeringModel.ViewModels
         /// Gets the <see cref="ReactiveCommand"/> used to copy a <see cref="ElementDefinition"/>
         /// </summary>
         public ReactiveCommand<Unit, Unit> CopyElementDefinitionCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> used to copy a <see cref="Parameter"/> or a <see cref="ParameterGroup"/> to the clipboard
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> CopyParameterGroupCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> used to paste the copied <see cref="Parameter"/> or <see cref="ParameterGroup"/> into the selected <see cref="ElementDefinition"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> PasteParameterGroupCommand { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ICommand"/> to create a <see cref="ParameterOverride"/>
@@ -582,6 +620,8 @@ namespace CDP4EngineeringModel.ViewModels
             this.CreateParameterGroup = ReactiveCommandCreator.Create(this.ExecuteCreateParameterGroup, this.WhenAnyValue(vm => vm.CanCreateParameterGroup));
             this.CreateElementDefinition = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<ElementDefinition>(this.Thing), this.WhenAnyValue(vm => vm.CanCreateElementDefinition));
             this.CopyElementDefinitionCommand = ReactiveCommandCreator.Create(this.ExecuteCopyElementDefinition, this.WhenAnyValue(vm => vm.CanCreateElementDefinition));
+            this.CopyParameterGroupCommand = ReactiveCommandCreator.Create(this.ExecuteCopyParameterGroup, this.WhenAnyValue(vm => vm.CanCopyParameterGroup));
+            this.PasteParameterGroupCommand = ReactiveCommandCreator.Create(this.ExecutePasteParameterGroup, this.WhenAnyValue(vm => vm.CanPasteParameterGroup));
             this.CreateSubscriptionCommand = ReactiveCommandCreator.Create(this.ExecuteCreateSubscriptionCommand, this.WhenAnyValue(x => x.CanCreateSubscription));
             this.BatchCreateSubscriptionCommand = ReactiveCommandCreator.Create(this.ExecuteBatchCreateSubscriptionCommand, this.WhenAnyValue(x => x.CanCreateBatchSubscriptions));
             this.BatchDeleteSubscriptionCommand = ReactiveCommandCreator.Create(this.ExecuteBatchDeleteSubscriptionCommand, this.WhenAnyValue(x => x.CanDeleteBatchSubscriptions));
@@ -599,6 +639,8 @@ namespace CDP4EngineeringModel.ViewModels
         public override void ComputePermission()
         {
             base.ComputePermission();
+
+            this.ComputeCopyPasteParameterPermission();
 
             if (this.SelectedThing == null)
             {
@@ -668,16 +710,17 @@ namespace CDP4EngineeringModel.ViewModels
                 this.ContextMenu.Insert(0, new ContextMenuItemViewModel("Create an Element Definition", "", this.CreateElementDefinition, MenuItemKind.Create, ClassKind.ElementDefinition));
                 this.ContextMenu.Insert(1, new ContextMenuItemViewModel("Create a Parameter Group", "", this.CreateParameterGroup, MenuItemKind.Create, ClassKind.ParameterGroup));
                 this.ContextMenu.Insert(2, new ContextMenuItemViewModel("Copy the Element Definition", "", this.CopyElementDefinitionCommand, MenuItemKind.Copy, ClassKind.ElementDefinition));
-                this.ContextMenu.Insert(3, new ContextMenuItemViewModel("Highlight Element Usages", "", this.HighlightElementUsagesCommand, MenuItemKind.Highlight, ClassKind.ElementUsage));
-                this.ContextMenu.Insert(4, new ContextMenuItemViewModel("Change Ownership", "", this.ChangeOwnershipCommand, MenuItemKind.Edit, ClassKind.NotThing));
+                this.ContextMenu.Insert(3, new ContextMenuItemViewModel("Paste a Parameter or Parameter Group", "CTRL+V", this.PasteParameterGroupCommand, MenuItemKind.None, ClassKind.Parameter));
+                this.ContextMenu.Insert(4, new ContextMenuItemViewModel("Highlight Element Usages", "", this.HighlightElementUsagesCommand, MenuItemKind.Highlight, ClassKind.ElementUsage));
+                this.ContextMenu.Insert(5, new ContextMenuItemViewModel("Change Ownership", "", this.ChangeOwnershipCommand, MenuItemKind.Edit, ClassKind.NotThing));
 
                 if (elementDefRow.IsTopElement)
                 {
-                    this.ContextMenu.Insert(5, new ContextMenuItemViewModel("Unset as Top Element", "", this.UnsetAsTopElementDefinitionCommand, MenuItemKind.Edit, ClassKind.NotThing));
+                    this.ContextMenu.Insert(6, new ContextMenuItemViewModel("Unset as Top Element", "", this.UnsetAsTopElementDefinitionCommand, MenuItemKind.Edit, ClassKind.NotThing));
                 }
                 else
                 {
-                    this.ContextMenu.Insert(5, new ContextMenuItemViewModel("Set as Top Element", "", this.SetAsTopElementDefinitionCommand, MenuItemKind.Edit, ClassKind.NotThing));
+                    this.ContextMenu.Insert(6, new ContextMenuItemViewModel("Set as Top Element", "", this.SetAsTopElementDefinitionCommand, MenuItemKind.Edit, ClassKind.NotThing));
                 }
 
                 return;
@@ -728,6 +771,8 @@ namespace CDP4EngineeringModel.ViewModels
             if (parameterGroupRow != null)
             {
                 this.ContextMenu.Insert(0, new ContextMenuItemViewModel("Create a Parameter Group", "", this.CreateParameterGroup, MenuItemKind.Create, ClassKind.ParameterGroup));
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Copy the Parameter Group", "CTRL+C", this.CopyParameterGroupCommand, MenuItemKind.Copy, ClassKind.ParameterGroup));
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Paste a Parameter or Parameter Group", "CTRL+V", this.PasteParameterGroupCommand, MenuItemKind.None, ClassKind.ParameterGroup));
                 return;
             }
 
@@ -743,6 +788,9 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ContextMenu.Insert(0, new ContextMenuItemViewModel("Subscribe to this Parameter", "", this.CreateSubscriptionCommand, MenuItemKind.Create, ClassKind.ParameterSubscription));
                 }
+
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Copy the Parameter", "CTRL+C", this.CopyParameterGroupCommand, MenuItemKind.Copy, ClassKind.Parameter));
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Paste a Parameter or Parameter Group", "CTRL+V", this.PasteParameterGroupCommand, MenuItemKind.None, ClassKind.Parameter));
 
                 return;
             }
@@ -1283,6 +1331,98 @@ namespace CDP4EngineeringModel.ViewModels
         }
 
         /// <summary>
+        /// Computes whether the <see cref="CopyParameterGroupCommand"/> and <see cref="PasteParameterGroupCommand"/> shall be enabled
+        /// </summary>
+        private void ComputeCopyPasteParameterPermission()
+        {
+            this.CanCopyParameterGroup = this.SelectedThing is ParameterRowViewModel || this.SelectedThing is ParameterGroupRowViewModel;
+
+            var targetElementDefinition = this.GetPasteTargetElementDefinition();
+
+            this.CanPasteParameterGroup = ParameterClipboard.CopiedThing != null
+                                          && targetElementDefinition != null
+                                          && this.PermissionService.CanWrite(ClassKind.Parameter, targetElementDefinition);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ElementDefinition"/> that the copied <see cref="Parameter"/> or <see cref="ParameterGroup"/> would be pasted into
+        /// based on the currently selected row, or null when no valid target can be resolved.
+        /// </summary>
+        /// <returns>The target <see cref="ElementDefinition"/> or null</returns>
+        private ElementDefinition GetPasteTargetElementDefinition()
+        {
+            switch (this.SelectedThing)
+            {
+                case ElementDefinitionRowViewModel elementDefinitionRow:
+                    return elementDefinitionRow.Thing;
+                case ParameterGroupRowViewModel parameterGroupRow:
+                    return parameterGroupRow.Thing.GetContainerOfType<ElementDefinition>();
+                case ParameterRowViewModel parameterRow when parameterRow.ContainerViewModel is ElementDefinitionRowViewModel:
+                    return parameterRow.Thing.GetContainerOfType<ElementDefinition>();
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Execute the <see cref="CopyParameterGroupCommand"/>
+        /// </summary>
+        private void ExecuteCopyParameterGroup()
+        {
+            if (this.SelectedThing == null || !(this.SelectedThing.Thing is Parameter || this.SelectedThing.Thing is ParameterGroup))
+            {
+                return;
+            }
+
+            ParameterClipboard.CopiedThing = this.SelectedThing.Thing;
+            this.ComputeCopyPasteParameterPermission();
+        }
+
+        /// <summary>
+        /// Execute the <see cref="PasteParameterGroupCommand"/>
+        /// </summary>
+        private async void ExecutePasteParameterGroup()
+        {
+            var source = ParameterClipboard.CopiedThing;
+            var targetElementDefinition = this.GetPasteTargetElementDefinition();
+
+            if (source == null || targetElementDefinition == null)
+            {
+                return;
+            }
+
+            var targetIteration = targetElementDefinition.GetContainerOfType<Iteration>();
+            var owner = targetIteration == null ? null : this.Session.QuerySelectedDomainOfExpertise(targetIteration);
+
+            if (owner == null)
+            {
+                this.Feedback = "The domain of expertise of the user performing the action could not be determined.";
+                return;
+            }
+
+            var targetGroup = (this.SelectedThing as ParameterGroupRowViewModel)?.Thing;
+
+            try
+            {
+                this.IsBusy = true;
+
+                var copyCreator = new CopyParameterAndGroupCreator(this.Session);
+                var warnings = await copyCreator.Copy(source, targetElementDefinition, targetGroup, owner);
+
+                this.Feedback = warnings.Any() ? string.Join(" ", warnings) : string.Empty;
+            }
+            catch (Exception exception)
+            {
+                logger.Error(exception, "An error occured when pasting a Parameter or Parameter Group");
+                this.Feedback = exception.Message;
+            }
+            finally
+            {
+                this.IsBusy = false;
+            }
+        }
+
+        /// <summary>
         /// Execute the <see cref="BatchCreateSubscriptionCommand"/>
         /// </summary>
         /// <returns>
@@ -1505,6 +1645,26 @@ namespace CDP4EngineeringModel.ViewModels
                 .Subscribe(_ => this.UpdateProperties());
 
             this.Disposables.Add(iterationSetupSubscription);
+
+            var sessionCloseSubscription = this.Session.CDPMessageBus.Listen<SessionEvent>()
+                .Where(sessionEvent => sessionEvent.Session == this.Session && sessionEvent.Status == SessionStatus.Closed)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.ClearParameterClipboardForClosedSession());
+
+            this.Disposables.Add(sessionCloseSubscription);
+        }
+
+        /// <summary>
+        /// Clears the shared <see cref="ParameterClipboard"/> when the copied <see cref="Thing"/> originates from the
+        /// <see cref="ISession"/> that is being closed, so that it cannot be pasted from a session that is no longer open and
+        /// the copied object graph is released for garbage collection.
+        /// </summary>
+        private void ClearParameterClipboardForClosedSession()
+        {
+            if (ParameterClipboard.CopiedThing != null && ParameterClipboard.CopiedThing.Cache == this.Session.Assembler.Cache)
+            {
+                ParameterClipboard.CopiedThing = null;
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
+++ b/EngineeringModel/Views/ElementDefinitionBrowser/ElementDefinitionsBrowser.xaml
@@ -85,11 +85,14 @@
                 </b:Interaction.Behaviors>
                 <dxmvvm:Interaction.Behaviors>
                     <cdp4Composition:ContextMenuBehavior />
+                    <dxmvvm:KeyToCommand KeyGesture="Ctrl+C" Command="{Binding Path=CopyParameterGroupCommand}" />
+                    <dxmvvm:KeyToCommand KeyGesture="Ctrl+V" Command="{Binding Path=PasteParameterGroupCommand}" />
                 </dxmvvm:Interaction.Behaviors>
                 <dxg:TreeListControl.View>
                     <dragDrop:TreeListViewDragDrop Name="View"
                                       AllowEditing="False"
                                       AutoWidth="False"
+                                      ClipboardCopyAllowed="False"
                                       EditorShowMode="MouseUpFocused"
                                       ExpandCollapseNodesOnNavigation="True"
                                       ExpandStateFieldName="IsExpanded"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description

Feat #24 

Adds copy/paste of a Parameter or a ParameterGroup (with its nested groups and parameters) between Element Definitions via context menu and Ctrl+C/Ctrl+V, copying only the definitions. Values reset to default, parameters whose ParameterType already exists on the target are skipped, and the pasting domain becomes the owner. A process-wide clipboard lets you paste across any iteration/model open in the same session, skipping parameters whose reference data isn't in the target model's RDL chain and it drops the state dependency if that statelist is not present. 
