### PR TITLE
Feat #387 Possible to set BaseQuantityKind on All kinds of QuantityKinds

### DIFF
--- a/BasicRdl.Tests/ViewModels/Dialogs/SimpleQuantityKindDialogViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Dialogs/SimpleQuantityKindDialogViewModelTestFixture.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleQuantityKindDialogViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary, Rowan de Voogt
 //
 //    This file is part of COMET-IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -171,6 +171,27 @@ namespace BasicRdl.Tests.ViewModels
         public void VerifyThatParameterlessContructorExists()
         {
             Assert.DoesNotThrow(() => new SimpleQuantityKindDialogViewModel());
+        }
+
+        [Test]
+        public void VerifyThatIsBaseQuantityKindIsTrueWhenQuantityKindIsInRdlBaseQuantityKind()
+        {
+            this.rdl.ParameterType.Add(this.simpleQuantityKind);
+            this.rdl.BaseQuantityKind.Add(this.simpleQuantityKind);
+
+            var vm = new SimpleQuantityKindDialogViewModel(this.simpleQuantityKind, this.transaction, this.session.Object, true, ThingDialogKind.Inspect, this.navigation.Object, this.rdl);
+
+            Assert.IsTrue(vm.IsBaseQuantityKind);
+        }
+
+        [Test]
+        public void VerifyThatIsBaseQuantityKindIsFalseForNewQuantityKind()
+        {
+            this.rdl.ParameterType.Add(this.simpleQuantityKind);
+
+            var vm = new SimpleQuantityKindDialogViewModel(this.simpleQuantityKind, this.transaction, this.session.Object, true, ThingDialogKind.Inspect, this.navigation.Object, this.rdl);
+
+            Assert.IsFalse(vm.IsBaseQuantityKind);
         }
     }
 }

--- a/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/ParameterTypesBrowserViewModelTestFixture.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTypesBrowserViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary, Rowan de Voogt
 //
 //    This file is part of COMET-IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -28,6 +28,8 @@ namespace BasicRdl.Tests.ViewModels
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reactive.Concurrency;
+    using System.Windows.Input;
 
     using BasicRdl.ViewModels;
 
@@ -41,6 +43,7 @@ namespace BasicRdl.Tests.ViewModels
 
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
     using CDP4Dal.Permission;
 
     using CommonServiceLocator;
@@ -48,6 +51,8 @@ namespace BasicRdl.Tests.ViewModels
     using Moq;
 
     using NUnit.Framework;
+
+    using ReactiveUI;
 
     /// <summary>
     /// Suite of tests for the <see cref="ParameterTypesBrowserViewModel"/>
