### PR TITLE
Feat #195 : AutoRefresh in Excel add-in.

### DIFF
--- a/CDP4Addin.Tests/OfficeRibbon/AddinRibbonPartTestFixture.cs
+++ b/CDP4Addin.Tests/OfficeRibbon/AddinRibbonPartTestFixture.cs
@@ -99,6 +99,9 @@ namespace CDP4Addin.Tests.OfficeRibbon
 
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDirectory);
             this.session.Setup(x => x.DataSourceUri).Returns("test");
+            this.session.Setup(x => x.Name).Returns("test");
+            this.session.Setup(x => x.Refresh()).Returns(Task.CompletedTask);
+            this.session.Setup(x => x.Reload()).Returns(Task.CompletedTask);
             this.session.Setup(x => x.Assembler).Returns(this.assembler);
             var iterationDictionary = new Dictionary<CDP4Common.EngineeringModelData.Iteration, Tuple<DomainOfExpertise, Participant>>();
             this.session.Setup(x => x.OpenIterations).Returns(iterationDictionary);
@@ -134,7 +137,7 @@ namespace CDP4Addin.Tests.OfficeRibbon
 
             this.serviceLocator.Setup(s => s.GetInstance<IAssemblyInformationService>()).Returns(this.assemblyLocationLoader.Object);
 
-            this.amountOfRibbonControls = 9;
+            this.amountOfRibbonControls = 18;
             this.order = 1;
 
             this.ribbonPart = new AddinRibbonPart(this.order, this.panelNavigationService.Object, null, this.dialogNavigationService.Object, null, this.appSettingService.Object, this.messageBus, this.exceptionHandlerService.Object, this.sessionCreator.Object);
@@ -185,6 +188,11 @@ namespace CDP4Addin.Tests.OfficeRibbon
             Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_SelectModelToOpen"));
             Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_SelectModelToClose"));
             Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_Plugins"));
+            Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_Refresh"));
+            Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_Reload"));
+            Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_AutoRefreshToggle"));
+            Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_AutoRefreshInterval"));
+            Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_AutoRefreshCountdown"));
 
             var openSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
             this.messageBus.SendMessage(openSessionEvent);
@@ -195,6 +203,11 @@ namespace CDP4Addin.Tests.OfficeRibbon
             Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_SelectModelToOpen"));
             Assert.IsFalse(this.ribbonPart.GetEnabled("CDP4_SelectModelToClose"));
             Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_Plugins"));
+            Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_Refresh"));
+            Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_Reload"));
+            Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_AutoRefreshToggle"));
+            Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_AutoRefreshInterval"));
+            Assert.IsTrue(this.ribbonPart.GetEnabled("CDP4_AutoRefreshCountdown"));
 
             var closeSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Closed);
             this.messageBus.SendMessage(closeSessionEvent);
@@ -250,6 +263,87 @@ namespace CDP4Addin.Tests.OfficeRibbon
             await this.ribbonPart.OnAction("CDP4_SelectModelToOpen");
 
             this.dialogNavigationService.Verify(x => x.NavigateModal(It.IsAny<IDialogViewModel>()));
+        }
+
+        [Test]
+        public async Task Verify_that_when_On_Action_CDP4_Refresh_the_session_is_refreshed()
+        {
+            var openSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
+            this.messageBus.SendMessage(openSessionEvent);
+
+            await this.ribbonPart.OnAction("CDP4_Refresh");
+
+            this.session.Verify(x => x.Refresh());
+        }
+
+        [Test]
+        public async Task Verify_that_when_On_Action_CDP4_Reload_the_session_is_reloaded()
+        {
+            var openSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
+            this.messageBus.SendMessage(openSessionEvent);
+
+            await this.ribbonPart.OnAction("CDP4_Reload");
+
+            this.session.Verify(x => x.Reload());
+        }
+
+        [Test]
+        public async Task Verify_that_CDP4_AutoRefreshToggle_toggles_the_pressed_state()
+        {
+            var openSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
+            this.messageBus.SendMessage(openSessionEvent);
+
+            Assert.IsFalse(this.ribbonPart.GetPressed("CDP4_AutoRefreshToggle"));
+
+            await this.ribbonPart.OnAction("CDP4_AutoRefreshToggle");
+
+            Assert.IsTrue(this.ribbonPart.GetPressed("CDP4_AutoRefreshToggle"));
+
+            await this.ribbonPart.OnAction("CDP4_AutoRefreshToggle");
+
+            Assert.IsFalse(this.ribbonPart.GetPressed("CDP4_AutoRefreshToggle"));
+        }
+
+        [Test]
+        public void Verify_that_the_interval_editBox_text_reflects_and_updates_the_interval()
+        {
+            var openSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
+            this.messageBus.SendMessage(openSessionEvent);
+
+            Assert.AreEqual("60", this.ribbonPart.GetText("CDP4_AutoRefreshInterval"));
+
+            this.ribbonPart.OnChange("CDP4_AutoRefreshInterval", "120");
+            Assert.AreEqual("120", this.ribbonPart.GetText("CDP4_AutoRefreshInterval"));
+
+            // out-of-range values are clamped
+            this.ribbonPart.OnChange("CDP4_AutoRefreshInterval", "9000");
+            Assert.AreEqual("300", this.ribbonPart.GetText("CDP4_AutoRefreshInterval"));
+
+            // invalid input is ignored and the previous value kept
+            this.ribbonPart.OnChange("CDP4_AutoRefreshInterval", "abc");
+            Assert.AreEqual("300", this.ribbonPart.GetText("CDP4_AutoRefreshInterval"));
+        }
+
+        [Test]
+        public void Verify_that_the_countdown_is_hidden_and_empty_when_auto_refresh_is_off()
+        {
+            var openSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
+            this.messageBus.SendMessage(openSessionEvent);
+
+            Assert.IsFalse(this.ribbonPart.GetVisible("CDP4_AutoRefreshCountdown"));
+            Assert.AreEqual(string.Empty, this.ribbonPart.GetLabel("CDP4_AutoRefreshCountdown"));
+        }
+
+        [Test]
+        public async Task Verify_that_the_countdown_is_shown_with_text_when_auto_refresh_is_enabled()
+        {
+            var openSessionEvent = new SessionEvent(this.session.Object, SessionStatus.Open);
+            this.messageBus.SendMessage(openSessionEvent);
+
+            await this.ribbonPart.OnAction("CDP4_AutoRefreshToggle");
+
+            Assert.IsTrue(this.ribbonPart.GetVisible("CDP4_AutoRefreshCountdown"));
+            Assert.That(this.ribbonPart.GetLabel("CDP4_AutoRefreshCountdown"), Does.StartWith("Next refresh in "));
         }
     }
 }

