### PR TITLE
Fix #329 : Disabled validaition with [ValidationOverride(false)] on Native Name of natural language

### DIFF
--- a/CDP4SiteDirectory.Tests/Dialogs/NaturalLanguageDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/NaturalLanguageDialogViewModelTestFixture.cs
@@ -38,6 +38,7 @@ namespace CDP4SiteDirectory.Tests.Dialogs
     using CDP4Common.SiteDirectoryData;
     using CDP4Common.Types;
 
+    using CDP4Composition.Attributes;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
 
@@ -163,6 +164,16 @@ namespace CDP4SiteDirectory.Tests.Dialogs
         {
             var naturalLanguageDialogViewModel = new NaturalLanguageDialogViewModel();
             Assert.IsNotNull(naturalLanguageDialogViewModel);
+        }
+
+        [Test]
+        public void VerifyThatNativeNameValidationIsDisabled()
+        {
+            var property = typeof(NaturalLanguageDialogViewModel).GetProperty(nameof(NaturalLanguageDialogViewModel.NativeName));
+            var attribute = property.GetCustomAttributes(typeof(ValidationOverrideAttribute), true).Cast<ValidationOverrideAttribute>().SingleOrDefault();
+
+            Assert.IsNotNull(attribute, "The NativeName property should carry a ValidationOverrideAttribute.");
+            Assert.IsFalse(attribute.IsValidationEnabled, "The NativeName is a free-text string and its validation must be disabled.");
         }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/Dialogs/NaturalLanguageDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/NaturalLanguageDialogViewModel.cs
@@ -1,6 +1,25 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="NaturalLanguageDialogViewModel.cs" company="Starion Group S.A.">
-//   Copyright (c) 2015 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
@@ -17,12 +36,19 @@ namespace CDP4SiteDirectory.ViewModels
     using CDP4Dal;
     using CDP4SiteDirectory.Views;
 
+    using ReactiveUI;
+
     /// <summary>
     /// The corresponding view-model for the <see cref="DomainOfExpertiseDialog"/> view used to create, edit or inspect a <see cref="DomainOfExpertise"/>
     /// </summary>
     [ThingDialogViewModelExport(ClassKind.NaturalLanguage)]
     public class NaturalLanguageDialogViewModel : CDP4CommonView.NaturalLanguageDialogViewModel, IThingDialogViewModel
     {
+        /// <summary>
+        /// Backing field for <see cref="NativeName"/>
+        /// </summary>
+        private string nativeName;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NaturalLanguageDialogViewModel"/> class
         /// </summary>
@@ -56,6 +82,19 @@ namespace CDP4SiteDirectory.ViewModels
         /// </summary>
         public NaturalLanguageDialogViewModel()
         {
+        }
+
+        /// <summary>
+        /// Gets or sets the NativeName of the current <see cref="NaturalLanguage"/>
+        /// </summary>
+        /// <remarks>
+        /// The NativeName is a free-text <see cref="string"/>, not a ShortName, so its validation has been disabled.
+        /// </remarks>
+        [ValidationOverride(false)]
+        public override string NativeName
+        {
+            get => this.nativeName;
+            set => this.RaiseAndSetIfChanged(ref this.nativeName, value);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
FIXED #329 
Removed Validation on NativeName for a Natural Language by giving it the [ValidationOverride(false)] attribute in the NaturalLanguageDialogViewmodel.cs