@@ -73,6 +78,7 @@ namespace BasicRdl.Tests.ViewModels
         [SetUp]
         public void Setup()
         {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
             this.serviceLocator = new Mock<IServiceLocator>();
             ServiceLocator.SetLocatorProvider(() => this.serviceLocator.Object);
 
@@ -311,6 +317,114 @@ namespace BasicRdl.Tests.ViewModels
 
             this.messageBus.SendObjectChangeEvent(sRdl, EventKind.Updated);
             Assert.IsTrue(vm.ParameterTypes.Count(x => x.ContainerRdl == "test") == 2);
+        }
+
+        [Test]
+        public void VerifyThatCanSetAsBaseQuantityKindIsFalseWhenNoRowIsSelected()
+        {
+            Assert.IsFalse(this.ParameterTypesBrowserViewModel.CanSetAsBaseQuantityKind);
+        }
+
+        [Test]
+        public void VerifyThatCanSetAsBaseQuantityKindIsTrueWhenWritableQuantityKindRowIsSelected()
+        {
+            var quantityKind = this.CreateSimpleQuantityKind();
+
+            this.messageBus.SendObjectChangeEvent(quantityKind, EventKind.Added);
+            this.ParameterTypesBrowserViewModel.SelectedThing = this.ParameterTypesBrowserViewModel.ParameterTypes.First();
+
+            Assert.IsTrue(this.ParameterTypesBrowserViewModel.CanSetAsBaseQuantityKind);
+        }
+
+        [Test]
+        public void VerifyThatCanSetAsBaseQuantityKindIsFalseWhenNonQuantityKindRowIsSelected()
+        {
+            var textParameterType = new TextParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { Container = this.siteRdl };
+
+            this.messageBus.SendObjectChangeEvent(textParameterType, EventKind.Added);
+            this.ParameterTypesBrowserViewModel.SelectedThing = this.ParameterTypesBrowserViewModel.ParameterTypes.First();
+
+            Assert.IsFalse(this.ParameterTypesBrowserViewModel.CanSetAsBaseQuantityKind);
+        }
+
+        [Test]
+        public void VerifyThatContextMenuShowsSetAsBaseQuantityKindWhenNotBase()
+        {
+            var quantityKind = this.CreateSimpleQuantityKind();
+
+            this.messageBus.SendObjectChangeEvent(quantityKind, EventKind.Added);
+            this.ParameterTypesBrowserViewModel.SelectedThing = this.ParameterTypesBrowserViewModel.ParameterTypes.First();
+            this.ParameterTypesBrowserViewModel.PopulateContextMenu();
+
+            Assert.IsTrue(this.ParameterTypesBrowserViewModel.ContextMenu.Any(x => x.Header == "Set as Base Quantity Kind"));
+            Assert.IsFalse(this.ParameterTypesBrowserViewModel.ContextMenu.Any(x => x.Header == "Unset as Base Quantity Kind"));
+        }
+
+        [Test]
+        public void VerifyThatContextMenuShowsUnsetAsBaseQuantityKindWhenIsBase()
+        {
+            var quantityKind = this.CreateSimpleQuantityKind();
+            this.siteRdl.BaseQuantityKind.Add(quantityKind);
+
+            this.messageBus.SendObjectChangeEvent(quantityKind, EventKind.Added);
+            this.ParameterTypesBrowserViewModel.SelectedThing = this.ParameterTypesBrowserViewModel.ParameterTypes.First();
+            this.ParameterTypesBrowserViewModel.PopulateContextMenu();
+
+            Assert.IsTrue(this.ParameterTypesBrowserViewModel.ContextMenu.Any(x => x.Header == "Unset as Base Quantity Kind"));
+            Assert.IsFalse(this.ParameterTypesBrowserViewModel.ContextMenu.Any(x => x.Header == "Set as Base Quantity Kind"));
+        }
+
+        [Test]
+        public void VerifyThatIsBaseQuantityKindIsUpdatedOnRdlUpdate()
+        {
+            var quantityKind = this.CreateSimpleQuantityKind();
+
+            this.messageBus.SendObjectChangeEvent(quantityKind, EventKind.Added);
+            var row = this.ParameterTypesBrowserViewModel.ParameterTypes.First();
+            Assert.IsFalse(row.IsBaseQuantityKind);
+
+            this.siteRdl.BaseQuantityKind.Add(quantityKind);
+            var rev = typeof(Thing).GetProperty("RevisionNumber");
+            rev.SetValue(this.siteRdl, 2);
+            this.messageBus.SendObjectChangeEvent(this.siteRdl, EventKind.Updated);
+
+            Assert.IsTrue(row.IsBaseQuantityKind);
+        }
+
+        [Test]
+        public void VerifyThatSetAsBaseQuantityKindCommandCallsSessionWrite()
+        {
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(System.Threading.Tasks.Task.CompletedTask);
+
+            var quantityKind = this.CreateSimpleQuantityKind();
+
+            this.messageBus.SendObjectChangeEvent(quantityKind, EventKind.Added);
+            this.ParameterTypesBrowserViewModel.SelectedThing = this.ParameterTypesBrowserViewModel.ParameterTypes.First();
+
+            ((ICommand)this.ParameterTypesBrowserViewModel.SetAsBaseQuantityKindCommand).Execute(null);
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SimpleQuantityKind"/> contained by the test <see cref="siteRdl"/>.
+        /// </summary>
+        /// <returns>The created <see cref="SimpleQuantityKind"/>.</returns>
+        private SimpleQuantityKind CreateSimpleQuantityKind()
+        {
+            var defaultScale = new CyclicRatioScale(Guid.NewGuid(), this.assembler.Cache, this.uri);
+
+            var quantityKind = new SimpleQuantityKind(Guid.NewGuid(), this.assembler.Cache, this.uri)
+            {
+                Name = "qk",
+                ShortName = "qk",
+                DefaultScale = defaultScale,
+                Container = this.siteRdl
+            };
+
+            this.siteRdl.ParameterType.Add(quantityKind);
+
+            return quantityKind;
         }
     }
 }