--- a/CDP4Addin.Tests/ViewModels/SessionRefreshViewModelTestFixture.cs
+++ b/CDP4Addin.Tests/ViewModels/SessionRefreshViewModelTestFixture.cs
@@ -1,0 +1,205 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SessionRefreshViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Addin.Tests.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reactive.Concurrency;
+    using System.Reactive.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using CDP4AddinCE.ViewModels;
+
+    using CDP4Dal;
+    using CDP4Dal.DAL;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="SessionRefreshViewModel"/>
+    /// </summary>
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    public class SessionRefreshViewModelTestFixture
+    {
+        /// <summary>
+        /// mocked data service
+        /// </summary>
+        private Mock<IDal> mockedDal;
+
+        /// <summary>
+        /// The view-model under test
+        /// </summary>
+        private SessionRefreshViewModel viewModel;
+
+        private List<CDP4Common.DTO.Thing> dalOutputs;
+
+        private CDPMessageBus messageBus;
+
+        private Session session;
+
+        [SetUp]
+        public void SetUp()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            this.messageBus = new CDPMessageBus();
+            this.dalOutputs = new List<CDP4Common.DTO.Thing>();
+
+            var sitedirectory = new CDP4Common.DTO.SiteDirectory(Guid.NewGuid(), 22);
+
+            var person = new CDP4Common.DTO.Person(Guid.NewGuid(), 22)
+            {
+                ShortName = "John"
+            };
+
+            sitedirectory.Person.Add(person.Iid);
+            this.dalOutputs.Add(sitedirectory);
+            this.dalOutputs.Add(person);
+
+            this.mockedDal = new Mock<IDal>();
+            this.mockedDal.Setup(x => x.Close());
+
+            var credentials = new Credentials("John", "Doe", new Uri("https://www.stariongroup.eu/"));
+
+            this.session = new Session(this.mockedDal.Object, credentials, this.messageBus);
+
+            this.viewModel = new SessionRefreshViewModel(this.session);
+
+            var openTaskCompletionSource = new TaskCompletionSource<IEnumerable<CDP4Common.DTO.Thing>>();
+            openTaskCompletionSource.SetResult(this.dalOutputs);
+            this.mockedDal.Setup(x => x.Open(It.IsAny<Credentials>(), It.IsAny<CancellationToken>())).Returns(openTaskCompletionSource.Task);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            this.viewModel.Dispose();
+            this.messageBus.ClearSubscriptions();
+        }
+
+        [Test]
+        public void VerifyThatConstructorThrowsOnNullSession()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SessionRefreshViewModel(null));
+        }
+
+        [Test]
+        public void VerifyThatAutoRefreshCanBeSet()
+        {
+            Assert.AreEqual(SessionRefreshViewModel.DefaultRefreshInterval, this.viewModel.AutoRefreshInterval);
+
+            this.viewModel.AutoRefreshInterval = 50;
+            Assert.AreEqual(50, this.viewModel.AutoRefreshInterval);
+
+            this.viewModel.IsAutoRefreshEnabled = true;
+            Assert.IsTrue(this.viewModel.IsAutoRefreshEnabled);
+            Assert.AreEqual(50, this.viewModel.AutoRefreshSecondsLeft);
+        }
+
+        [Test]
+        public void VerifyThatSetIntervalFromTextParsesAndClamps()
+        {
+            this.viewModel.SetIntervalFromText("120");
+            Assert.AreEqual(120, this.viewModel.AutoRefreshInterval);
+
+            this.viewModel.SetIntervalFromText("9000");
+            Assert.AreEqual(SessionRefreshViewModel.MaximumRefreshInterval, this.viewModel.AutoRefreshInterval);
+
+            this.viewModel.SetIntervalFromText("1");
+            Assert.AreEqual(SessionRefreshViewModel.MinimumRefreshInterval, this.viewModel.AutoRefreshInterval);
+
+            // invalid input is ignored and the previous value kept
+            this.viewModel.SetIntervalFromText("not-a-number");
+            Assert.AreEqual(SessionRefreshViewModel.MinimumRefreshInterval, this.viewModel.AutoRefreshInterval);
+        }
+
+        [Test]
+        public async Task VerifyThatRefreshUpdatesTheLastUpdateDateTime()
+        {
+            var updatedSiteDir = new CDP4Common.DTO.SiteDirectory(this.dalOutputs[0].Iid, 30);
+
+            var readTaskCompletionSource = new TaskCompletionSource<IEnumerable<CDP4Common.DTO.Thing>>();
+            readTaskCompletionSource.SetResult(new List<CDP4Common.DTO.Thing> { updatedSiteDir });
+            this.mockedDal.Setup(x => x.Read(It.IsAny<CDP4Common.DTO.Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>())).Returns(readTaskCompletionSource.Task);
+
+            await this.session.Open();
+
+            var datetime = DateTime.Now;
+            await this.viewModel.Refresh.Execute();
+
+            Assert.IsFalse(datetime > this.viewModel.LastUpdateDateTime);
+        }
+
+        [Test]
+        public async Task VerifyThatReloadUpdatesTheLastUpdateDateTime()
+        {
+            var updatedSiteDir = new CDP4Common.DTO.SiteDirectory(this.dalOutputs[0].Iid, 30);
+
+            var readTaskCompletionSource = new TaskCompletionSource<IEnumerable<CDP4Common.DTO.Thing>>();
+            readTaskCompletionSource.SetResult(new List<CDP4Common.DTO.Thing> { updatedSiteDir });
+            this.mockedDal.Setup(x => x.Read(It.IsAny<CDP4Common.DTO.Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>())).Returns(readTaskCompletionSource.Task);
+
+            await this.session.Open();
+
+            var datetime = DateTime.Now;
+            await this.viewModel.Reload.Execute();
+
+            Assert.IsFalse(datetime > this.viewModel.LastUpdateDateTime);
+        }
+
+        [Test]
+        public async Task VerifyThatErrorMessageIsReceivedUponRefreshFailure()
+        {
+            await this.session.Open();
+
+            this.mockedDal.Setup(x => x.Read(It.IsAny<CDP4Common.DTO.Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()))
+                .ThrowsAsync(new Exception("test failure"));
+
+            await this.viewModel.Refresh.Execute();
+
+            Assert.AreEqual("test failure", this.viewModel.ErrorMessage);
+        }
+
+        [Test]
+        public async Task VerifyThatErrorMessageIsReceivedUponReloadFailure()
+        {
+            await this.session.Open();
+
+            this.mockedDal.Setup(x => x.Read(It.IsAny<CDP4Common.DTO.Thing>(), It.IsAny<CancellationToken>(), It.IsAny<IQueryAttributes>()))
+                .ThrowsAsync(new Exception("test failure"));
+
+            await this.viewModel.Reload.Execute();
+
+            Assert.AreEqual("test failure", this.viewModel.ErrorMessage);
+        }
+    }
+}