--- a/BasicRdl/ViewModels/Dialogs/DerivedQuantityKindDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/DerivedQuantityKindDialogViewModel.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DerivedQuantityKindDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 // 
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary, Rowan de Voogt
 // 
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -50,6 +50,11 @@ namespace BasicRdl.ViewModels
     [ThingDialogViewModelExport(ClassKind.DerivedQuantityKind)]
     public class DerivedQuantityKindDialogViewModel : CDP4CommonView.DerivedQuantityKindDialogViewModel, IThingDialogViewModel
     {
+        /// <summary>
+        /// The backing field for <see cref="IsBaseQuantityKind"/>
+        /// </summary>
+        private bool isBaseQuantityKind;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DerivedQuantityKindDialogViewModel"/> class.
         /// </summary>
@@ -102,7 +107,16 @@ namespace BasicRdl.ViewModels
         /// Gets or sets the Inspect <see cref="ICommand"/> to inspect the <see cref="SelectedDefaultScale"/>
         /// </summary>
         public ReactiveCommand<Unit, Unit> InspectSelectedScaleCommand { get; protected set; }
-        
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="DerivedQuantityKind"/> is a base quantity kind of the container <see cref="ReferenceDataLibrary"/>.
+        /// </summary>
+        public bool IsBaseQuantityKind
+        {
+            get => this.isBaseQuantityKind;
+            set => this.RaiseAndSetIfChanged(ref this.isBaseQuantityKind, value);
+        }
+
         /// <summary>
         /// Updates the <see cref="OkCanExecute"/> property using validation rules
         /// </summary>
@@ -119,6 +133,35 @@ namespace BasicRdl.ViewModels
         {
             base.UpdateProperties();
             this.PopulatePossiblePossibleScales();
+
+            var containerRdl = this.Container as ReferenceDataLibrary;
+            this.IsBaseQuantityKind = containerRdl != null && containerRdl.BaseQuantityKind.Any(q => q.Iid == this.Thing.Iid);
+        }
+
+        /// <summary>
+        /// Update the transaction with the Thing represented by this Dialog
+        /// </summary>
+        protected override void UpdateTransaction()
+        {
+            base.UpdateTransaction();
+
+            var containerRdl = this.Container as ReferenceDataLibrary;
+
+            if (containerRdl == null)
+            {
+                return;
+            }
+
+            var existingBaseQuantityKind = containerRdl.BaseQuantityKind.FirstOrDefault(q => q.Iid == this.Thing.Iid);
+
+            if (this.IsBaseQuantityKind && existingBaseQuantityKind == null)
+            {
+                containerRdl.BaseQuantityKind.Add(this.Thing);
+            }
+            else if (!this.IsBaseQuantityKind && existingBaseQuantityKind != null)
+            {
+                containerRdl.BaseQuantityKind.Remove(existingBaseQuantityKind);
+            }
         }
 
         /// <summary>

--- a/BasicRdl/ViewModels/Dialogs/SimpleQuantityKindDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/SimpleQuantityKindDialogViewModel.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SimpleQuantityKindDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 // 
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary, Rowan de Voogt
 // 
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -50,6 +50,11 @@ namespace BasicRdl.ViewModels
     [ThingDialogViewModelExport(ClassKind.SimpleQuantityKind)]
     public class SimpleQuantityKindDialogViewModel : CDP4CommonView.SimpleQuantityKindDialogViewModel, IThingDialogViewModel
     {
+        /// <summary>
+        /// The backing field for <see cref="IsBaseQuantityKind"/>
+        /// </summary>
+        private bool isBaseQuantityKind;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SimpleQuantityKindDialogViewModel"/> class.
         /// </summary>
@@ -103,6 +108,15 @@ namespace BasicRdl.ViewModels
         public ReactiveCommand<Unit, Unit> InspectSelectedScaleCommand { get; protected set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="SimpleQuantityKind"/> is a base quantity kind of the container <see cref="ReferenceDataLibrary"/>.
+        /// </summary>
+        public bool IsBaseQuantityKind
+        {
+            get => this.isBaseQuantityKind;
+            set => this.RaiseAndSetIfChanged(ref this.isBaseQuantityKind, value);
+        }
+
+        /// <summary>
         /// Updates the <see cref="OkCanExecute"/> property using validation rules
         /// </summary>
         protected override void UpdateOkCanExecute()
@@ -118,6 +132,35 @@ namespace BasicRdl.ViewModels
         {
             base.UpdateProperties();
             this.PopulatePossiblePossibleScales();
+
+            var containerRdl = this.Container as ReferenceDataLibrary;
+            this.IsBaseQuantityKind = containerRdl != null && containerRdl.BaseQuantityKind.Any(q => q.Iid == this.Thing.Iid);
+        }
+
+        /// <summary>
+        /// Update the transaction with the Thing represented by this Dialog
+        /// </summary>
+        protected override void UpdateTransaction()
+        {
+            base.UpdateTransaction();
+
+            var containerRdl = this.Container as ReferenceDataLibrary;
+
+            if (containerRdl == null)
+            {
+                return;
+            }
+
+            var existingBaseQuantityKind = containerRdl.BaseQuantityKind.FirstOrDefault(q => q.Iid == this.Thing.Iid);
+
+            if (this.IsBaseQuantityKind && existingBaseQuantityKind == null)
+            {
+                containerRdl.BaseQuantityKind.Add(this.Thing);
+            }
+            else if (!this.IsBaseQuantityKind && existingBaseQuantityKind != null)
+            {
+                containerRdl.BaseQuantityKind.Remove(existingBaseQuantityKind);
+            }
         }
 
         /// <summary>

--- a/BasicRdl/ViewModels/Dialogs/SpecializedQuantityKindDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/SpecializedQuantityKindDialogViewModel.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SpecializedQuantityKindDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 // 
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary, Rowan de Voogt
 // 
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -50,6 +50,11 @@ namespace BasicRdl.ViewModels
     [ThingDialogViewModelExport(ClassKind.SpecializedQuantityKind)]
     public class SpecializedQuantityKindDialogViewModel : CDP4CommonView.SpecializedQuantityKindDialogViewModel, IThingDialogViewModel
     {
+        /// <summary>
+        /// The backing field for <see cref="IsBaseQuantityKind"/>
+        /// </summary>
+        private bool isBaseQuantityKind;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SpecializedQuantityKindDialogViewModel"/> class.
         /// </summary>
@@ -106,7 +111,16 @@ namespace BasicRdl.ViewModels
         /// <summary>
         /// Gets all the possible <see cref="MeasurementScale"/> for the current <see cref="SpecializedQuantityKind"/>
         /// </summary>
-        public ReactiveList<MeasurementScale> AllPossibleScale { get; private set; } 
+        public ReactiveList<MeasurementScale> AllPossibleScale { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="SpecializedQuantityKind"/> is a base quantity kind of the container <see cref="ReferenceDataLibrary"/>.
+        /// </summary>
+        public bool IsBaseQuantityKind
+        {
+            get => this.isBaseQuantityKind;
+            set => this.RaiseAndSetIfChanged(ref this.isBaseQuantityKind, value);
+        }
 
         /// <summary>
         /// Initializes the dialog
@@ -135,6 +149,35 @@ namespace BasicRdl.ViewModels
             base.UpdateProperties();
             this.PopulatePossiblePossibleScales();
             this.PopulateGeneralScale();
+
+            var containerRdl = this.Container as ReferenceDataLibrary;
+            this.IsBaseQuantityKind = containerRdl != null && containerRdl.BaseQuantityKind.Any(q => q.Iid == this.Thing.Iid);
+        }
+
+        /// <summary>
+        /// Update the transaction with the Thing represented by this Dialog
+        /// </summary>
+        protected override void UpdateTransaction()
+        {
+            base.UpdateTransaction();
+
+            var containerRdl = this.Container as ReferenceDataLibrary;
+
+            if (containerRdl == null)
+            {
+                return;
+            }
+
+            var existingBaseQuantityKind = containerRdl.BaseQuantityKind.FirstOrDefault(q => q.Iid == this.Thing.Iid);
+
+            if (this.IsBaseQuantityKind && existingBaseQuantityKind == null)
+            {
+                containerRdl.BaseQuantityKind.Add(this.Thing);
+            }
+            else if (!this.IsBaseQuantityKind && existingBaseQuantityKind != null)
+            {
+                containerRdl.BaseQuantityKind.Remove(existingBaseQuantityKind);
+            }
         }
 
         /// <summary>

--- a/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
+++ b/BasicRdl/ViewModels/ParameterTypesBrowserViewModel.cs
@@ -1,8 +1,8 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ParameterTypesBrowserViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary, Rowan de Voogt
 //
 //    This file is part of COMET-IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -48,6 +48,7 @@ namespace BasicRdl.ViewModels
 
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
 
     using CommonServiceLocator;
 
@@ -68,6 +69,11 @@ namespace BasicRdl.ViewModels
         /// Backing field for the <see cref="CanCreateParameterType"/> property
         /// </summary>
         private bool canCreateParameterType;
+
+        /// <summary>
+        /// Backing field for the <see cref="CanSetAsBaseQuantityKind"/> property
+        /// </summary>
+        private bool canSetAsBaseQuantityKind;
 
         /// <summary>
         /// The backing field for <see cref="ShowOnlyFavorites"/> property.
@@ -141,6 +147,20 @@ namespace BasicRdl.ViewModels
             get => this.canCreateParameterType;
             set => this.RaiseAndSetIfChanged(ref this.canCreateParameterType, value);
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the selected <see cref="QuantityKind"/> may be set or unset as a base quantity kind
+        /// </summary>
+        public bool CanSetAsBaseQuantityKind
+        {
+            get => this.canSetAsBaseQuantityKind;
+            private set => this.RaiseAndSetIfChanged(ref this.canSetAsBaseQuantityKind, value);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> used to set or unset the selected <see cref="QuantityKind"/> as a base quantity kind
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> SetAsBaseQuantityKindCommand { get; private set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to display favorites.
@@ -319,6 +339,10 @@ namespace BasicRdl.ViewModels
             this.CreateSampledFunctionParameterType = ReactiveCommandCreator.Create(() => this.ExecuteCreateCommand<SampledFunctionParameterType>(), this.WhenAnyValue(vm => vm.CanCreateParameterType));
 
             this.ToggleFavoriteCommand = ReactiveCommandCreator.Create(this.ExecuteToggleFavoriteCommand);
+
+            this.SetAsBaseQuantityKindCommand = ReactiveCommandCreator.Create(
+                this.ExecuteSetAsBaseQuantityKindCommand,
+                this.WhenAnyValue(x => x.CanSetAsBaseQuantityKind));
         }
 
         /// <summary>
@@ -328,6 +352,16 @@ namespace BasicRdl.ViewModels
         {
             base.ComputePermission();
             this.CanCreateParameterType = this.Session.OpenReferenceDataLibraries.Any();
+
+            if (this.SelectedThing is ParameterTypeRowViewModel selectedRow && selectedRow.Thing is QuantityKind)
+            {
+                var rdl = selectedRow.Thing.Container as ReferenceDataLibrary;
+                this.CanSetAsBaseQuantityKind = rdl != null && this.Session.PermissionService.CanWrite(rdl);
+            }
+            else
+            {
+                this.CanSetAsBaseQuantityKind = false;
+            }
         }
 
         /// <summary>
@@ -345,6 +379,16 @@ namespace BasicRdl.ViewModels
                         "",
                         this.ToggleFavoriteCommand,
                         MenuItemKind.Favorite));
+
+                if (selectedParameterTypeRow.Thing is QuantityKind)
+                {
+                    this.ContextMenu.Add(
+                        new ContextMenuItemViewModel(
+                            selectedParameterTypeRow.IsBaseQuantityKind ? "Unset as Base Quantity Kind" : "Set as Base Quantity Kind",
+                            "",
+                            this.SetAsBaseQuantityKindCommand,
+                            MenuItemKind.None));
+                }
             }
 
             this.ContextMenu.Add(
@@ -442,6 +486,41 @@ namespace BasicRdl.ViewModels
                     this.CreateTimeOfDayParameterType,
                     MenuItemKind.Create,
                     ClassKind.TimeOfDayParameterType));
+        }
+
+        /// <summary>
+        /// Executes the <see cref="SetAsBaseQuantityKindCommand"/> by toggling the base-quantity-kind membership of the selected
+        /// <see cref="QuantityKind"/> on the container <see cref="ReferenceDataLibrary"/>.
+        /// </summary>
+        private async void ExecuteSetAsBaseQuantityKindCommand()
+        {
+            if (!(this.SelectedThing is ParameterTypeRowViewModel selectedRow) || !(selectedRow.Thing is QuantityKind quantityKind))
+            {
+                return;
+            }
+
+            var rdl = quantityKind.Container as ReferenceDataLibrary;
+
+            if (rdl == null)
+            {
+                return;
+            }
+
+            var rdlClone = rdl.Clone(false);
+            var existingBaseQuantityKind = rdlClone.BaseQuantityKind.FirstOrDefault(q => q.Iid == quantityKind.Iid);
+
+            if (existingBaseQuantityKind != null)
+            {
+                rdlClone.BaseQuantityKind.Remove(existingBaseQuantityKind);
+            }
+            else
+            {
+                rdlClone.BaseQuantityKind.Add(quantityKind);
+            }
+
+            var transactionContext = TransactionContextResolver.ResolveContext(this.Thing);
+            var transaction = new ThingTransaction(transactionContext, rdlClone);
+            await this.DalWrite(transaction);
         }
 
         /// <summary>