--- a/CDP4Addin/Addin.cs
+++ b/CDP4Addin/Addin.cs
@@ -40,6 +40,7 @@ namespace CDP4AddinCE
     using System.Threading.Tasks;
     using System.Windows;
 
+    using CDP4AddinCE.Events;
     using CDP4AddinCE.Settings;
     using CDP4AddinCE.Utils;
 
@@ -191,6 +192,90 @@ namespace CDP4AddinCE
             try
             {
                 await this.FluentRibbonManager.OnAction(control.Id, control.Tag);
+            }
+            catch (Exception ex)
+            {
+                // NOTE: manually handle exceptions as the UI specific dispatcher thread does not work
+                HandleException(ex);
+            }
+
+            if (this.RibbonUI != null)
+            {
+                this.RibbonUI.Invalidate();
+            }
+            else
+            {
+                logger.Warn("The RibbonUI is null and cannot be invalidated");
+            }
+        }
+
+        /// <summary>
+        /// Executes the OnAction callback for a toggle/checkBox control that is invoked from the <see cref="Office.IRibbonControl"/>
+        /// </summary>
+        /// <param name="control">
+        /// The ribbon control that invokes the callback
+        /// </param>
+        /// <param name="pressed">
+        /// a value indicating whether the toggle control is pressed
+        /// </param>
+        /// <remarks>
+        /// A checkBox or toggleButton uses a different callback signature than a regular button. The pressed state is
+        /// owned by the <see cref="RibbonPart"/>; the control is toggled there and re-queried through GetPressed.
+        /// </remarks>
+        public async Task OnToggleAction(IRibbonControl control, bool pressed)
+        {
+            logger.Trace("{0} OnToggleAction {1}", control.Id, pressed);
+
+            try
+            {
+                await this.FluentRibbonManager.OnAction(control.Id, control.Tag);
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+            }
+
+            if (this.RibbonUI != null)
+            {
+                this.RibbonUI.Invalidate();
+            }
+            else
+            {
+                logger.Warn("The RibbonUI is null and cannot be invalidated");
+            }
+        }
+
+        /// <summary>
+        /// Executes the GetText callback that supplies the text shown in an editBox control
+        /// </summary>
+        /// <param name="control">
+        /// The ribbon control that invokes the callback
+        /// </param>
+        /// <returns>
+        /// the text shown in the editBox
+        /// </returns>
+        public string GetText(IRibbonControl control)
+        {
+            logger.Trace("{0} GetText", control.Id);
+            return this.FluentRibbonManager.GetText(control.Id, control.Tag);
+        }
+
+        /// <summary>
+        /// Executes the OnChange callback that is invoked when the text of an editBox control has changed
+        /// </summary>
+        /// <param name="control">
+        /// The ribbon control that invokes the callback
+        /// </param>
+        /// <param name="text">
+        /// The new text entered in the editBox
+        /// </param>
+        public void OnEditBoxChange(IRibbonControl control, string text)
+        {
+            logger.Trace("{0} OnEditBoxChange {1}", control.Id, text);
+
+            try
+            {
+                this.FluentRibbonManager.OnChange(control.Id, text, control.Tag);
             }
             catch (Exception ex)
             {
@@ -461,6 +546,10 @@ namespace CDP4AddinCE
                 .Where(x => x.Status == SessionStatus.Closed)
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(this.HandleCloseSession);
+
+            this.messageBus.Listen<RibbonInvalidationEvent>()
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.RibbonUI?.Invalidate());
         }
 
         /// <summary>