@@ -558,6 +637,11 @@ namespace BasicRdl.ViewModels
                 if (parameter.ContainerRdl != rdl.ShortName)
                 {
                     parameter.ContainerRdl = rdl.ShortName;
+                }
+
+                if (parameter.Thing is QuantityKind quantityKind)
+                {
+                    parameter.IsBaseQuantityKind = rdl.BaseQuantityKind.Any(q => q.Iid == quantityKind.Iid);
                 }
             }
         }

--- a/BasicRdl/Views/Dialogs/DerivedQuantityKindDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DerivedQuantityKindDialog.xaml
@@ -39,6 +39,7 @@
                                                  ValidatesOnDataErrors=True,
                                                  UpdateSourceTrigger=PropertyChanged}" />
                 </dxlc:LayoutItem>
+                <items:IsBaseQuantityKindLayoutItem />
                 <items:IsDeprecatedLayoutItem />
                 <items:ScaleLayoutItem/>
                 <items:AliasDisplayLayoutItem />

--- a/BasicRdl/Views/Dialogs/SimpleQuantityKindDialog.xaml
+++ b/BasicRdl/Views/Dialogs/SimpleQuantityKindDialog.xaml
@@ -42,6 +42,7 @@
                                                  UpdateSourceTrigger=PropertyChanged}" 
                                   ShowError="True"/>
                 </dxlc:LayoutItem>
+                <items:IsBaseQuantityKindLayoutItem />
                 <items:IsDeprecatedLayoutItem />
                 <items:ScaleLayoutItem/>
                 <items:AliasDisplayLayoutItem />

--- a/BasicRdl/Views/Dialogs/SpecializedQuantityKindDialog.xaml
+++ b/BasicRdl/Views/Dialogs/SpecializedQuantityKindDialog.xaml
@@ -112,9 +112,10 @@
                                                  UpdateSourceTrigger=PropertyChanged}" 
                                   ShowError="True"/>
                 </dxlc:LayoutItem>
+                <items:IsBaseQuantityKindLayoutItem />
                 <items:IsDeprecatedLayoutItem />
-                
-                <dxlc:LayoutItem Label="Generalization Scales: " 
+
+                <dxlc:LayoutItem Label="Generalization Scales: "
                                  LabelPosition="Top"
                                  Height="130">
                     <dxg:GridControl x:Name="ScalesGrid"

--- a/CDP4Composition/CommonView/Items/IsBaseQuantityKindLayoutItem.xaml
+++ b/CDP4Composition/CommonView/Items/IsBaseQuantityKindLayoutItem.xaml
@@ -1,0 +1,13 @@
+<dxlc:LayoutItem x:Class="CDP4CommonView.Items.IsBaseQuantityKindLayoutItem"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             mc:Ignorable="d"
+             Label="Base Quantity Kind:">
+    <dxe:CheckEdit Name="IsBaseQuantityKind"
+                    IsChecked="{Binding Path=IsBaseQuantityKind, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    IsReadOnly="{Binding IsReadOnly}"/>
+</dxlc:LayoutItem>

--- a/CDP4Composition/CommonView/Items/IsBaseQuantityKindLayoutItem.xaml.cs
+++ b/CDP4Composition/CommonView/Items/IsBaseQuantityKindLayoutItem.xaml.cs
@@ -1,0 +1,43 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IsBaseQuantityKindLayoutItem.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4CommonView.Items
+{
+    using DevExpress.Xpf.LayoutControl;
+
+    /// <summary>
+    /// Interaction logic for IsBaseQuantityKindLayoutItem.xaml
+    /// </summary>
+    public partial class IsBaseQuantityKindLayoutItem : LayoutItem
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IsBaseQuantityKindLayoutItem"/> class.
+        /// </summary>
+        public IsBaseQuantityKindLayoutItem()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
feat #387 
a bit similar to how i did #1440 
Added BaseQuantityKinds to all QuantityKindsdialogs also added a contextmenu option to set as BaseQuantityKinds,
Made baseQuantityKinds bold in ParameterTypebrowser