--- a/CDP4Addin/Events/RibbonInvalidationEvent.cs
+++ b/CDP4Addin/Events/RibbonInvalidationEvent.cs
@@ -25,10 +25,13 @@
 
 namespace CDP4AddinCE.Events
 {
+    using System.Runtime.InteropServices;
+
     /// <summary>
     /// An event published on the <see cref="CDP4Dal.ICDPMessageBus"/> to request that the Office Fluent Ribbon
     /// re-queries its callbacks (for example to update the auto-refresh countdown shown on the ribbon).
     /// </summary>
+    [ComVisible(false)]
     public class RibbonInvalidationEvent
     {
     }

--- a/CDP4Addin/Events/RibbonInvalidationEvent.cs
+++ b/CDP4Addin/Events/RibbonInvalidationEvent.cs
@@ -1,0 +1,35 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RibbonInvalidationEvent.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4AddinCE.Events
+{
+    /// <summary>
+    /// An event published on the <see cref="CDP4Dal.ICDPMessageBus"/> to request that the Office Fluent Ribbon
+    /// re-queries its callbacks (for example to update the auto-refresh countdown shown on the ribbon).
+    /// </summary>
+    public class RibbonInvalidationEvent
+    {
+    }
+}

--- a/CDP4Addin/OfficeRibbon/AddinRibbonPart.cs
+++ b/CDP4Addin/OfficeRibbon/AddinRibbonPart.cs
@@ -27,10 +27,13 @@ namespace CDP4AddinCE
 {
     using System;
     using System.Collections.Generic;
+    using System.Reactive.Linq;
     using System.Reflection;
     using System.Threading.Tasks;
 
+    using CDP4AddinCE.Events;
     using CDP4AddinCE.Settings;
+    using CDP4AddinCE.ViewModels;
 
     using CDP4Common.ExceptionHandlerService;
 
@@ -47,6 +50,8 @@ namespace CDP4AddinCE
     using CDP4ShellDialogs.ViewModels;
 
     using NLog;
+
+    using ReactiveUI;
 
     /// <summary>
     /// The purpose of the <see cref="AddinRibbonPart"/> class is to describe and provide a part of the Fluent Ribbon
@@ -80,9 +85,23 @@ namespace CDP4AddinCE
         private readonly ISessionCreator sessionCreator;
 
         /// <summary>
-        /// The <see cref="IAuthenticationRefreshService" /> that provides authentication refresh behavior 
+        /// The <see cref="IAuthenticationRefreshService" /> that provides authentication refresh behavior
         /// </summary>
         private IAuthenticationRefreshService authenticationRefreshService;
+
+        /// <summary>
+        /// The <see cref="SessionRefreshViewModel"/> that holds the auto-refresh state and timer for the active <see cref="session"/>.
+        /// </summary>
+        /// <remarks>
+        /// A single instance is kept alive for the lifetime of the <see cref="session"/> so that the automatic refresh
+        /// timer keeps running in the background while the user works in Excel.
+        /// </remarks>
+        private SessionRefreshViewModel sessionRefreshViewModel;
+
+        /// <summary>
+        /// The subscription that requests a ribbon refresh while the auto-refresh countdown is running.
+        /// </summary>
+        private IDisposable countdownSubscription;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AddinRibbonPart"/> class.
@@ -166,6 +185,16 @@ namespace CDP4AddinCE
                     var modelPluginDialogViewModel = new PluginManagerViewModel<AddinAppSettings>(this.appSettingService);
                     var modelPluginDialogResult = this.DialogNavigationService.NavigateModal(modelPluginDialogViewModel) as DataSourceSelectionResult;
                     break;
+                case "CDP4_Refresh":
+                    await this.GetOrCreateSessionRefreshViewModel().Refresh.Execute();
+                    break;
+                case "CDP4_Reload":
+                    await this.GetOrCreateSessionRefreshViewModel().Reload.Execute();
+                    break;
+                case "CDP4_AutoRefreshToggle":
+                    var toggled = this.GetOrCreateSessionRefreshViewModel();
+                    toggled.IsAutoRefreshEnabled = !toggled.IsAutoRefreshEnabled;
+                    break;
                 default:
                     logger.Debug("The ribbon control with Id {0} and Tag {1} is not handled by the current RibbonPart", ribbonControlId, ribbonControlTag);
                     break;
@@ -210,9 +239,157 @@ namespace CDP4AddinCE
                     return this.session != null && this.session.OpenIterations.Count > 0;
                 case "CDP4_Plugins":
                     return true;
+                case "CDP4_Refresh":
+                case "CDP4_Reload":
+                case "CDP4_AutoRefreshToggle":
+                case "CDP4_AutoRefreshInterval":
+                case "CDP4_AutoRefreshCountdown":
+                    return this.session != null;
                 default:
                     return false;
             }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether a control is visible or not
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        /// <returns>
+        /// true if visible, false if not
+        /// </returns>
+        public override bool GetVisible(string ribbonControlId, string ribbonControlTag = "")
+        {
+            switch (ribbonControlId)
+            {
+                case "CDP4_AutoRefreshCountdown":
+                    return this.sessionRefreshViewModel?.IsAutoRefreshEnabled ?? false;
+                default:
+                    return true;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether a toggle control is pressed or not
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        /// <returns>
+        /// true if pressed, false if not pressed
+        /// </returns>
+        public override bool GetPressed(string ribbonControlId, string ribbonControlTag = "")
+        {
+            switch (ribbonControlId)
+            {
+                case "CDP4_AutoRefreshToggle":
+                    return this.sessionRefreshViewModel?.IsAutoRefreshEnabled ?? false;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets the label as a <see cref="string"/> for the control
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        /// <returns>
+        /// the label that is displayed on the control
+        /// </returns>
+        public override string GetLabel(string ribbonControlId, string ribbonControlTag = "")
+        {
+            switch (ribbonControlId)
+            {
+                case "CDP4_AutoRefreshCountdown":
+                    var viewModel = this.sessionRefreshViewModel;
+
+                    if (viewModel == null || !viewModel.IsAutoRefreshEnabled)
+                    {
+                        return string.Empty;
+                    }
+
+                    return $"Next refresh in {viewModel.AutoRefreshSecondsLeft}s";
+                default:
+                    return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the text shown in an editBox control
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        /// <returns>
+        /// the text shown in the editBox
+        /// </returns>
+        public override string GetText(string ribbonControlId, string ribbonControlTag = "")
+        {
+            switch (ribbonControlId)
+            {
+                case "CDP4_AutoRefreshInterval":
+                    return (this.sessionRefreshViewModel?.AutoRefreshInterval ?? SessionRefreshViewModel.DefaultRefreshInterval).ToString();
+                default:
+                    return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Invoked when the text of an editBox control has changed
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="text">
+        /// The new text entered in the editBox
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        public override void OnChange(string ribbonControlId, string text, string ribbonControlTag = "")
+        {
+            switch (ribbonControlId)
+            {
+                case "CDP4_AutoRefreshInterval":
+                    this.GetOrCreateSessionRefreshViewModel().SetIntervalFromText(text);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SessionRefreshViewModel"/> associated to the active <see cref="session"/>, creating it on first use.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="SessionRefreshViewModel"/> that holds the auto-refresh state and timer for the active <see cref="session"/>.
+        /// </returns>
+        private SessionRefreshViewModel GetOrCreateSessionRefreshViewModel()
+        {
+            if (this.sessionRefreshViewModel == null)
+            {
+                this.sessionRefreshViewModel = new SessionRefreshViewModel(this.session);
+                
+                this.countdownSubscription = this.sessionRefreshViewModel
+                    .WhenAnyValue(x => x.IsAutoRefreshEnabled, x => x.AutoRefreshSecondsLeft)
+                    .Where(tuple => !tuple.Item1 || tuple.Item2 % 5 == 0)
+                    .Subscribe(_ => this.CDPMessageBus.SendMessage(new RibbonInvalidationEvent()));
+            }
+
+            return this.sessionRefreshViewModel;
         }
 
         /// <summary>
@@ -254,12 +431,17 @@ namespace CDP4AddinCE
             if (sessionChange.Status == SessionStatus.Open)
             {
                 this.session = sessionChange.Session;
+                this.GetOrCreateSessionRefreshViewModel();
             }
 
             if (sessionChange.Status == SessionStatus.Closed)
             {
                 this.authenticationRefreshService?.Dispose();
                 this.authenticationRefreshService = null;
+                this.countdownSubscription?.Dispose();
+                this.countdownSubscription = null;
+                this.sessionRefreshViewModel?.Dispose();
+                this.sessionRefreshViewModel = null;
                 this.session = null;
             }
         }

--- a/CDP4Addin/Resources/RibbonXml/addinribbon.xml
+++ b/CDP4Addin/Resources/RibbonXml/addinribbon.xml
@@ -9,15 +9,15 @@
     <button id="CDP4_SelectModelToClose" label="Close" screentip="Select an Engineering Model to close" imageMso="FileDropSqlDatabase" onAction="OnAction" getEnabled="GetEnabled" />
   </group>
   <group id="CDP4refresh" label="Refresh">
-    <box id="CDP4_RefreshRow1" boxStyle="horizontal">
+    <box id="CDP4_RefreshButtonsRow" boxStyle="horizontal">
       <button id="CDP4_Refresh" label="Refresh" screentip="Refresh the data-source (current revision + delta)" imageMso="Refresh" onAction="OnAction" getEnabled="GetEnabled" />
       <button id="CDP4_Reload" label="Reload" screentip="Reload all the data from the data-source (revision 0 + delta)" imageMso="RefreshAll" onAction="OnAction" getEnabled="GetEnabled" />
     </box>
-    <box id="CDP4_RefreshRow2" boxStyle="horizontal">
+    <box id="CDP4_AutoRefreshSettingsRow" boxStyle="horizontal">
       <checkBox id="CDP4_AutoRefreshToggle" label="Auto Refresh every" screentip="Enable automatic refresh of the data-source at the configured interval" getPressed="GetPressed" onAction="OnToggleAction" getEnabled="GetEnabled" />
       <editBox id="CDP4_AutoRefreshInterval" sizeString="000" screentip="Automatic refresh interval in seconds (5-300)" getText="GetText" onChange="OnEditBoxChange" getEnabled="GetEnabled" />
     </box>
-    <box id="CDP4_RefreshRow3" boxStyle="horizontal">
+    <box id="CDP4_AutoRefreshCountdownRow" boxStyle="horizontal">
       <button id="CDP4_AutoRefreshCountdown" getLabel="GetLabel" getVisible="GetVisible" getEnabled="GetEnabled" onAction="OnAction" />
     </box>
   </group>

--- a/CDP4Addin/Resources/RibbonXml/addinribbon.xml
+++ b/CDP4Addin/Resources/RibbonXml/addinribbon.xml
@@ -8,6 +8,19 @@
     <button id="CDP4_SelectModelToOpen" label="Open" screentip="Select an Engineering Model to open" imageMso="ServerConnection" onAction="OnAction" getEnabled="GetEnabled" />
     <button id="CDP4_SelectModelToClose" label="Close" screentip="Select an Engineering Model to close" imageMso="FileDropSqlDatabase" onAction="OnAction" getEnabled="GetEnabled" />
   </group>
+  <group id="CDP4refresh" label="Refresh">
+    <box id="CDP4_RefreshRow1" boxStyle="horizontal">
+      <button id="CDP4_Refresh" label="Refresh" screentip="Refresh the data-source (current revision + delta)" imageMso="Refresh" onAction="OnAction" getEnabled="GetEnabled" />
+      <button id="CDP4_Reload" label="Reload" screentip="Reload all the data from the data-source (revision 0 + delta)" imageMso="RefreshAll" onAction="OnAction" getEnabled="GetEnabled" />
+    </box>
+    <box id="CDP4_RefreshRow2" boxStyle="horizontal">
+      <checkBox id="CDP4_AutoRefreshToggle" label="Auto Refresh every" screentip="Enable automatic refresh of the data-source at the configured interval" getPressed="GetPressed" onAction="OnToggleAction" getEnabled="GetEnabled" />
+      <editBox id="CDP4_AutoRefreshInterval" sizeString="000" screentip="Automatic refresh interval in seconds (5-300)" getText="GetText" onChange="OnEditBoxChange" getEnabled="GetEnabled" />
+    </box>
+    <box id="CDP4_RefreshRow3" boxStyle="horizontal">
+      <button id="CDP4_AutoRefreshCountdown" getLabel="GetLabel" getVisible="GetVisible" getEnabled="GetEnabled" onAction="OnAction" />
+    </box>
+  </group>
   <group id="CDP4info" label="Info">
     <button id="CDP4_Plugins" label="Plugins" screentip="Select Plugins" imageMso="DatabaseAnalyzeTable" onAction="OnAction" getEnabled="GetEnabled" />
   </group>

--- a/CDP4Addin/ViewModels/SessionRefreshViewModel.cs
+++ b/CDP4Addin/ViewModels/SessionRefreshViewModel.cs
@@ -28,6 +28,7 @@ namespace CDP4AddinCE.ViewModels
     using System;
     using System.Reactive;
     using System.Reactive.Linq;
+    using System.Runtime.InteropServices;
     using System.Windows.Threading;
 
     using CDP4Composition.Mvvm;
@@ -45,6 +46,7 @@ namespace CDP4AddinCE.ViewModels
     /// and exposes the on-demand Refresh and Reload commands. This is the add-in counterpart of the auto-refresh
     /// control that is available on the ribbon of the CDP4-COMET IME.
     /// </summary>
+    [ComVisible(false)]
     public class SessionRefreshViewModel : ReactiveObject, IDisposable
     {
         /// <summary>

--- a/CDP4Addin/ViewModels/SessionRefreshViewModel.cs
+++ b/CDP4Addin/ViewModels/SessionRefreshViewModel.cs
@@ -1,0 +1,329 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SessionRefreshViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4AddinCE.ViewModels
+{
+    using System;
+    using System.Reactive;
+    using System.Reactive.Linq;
+    using System.Windows.Threading;
+
+    using CDP4Composition.Mvvm;
+    using CDP4Composition.Utilities;
+
+    using CDP4Dal;
+
+    using NLog;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Backs the auto-refresh controls that live directly on the Excel add-in ribbon. It holds the auto-refresh
+    /// state and a <see cref="DispatcherTimer"/> that refreshes the active <see cref="ISession"/> in the background,
+    /// and exposes the on-demand Refresh and Reload commands. This is the add-in counterpart of the auto-refresh
+    /// control that is available on the ribbon of the CDP4-COMET IME.
+    /// </summary>
+    public class SessionRefreshViewModel : ReactiveObject, IDisposable
+    {
+        /// <summary>
+        /// The NLog logger
+        /// </summary>
+        private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
+        /// <summary>
+        /// The default auto refresh interval expressed in seconds
+        /// </summary>
+        public const uint DefaultRefreshInterval = 60;
+
+        /// <summary>
+        /// The minimum auto refresh interval expressed in seconds
+        /// </summary>
+        public const uint MinimumRefreshInterval = 5;
+
+        /// <summary>
+        /// The maximum auto refresh interval expressed in seconds
+        /// </summary>
+        public const uint MaximumRefreshInterval = 300;
+
+        /// <summary>
+        /// The timer used to drive the automatic refresh
+        /// </summary>
+        private DispatcherTimer timer;
+
+        /// <summary>
+        /// Backing field for the <see cref="AutoRefreshInterval"/> property
+        /// </summary>
+        private uint autoRefreshInterval;
+
+        /// <summary>
+        /// Backing field for the <see cref="AutoRefreshSecondsLeft"/> property
+        /// </summary>
+        private uint autoRefreshSecondsLeft;
+
+        /// <summary>
+        /// Backing field for the <see cref="IsAutoRefreshEnabled"/> property
+        /// </summary>
+        private bool isAutoRefreshEnabled;
+
+        /// <summary>
+        /// Backing field for the <see cref="LastUpdateDateTime"/> property
+        /// </summary>
+        private DateTime lastUpdateDateTime;
+
+        /// <summary>
+        /// Backing field for the <see cref="ErrorMessage"/> property
+        /// </summary>
+        private string errorMessage;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SessionRefreshViewModel"/> class.
+        /// </summary>
+        /// <param name="session">
+        /// The <see cref="ISession"/> that is refreshed or reloaded
+        /// </param>
+        public SessionRefreshViewModel(ISession session)
+        {
+            this.Session = session ?? throw new ArgumentNullException(nameof(session));
+            this.AutoRefreshInterval = DefaultRefreshInterval;
+
+            this.Refresh = ReactiveCommandCreator.Create(this.ExecuteRefresh);
+            this.Reload = ReactiveCommandCreator.Create(this.ExecuteReload);
+
+            this.WhenAnyValue(
+                    x => x.IsAutoRefreshEnabled,
+                    x => x.AutoRefreshInterval)
+                .Subscribe(_ => this.SetTimer());
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ISession"/> that is encapsulated by the current <see cref="SessionRefreshViewModel"/>.
+        /// </summary>
+        public ISession Session { get; }
+
+        /// <summary>
+        /// Gets the Refresh <see cref="ReactiveCommand{TParam,TResult}"/> that refreshes the encapsulated <see cref="ISession"/>
+        /// (current revision + delta).
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> Refresh { get; }
+
+        /// <summary>
+        /// Gets the Reload <see cref="ReactiveCommand{TParam,TResult}"/> that reloads the encapsulated <see cref="ISession"/>
+        /// (revision 0 + delta).
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> Reload { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the automatic refresh of the <see cref="ISession"/> is enabled or disabled.
+        /// </summary>
+        public bool IsAutoRefreshEnabled
+        {
+            get => this.isAutoRefreshEnabled;
+
+            set => this.RaiseAndSetIfChanged(ref this.isAutoRefreshEnabled, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the auto-refresh interval expressed in seconds.
+        /// </summary>
+        public uint AutoRefreshInterval
+        {
+            get => this.autoRefreshInterval;
+
+            set => this.RaiseAndSetIfChanged(ref this.autoRefreshInterval, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the number of seconds left before the next automatic refresh.
+        /// </summary>
+        public uint AutoRefreshSecondsLeft
+        {
+            get => this.autoRefreshSecondsLeft;
+
+            set => this.RaiseAndSetIfChanged(ref this.autoRefreshSecondsLeft, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="DateTime"/> at which the session last refreshed or reloaded data from the server
+        /// </summary>
+        public DateTime LastUpdateDateTime
+        {
+            get => this.lastUpdateDateTime;
+
+            set => this.RaiseAndSetIfChanged(ref this.lastUpdateDateTime, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the message of the last error that occurred while refreshing or reloading, if any.
+        /// </summary>
+        public string ErrorMessage
+        {
+            get => this.errorMessage;
+
+            set => this.RaiseAndSetIfChanged(ref this.errorMessage, value);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="AutoRefreshInterval"/> from a user supplied string, clamping it to the allowed range.
+        /// Invalid input is ignored and the previous value is kept.
+        /// </summary>
+        /// <param name="text">
+        /// The text entered in the interval edit box
+        /// </param>
+        public void SetIntervalFromText(string text)
+        {
+            if (uint.TryParse(text, out var parsed))
+            {
+                this.AutoRefreshInterval = ClampInterval(parsed);
+            }
+        }
+
+        /// <summary>
+        /// Clamps an interval to the <see cref="MinimumRefreshInterval"/>..<see cref="MaximumRefreshInterval"/> range.
+        /// </summary>
+        /// <param name="interval">The interval to clamp.</param>
+        /// <returns>The clamped interval.</returns>
+        private static uint ClampInterval(uint interval)
+        {
+            if (interval < MinimumRefreshInterval)
+            {
+                return MinimumRefreshInterval;
+            }
+
+            return interval > MaximumRefreshInterval ? MaximumRefreshInterval : interval;
+        }
+
+        /// <summary>
+        /// Executes the <see cref="Refresh"/> Command and refreshes the <see cref="ISession"/>
+        /// </summary>
+        private async void ExecuteRefresh()
+        {
+            try
+            {
+                this.ErrorMessage = null;
+                await this.Session.Refresh();
+                this.LastUpdateDateTime = DateTime.Now;
+            }
+            catch (Exception e)
+            {
+                this.ErrorMessage = e.Message;
+                logger.Error(e, "The session {0} could not be refreshed", this.Session.DataSourceUri);
+            }
+        }
+
+        /// <summary>
+        /// Executes the <see cref="Reload"/> Command and reloads the <see cref="ISession"/>
+        /// </summary>
+        private async void ExecuteReload()
+        {
+            try
+            {
+                this.ErrorMessage = null;
+                await this.Session.Reload();
+                this.LastUpdateDateTime = DateTime.Now;
+            }
+            catch (Exception e)
+            {
+                this.ErrorMessage = e.Message;
+                logger.Error(e, "The session {0} could not be reloaded", this.Session.DataSourceUri);
+            }
+        }
+
+        /// <summary>
+        /// Sets the timer according to the current automatic refresh settings
+        /// </summary>
+        private void SetTimer()
+        {
+            if (this.IsAutoRefreshEnabled)
+            {
+                this.timer?.Stop();
+
+                this.AutoRefreshSecondsLeft = this.AutoRefreshInterval;
+
+                this.timer = new DispatcherTimer
+                {
+                    Interval = TimeSpan.FromSeconds(1)
+                };
+
+                this.timer.Tick += this.OnTimerElapsed;
+
+                this.timer.Start();
+            }
+            else
+            {
+                this.timer?.Stop();
+            }
+        }
+
+        /// <summary>
+        /// The event-handler that is invoked on every elapsed second of the <see cref="timer"/>.
+        /// </summary>
+        /// <param name="sender">The sender</param>
+        /// <param name="e">The event arguments.</param>
+        private async void OnTimerElapsed(object sender, EventArgs e)
+        {
+            this.AutoRefreshSecondsLeft -= 1;
+
+            if (this.AutoRefreshSecondsLeft == 0)
+            {
+                this.timer.Stop();
+
+                try
+                {
+                    LockProvider.EnterLock(LockType.SesionRefresh);
+                    this.ErrorMessage = null;
+                    await this.Session.Refresh();
+                    this.LastUpdateDateTime = DateTime.Now;
+                }
+                catch (Exception ex)
+                {
+                    this.ErrorMessage = ex.Message;
+                    logger.Error(ex, "The automatic refresh of session {0} failed", this.Session.DataSourceUri);
+                }
+                finally
+                {
+                    LockProvider.ExitLock(LockType.SesionRefresh);
+                    this.AutoRefreshSecondsLeft = this.AutoRefreshInterval;
+                    this.timer.Start();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Disposes of this <see cref="SessionRefreshViewModel"/>, stopping the automatic refresh timer.
+        /// </summary>
+        public void Dispose()
+        {
+            try
+            {
+                LockProvider.EnterLock(LockType.SesionRefresh);
+                this.timer?.Stop();
+            }
+            finally
+            {
+                LockProvider.ExitLock(LockType.SesionRefresh);
+            }
+        }
+    }
+}

--- a/CDP4Composition/OfficeRibbon/FluentRibbonManager.cs
+++ b/CDP4Composition/OfficeRibbon/FluentRibbonManager.cs
@@ -520,6 +520,47 @@ namespace CDP4Composition
         }
 
         /// <summary>
+        /// Gets the text shown in an editBox control
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        /// <returns>
+        /// a string that represents the text shown in the editBox
+        /// </returns>
+        public string GetText(string ribbonControlId, string ribbonControlTag = "")
+        {
+            var ribbonPart = this.GetRibbonPartBase(ribbonControlId);
+            if (ribbonPart != null)
+            {
+                return ribbonPart.GetText(ribbonControlId, ribbonControlTag);
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Invoked when the text of an editBox control has changed
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="text">
+        /// The new text entered in the editBox
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        public void OnChange(string ribbonControlId, string text, string ribbonControlTag = "")
+        {
+            var ribbonPart = this.GetRibbonPartBase(ribbonControlId);
+            ribbonPart?.OnChange(ribbonControlId, text, ribbonControlTag);
+        }
+
+        /// <summary>
         /// Gets a value indicating whether a control is visible or not
         /// </summary>
         /// <param name="ribbonControlId">

--- a/CDP4Composition/OfficeRibbon/IFluentRibbonCallback.cs
+++ b/CDP4Composition/OfficeRibbon/IFluentRibbonCallback.cs
@@ -181,6 +181,34 @@ namespace CDP4Composition.OfficeRibbon
         bool GetPressed(string ribbonControlId, string ribbonControlTag = "");
 
         /// <summary>
+        /// Gets the text shown in an editBox control
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        /// <returns>
+        /// a string that represents the text shown in the editBox
+        /// </returns>
+        string GetText(string ribbonControlId, string ribbonControlTag = "");
+
+        /// <summary>
+        /// Invoked when the text of an editBox control has changed
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="text">
+        /// The new text entered in the editBox
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        void OnChange(string ribbonControlId, string text, string ribbonControlTag = "");
+
+        /// <summary>
         /// Gets a value indicating whether a control is visible or not
         /// </summary>
         /// <param name="ribbonControlId">

--- a/CDP4Composition/OfficeRibbon/RibbonPart.cs
+++ b/CDP4Composition/OfficeRibbon/RibbonPart.cs
@@ -385,6 +385,41 @@ namespace CDP4Composition
         }
 
         /// <summary>
+        /// Gets the text shown in an editBox control
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        /// <returns>
+        /// a string that represents the text shown in the editBox
+        /// </returns>
+        public virtual string GetText(string ribbonControlId, string ribbonControlTag = "")
+        {
+            logger.Debug("The GetText method of the {0} is not overriden", this.GetType());
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Invoked when the text of an editBox control has changed
+        /// </summary>
+        /// <param name="ribbonControlId">
+        /// The Id property of the associated RibbonControl
+        /// </param>
+        /// <param name="text">
+        /// The new text entered in the editBox
+        /// </param>
+        /// <param name="ribbonControlTag">
+        /// The Tag property of the associated RibbonControl
+        /// </param>
+        public virtual void OnChange(string ribbonControlId, string text, string ribbonControlTag = "")
+        {
+            logger.Debug("The OnChange method of the {0} is not overriden", this.GetType());
+        }
+
+        /// <summary>
         /// Gets a value indicating whether a control is visible or not
         /// </summary>
         /// <param name="ribbonControlId">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feature #195 Auto refresh in the excel add-in.

Adds a Refresh group to the Excel add-in ribbon:  Refresh/Reload buttons, an Auto Refresh checkbox with a typeable interval, and a live "Next refresh in Xs" countdown in steps of 5 seconds. Could not add a progressbar in that field so this was the second best.
Auto-refresh runs on a background timer in a new SessionRefreshViewModel owned by AddinRibbonPart, and the ribbon is refreshed via a RibbonInvalidationEvent on the message bus.
Adds the getText/onChange ribbon callbacks to the shared IFluentRibbonCallback/RibbonPart/FluentRibbonManager.

<img width="281" height="158" alt="image" src="https://github.com/user-attachments/assets/e098f41d-a81c-4e87-a9bf-b7ebf50a1e33" />



