### PR TITLE
feat #404 Facelift for DomainSwitchingDialog and ModelClosingDialog

### DIFF
--- a/CDP4ShellDialogs/ViewModels/ModelClosingDialogViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelClosingDialogViewModel.cs
@@ -53,7 +53,17 @@ namespace CDP4ShellDialogs.ViewModels
     public class ModelClosingDialogViewModel : DialogViewModelBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ModelClosingDialogViewModel"/> class. 
+        /// Backing field for the <see cref="SelectedRowSession"/> property.
+        /// </summary>
+        private ModelSelectionSessionRowViewModel selectedRowSession;
+
+        /// <summary>
+        /// Backing field for the <see cref="IterationRows"/> property.
+        /// </summary>
+        private List<ModelSelectionIterationSetupRowViewModel> iterationRows;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModelClosingDialogViewModel"/> class.
         /// </summary>
         /// <param name="sessionAvailable">
         /// The session Available.
@@ -75,6 +85,24 @@ namespace CDP4ShellDialogs.ViewModels
         /// Gets the list of <see cref="BaseRowViewModel"/> available
         /// </summary>
         public DisposableReactiveList<ModelSelectionSessionRowViewModel> SessionsAvailable { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the selected source <see cref="ModelSelectionSessionRowViewModel"/>
+        /// </summary>
+        public ModelSelectionSessionRowViewModel SelectedRowSession
+        {
+            get => this.selectedRowSession;
+            set => this.RaiseAndSetIfChanged(ref this.selectedRowSession, value);
+        }
+
+        /// <summary>
+        /// Gets the flat list of <see cref="ModelSelectionIterationSetupRowViewModel"/> of the <see cref="SelectedRowSession"/>
+        /// </summary>
+        public List<ModelSelectionIterationSetupRowViewModel> IterationRows
+        {
+            get => this.iterationRows;
+            private set => this.RaiseAndSetIfChanged(ref this.iterationRows, value);
+        }
 
         /// <summary>
         /// Gets the list of <see cref="IterationSetup"/> selected
@@ -112,6 +140,21 @@ namespace CDP4ShellDialogs.ViewModels
             this.CancelCommand.Subscribe();
 
             this.SelectedIterations.ItemsAdded.Subscribe(this.FilterIterationSelectionItems);
+
+            this.WhenAnyValue(x => x.SelectedRowSession).Subscribe(this.PopulateIterationRows);
+        }
+
+        /// <summary>
+        /// Populates the flat <see cref="IterationRows"/> from the <paramref name="session"/> and resets the current selection
+        /// </summary>
+        /// <param name="session">The selected <see cref="ModelSelectionSessionRowViewModel"/></param>
+        private void PopulateIterationRows(ModelSelectionSessionRowViewModel session)
+        {
+            this.SelectedIterations.Clear();
+
+            this.IterationRows = session == null
+                ? new List<ModelSelectionIterationSetupRowViewModel>()
+                : session.EngineeringModelSetupRowViewModels.SelectMany(m => m.IterationSetupRowViewModels).ToList();
         }
 
         /// <summary>
@@ -195,6 +238,8 @@ namespace CDP4ShellDialogs.ViewModels
                 // remove model rows that don't have any open iteration
                 availableSession.EngineeringModelSetupRowViewModels.RemoveAllAndDispose(availableSession.EngineeringModelSetupRowViewModels.ToList().Where(x => !x.IterationSetupRowViewModels.Any()));
             }
+
+            this.SelectedRowSession = this.SessionsAvailable.FirstOrDefault();
         }
 
         /// <summary>

--- a/CDP4ShellDialogs/ViewModels/ModelIterationDomainSwitchDialogViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelIterationDomainSwitchDialogViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="ModelIterationDomainSwitchDialogViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2022 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerenï¿½, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Thï¿½ate, Omar Elebiary
 //
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -50,6 +50,16 @@ namespace CDP4ShellDialogs.ViewModels
     public class ModelIterationDomainSwitchDialogViewModel : DialogViewModelBase
     {
         /// <summary>
+        /// Backing field for the <see cref="SelectedRowSession" /> property.
+        /// </summary>
+        private SwitchDomainSessionRowViewModel selectedRowSession;
+
+        /// <summary>
+        /// Backing field for the <see cref="IterationRows" /> property.
+        /// </summary>
+        private List<SwitchDomainIterationSetupRowViewModel> iterationRows;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ModelClosingDialogViewModel" /> class.
         /// </summary>
         /// <param name="sessionAvailable">
@@ -74,6 +84,24 @@ namespace CDP4ShellDialogs.ViewModels
         public DisposableReactiveList<SwitchDomainSessionRowViewModel> SessionsAvailable { get; private set; }
 
         /// <summary>
+        /// Gets or sets the selected source <see cref="SwitchDomainSessionRowViewModel" />
+        /// </summary>
+        public SwitchDomainSessionRowViewModel SelectedRowSession
+        {
+            get => this.selectedRowSession;
+            set => this.RaiseAndSetIfChanged(ref this.selectedRowSession, value);
+        }
+
+        /// <summary>
+        /// Gets the flat list of <see cref="SwitchDomainIterationSetupRowViewModel" /> of the <see cref="SelectedRowSession" />
+        /// </summary>
+        public List<SwitchDomainIterationSetupRowViewModel> IterationRows
+        {
+            get => this.iterationRows;
+            private set => this.RaiseAndSetIfChanged(ref this.iterationRows, value);
+        }
+
+        /// <summary>
         /// Gets the list of <see cref="IterationSetup" /> selected
         /// </summary>
         public ReactiveList<IViewModelBase<Thing>> SelectedIterations { get; set; }
@@ -96,7 +124,7 @@ namespace CDP4ShellDialogs.ViewModels
             this.SelectedIterations = new ReactiveList<IViewModelBase<Thing>>();
             this.IsBusy = false;
 
-            var canOk = this.WhenAnyValue(x => x.SelectedIterations.Count, count => count != 0);
+            var canOk = this.WhenAnyValue(x => x.IterationRows, rows => rows != null && rows.Count != 0);
 
             this.SwitchCommand = ReactiveCommandCreator.CreateAsyncTask(this.ExecuteDomainSwitch, canOk, RxApp.MainThreadScheduler);
 
@@ -110,6 +138,21 @@ namespace CDP4ShellDialogs.ViewModels
             this.CancelCommand = ReactiveCommandCreator.Create(this.ExecuteCancel);
 
             this.SelectedIterations.ItemsAdded.Subscribe(this.FilterIterationSelectionItems);
+
+            this.WhenAnyValue(x => x.SelectedRowSession).Subscribe(this.PopulateIterationRows);
+        }
+
+        /// <summary>
+        /// Populates the flat <see cref="IterationRows" /> from the <paramref name="session" /> and resets the current selection
+        /// </summary>
+        /// <param name="session">The selected <see cref="SwitchDomainSessionRowViewModel" /></param>
+        private void PopulateIterationRows(SwitchDomainSessionRowViewModel session)
+        {
+            this.SelectedIterations.Clear();
+
+            this.IterationRows = session == null
+                ? new List<SwitchDomainIterationSetupRowViewModel>()
+                : session.EngineeringModelSetupRowViewModels.SelectMany(m => m.IterationSetupRowViewModels).ToList();
         }
 
         /// <summary>
@@ -123,16 +166,22 @@ namespace CDP4ShellDialogs.ViewModels
             this.IsBusy = true;
             this.LoadingMessage = "Switching...";
 
-            foreach (var iteration in this.SelectedIterations)
+            foreach (var row in this.IterationRows)
             {
-                var modelrow = (SwitchDomainIterationSetupRowViewModel)iteration;
-                var session = modelrow.Session;
+                var session = row.Session;
 
-                var openIteration = session.OpenIterations.Keys.FirstOrDefault(x => x.Iid == modelrow.IterationIid);
+                var openIteration = session.OpenIterations.Keys.FirstOrDefault(x => x.Iid == row.IterationIid);
 
-                if (openIteration != null)
+                if (openIteration == null || row.SelectedDomain == null)
                 {
-                    session.SwitchDomain(modelrow.IterationIid, modelrow.SelectedDomain);
+                    continue;
+                }
+
+                var currentDomain = session.QuerySelectedDomainOfExpertise(openIteration);
+
+                if (!Equals(currentDomain, row.SelectedDomain))
+                {
+                    session.SwitchDomain(row.IterationIid, row.SelectedDomain);
                 }
             }
 
@@ -164,6 +213,8 @@ namespace CDP4ShellDialogs.ViewModels
             {
                 this.SessionsAvailable.Add(new SwitchDomainSessionRowViewModel(session.RetrieveSiteDirectory(), session));
             }
+
+            this.SelectedRowSession = this.SessionsAvailable.FirstOrDefault();
         }
 
         /// <summary>

--- a/CDP4ShellDialogs/ViewModels/ModelSelectionIterationSetupRowViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelSelectionIterationSetupRowViewModel.cs
@@ -80,6 +80,8 @@ namespace CDP4ShellDialogs.ViewModels
 
             this.Name = "iteration_" + this.Thing.IterationNumber.ToString(CultureInfo.InvariantCulture);
 
+            this.ModelName = (this.Thing.Container as EngineeringModelSetup)?.Name;
+
             this.FrozenOnDate = !this.Thing.FrozenOn.HasValue ? "Active" : this.Thing.FrozenOn.Value.ToString("yyyy-MM-dd HH:mm:ss");
         }
 
@@ -87,6 +89,11 @@ namespace CDP4ShellDialogs.ViewModels
         /// Gets or sets the name.
         /// </summary>
         public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the name of the <see cref="EngineeringModelSetup"/> that contains the <see cref="IterationSetup"/>
+        /// </summary>
+        public string ModelName { get; private set; }
 
         /// <summary>
         /// Gets or sets the date at which the iteration was Frozen

--- a/CDP4ShellDialogs/ViewModels/SwitchDomainIterationSetupRowViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/SwitchDomainIterationSetupRowViewModel.cs
@@ -86,6 +86,8 @@ namespace CDP4ShellDialogs.ViewModels
 
             this.Name = "iteration_" + this.Thing.IterationNumber.ToString(CultureInfo.InvariantCulture);
 
+            this.ModelName = (this.Thing.Container as EngineeringModelSetup)?.Name;
+
             this.FrozenOnDate = !this.Thing.FrozenOn.HasValue ? "Active" : this.Thing.FrozenOn.Value.ToString("yyyy-MM-dd HH:mm:ss");
         }
 
@@ -93,6 +95,11 @@ namespace CDP4ShellDialogs.ViewModels
         /// Gets or sets the name.
         /// </summary>
         public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets the name of the <see cref="EngineeringModelSetup" /> that contains the <see cref="IterationSetup" />
+        /// </summary>
+        public string ModelName { get; private set; }
 
         /// <summary>
         /// Gets or sets the date at which the iteration was Frozen

--- a/CDP4ShellDialogs/Views/ModelClosingDialog.xaml
+++ b/CDP4ShellDialogs/Views/ModelClosingDialog.xaml
@@ -8,106 +8,72 @@
              xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
-             xmlns:viewModels="clr-namespace:CDP4ShellDialogs.ViewModels"
              xmlns:views1="clr-namespace:CDP4Composition.Views;assembly=CDP4Composition"
              x:Name="IterationsSelection"
              Title="Select iterations to close"
-             Width="500"
-             Height="400"
+             Width="700"
+             Height="600"
              dx:ThemeManager.ThemeName="Seven"
              navigation:ExtendedDialogResultCloser.DialogResult="{Binding DialogResult}"
              mc:Ignorable="d">
-    <dx:DXWindow.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:ModelSelectionSessionRowViewModel}" ItemsSource="{Binding EngineeringModelSetupRowViewModels}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3"
-                               Source="{dx:DXImage Image=Database_16x16.png}" />
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:ModelSelectionEngineeringModelSetupRowViewModel}" ItemsSource="{Binding IterationSetupRowViewModels}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3"
-                               Source="{dx:DXImage Image=Technology_16x16.png}" />
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:ModelSelectionIterationSetupRowViewModel}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3"
-                               Source="{dx:DXImage Image=GroupFieldCollection_16x16.png}" />
-                    </dx:PixelSnapper>
-                    <dx:MeasurePixelSnapper>
-                        <ContentPresenter x:Name="defaultRowPresenter"
-                                          Content="{Binding}"
-                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                    </dx:MeasurePixelSnapper>
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-    </dx:DXWindow.Resources>
-
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <dxlc:LayoutGroup Grid.Row="0"
+
+        <dxlc:LayoutItem Grid.Row="0"
+                         Margin="5"
+                         AddColonToLabel="True"
+                         Name="SessionSource"
+                         Label="Source"
+                         ToolTip="Select a Source">
+            <dxe:ComboBoxEdit ItemsSource="{Binding SessionsAvailable}"
+                              SelectedItem="{Binding SelectedRowSession, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              DisplayMember="Name" />
+        </dxlc:LayoutItem>
+
+        <dxlc:LayoutGroup Grid.Row="1"
                           Margin="5"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
-                          Header="Engineering Models"
+                          Header="Open Iterations"
                           Orientation="Vertical"
                           View="GroupBox">
-            <dxg:TreeListControl x:Name="iterationSelectionTreeListControl"
-                                 HorizontalAlignment="Stretch"
-                                 VerticalAlignment="Stretch"
-                                 ItemsSource="{Binding SessionsAvailable}"
-                                 SelectedItems="{Binding SelectedIterations}"
-                                 SelectionMode="Row">
-                <dxg:TreeListControl.Columns>
-                    <dxg:TreeListColumn FieldName="Name" HorizontalHeaderContentAlignment="Left" />
-                </dxg:TreeListControl.Columns>
-                <dxg:TreeListControl.View>
-                    <dxg:TreeListView x:Name="View"
-                                      AllowEditing="False"
-                                      AutoExpandAllNodes="True"
-                                      AutoWidth="True"
-                                      HorizontalScrollbarVisibility="Auto"
-                                      NavigationStyle="Cell"
-                                      ShowHorizontalLines="False"
-                                      ShowIndicator="False"
-                                      ShowNodeImages="False"
-                                      ShowVerticalLines="False"
-                                      TreeDerivationMode="HierarchicalDataTemplate"
-                                      TreeLineStyle="Solid"
-                                      VerticalScrollbarVisibility="Auto" />
-                </dxg:TreeListControl.View>
-            </dxg:TreeListControl>
+            <dxg:GridControl Name="IterationGridControl"
+                             AllowLiveDataShaping="False"
+                             ItemsSource="{Binding IterationRows}"
+                             SelectedItems="{Binding SelectedIterations}"
+                             SelectionMode="Row">
+                <dxg:GridControl.View>
+                    <dxg:TableView Name="GridViewIteration"
+                                   HorizontalAlignment="Stretch"
+                                   VerticalAlignment="Stretch"
+                                   AllowColumnMoving="True"
+                                   AllowEditing="False"
+                                   AllowGrouping="True"
+                                   AutoWidth="true"
+                                   ShowFilterPanelMode="Never"
+                                   IsDetailButtonVisibleBinding="{x:Null}"
+                                   ShowGroupPanel="False"
+                                   ShowCheckBoxSelectorColumn="True"
+                                   ShowSearchPanelMode="Always">
+                        <dxg:TableView.RowStyle>
+                            <Style TargetType="{x:Type dxg:RowControl}">
+                                <Setter Property="ToolTip" Value="Select the iterations to close" />
+                                <Setter Property="Height" Value="30" />
+                            </Style>
+                        </dxg:TableView.RowStyle>
+                    </dxg:TableView>
+                </dxg:GridControl.View>
+                <dxg:GridControl.Columns>
+                    <dxg:GridColumn FieldName="ModelName" Header="Model" SortMode="Value" SortIndex="0" />
+                    <dxg:GridColumn FieldName="Name" Header="Iteration" />
+                    <dxg:GridColumn FieldName="FrozenOnDate" Header="Frozen On" />
+                </dxg:GridControl.Columns>
+            </dxg:GridControl>
 
             <dxlc:LayoutItem>
                 <TextBox IsReadOnly="True"
@@ -115,31 +81,32 @@
                                         Mode=OneWay}"
                          Visibility="{Binding Path=HasError,
                                               UpdateSourceTrigger=PropertyChanged,
-                                              Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                              Converter={dx:BooleanToVisibilityConverter}}" />
             </dxlc:LayoutItem>
         </dxlc:LayoutGroup>
 
-        <views1:LoadingControl Grid.Row="0" Visibility="{Binding IsBusy, Converter={dx:BooleanToVisibilityConverter}}" />
+        <views1:LoadingControl Grid.Row="1" Visibility="{Binding IsBusy, Converter={dx:BooleanToVisibilityConverter}}" />
 
-        <dxlc:LayoutGroup Grid.Row="1"
+        <StackPanel Grid.Row="2" Margin="5,5,5,5" Background="Cornsilk">
+            <TextBlock TextWrapping="Wrap" Margin="5,5,5,5"
+                       Text="Select one or more iterations and click Close to close them" />
+        </StackPanel>
+
+        <dxlc:LayoutGroup Grid.Row="3"
                           Height="30"
-                          Margin="5">
-            <Button MinWidth="75"
-                    MinHeight="25"
-                    MaxWidth="75"
-                    MaxHeight="25"
+                          Margin="0,0,0,5">
+            <Button Content="Close"
                     Margin="5"
+                    Width="75"
+                    Height="25"
                     HorizontalAlignment="Right"
-                    Command="{Binding CloseCommand}"
-                    Content="Close" />
-            <Button MinWidth="75"
-                    MinHeight="25"
-                    MaxWidth="75"
-                    MaxHeight="25"
+                    Command="{Binding CloseCommand}" />
+            <Button Content="Cancel"
                     Margin="5"
+                    Width="75"
+                    Height="25"
                     HorizontalAlignment="Right"
                     Command="{Binding CancelCommand}"
-                    Content="Cancel"
                     IsDefault="True" />
         </dxlc:LayoutGroup>
     </Grid>

--- a/CDP4ShellDialogs/Views/ModelIterationDomainSwitchDialog.xaml
+++ b/CDP4ShellDialogs/Views/ModelIterationDomainSwitchDialog.xaml
@@ -8,124 +8,85 @@
              xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
-             xmlns:viewModels="clr-namespace:CDP4ShellDialogs.ViewModels"
              xmlns:views1="clr-namespace:CDP4Composition.Views;assembly=CDP4Composition"
              x:Name="IterationsSelection"
              Title="Switch domain for the selected iterations"
-             Width="500"
-             Height="400"
+             Width="700"
+             Height="600"
              dx:ThemeManager.ThemeName="Seven"
              navigation:ExtendedDialogResultCloser.DialogResult="{Binding DialogResult}"
              mc:Ignorable="d">
-    <dx:DXWindow.Resources>
-        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:SwitchDomainSessionRowViewModel}" ItemsSource="{Binding EngineeringModelSetupRowViewModels}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3"
-                               Source="{dx:DXImage Image=Database_16x16.png}" />
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:SwitchDomainEngineeringModelSetupRowViewModel}" ItemsSource="{Binding IterationSetupRowViewModels}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3"
-                               Source="{dx:DXImage Image=Technology_16x16.png}" />
-                    </dx:PixelSnapper>
-                    <ContentPresenter x:Name="defaultRowPresenter"
-                                      Content="{Binding}"
-                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-
-        <HierarchicalDataTemplate DataType="{x:Type viewModels:SwitchDomainIterationSetupRowViewModel}">
-            <dx:MeasurePixelSnapper>
-                <StackPanel Orientation="Horizontal">
-                    <dx:PixelSnapper>
-                        <Image Width="16"
-                               Height="16"
-                               Margin="3"
-                               Source="{dx:DXImage Image=GroupFieldCollection_16x16.png}" />
-                    </dx:PixelSnapper>
-                    <dx:MeasurePixelSnapper>
-                        <ContentPresenter x:Name="defaultRowPresenter"
-                                          Content="{Binding}"
-                                          ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
-                    </dx:MeasurePixelSnapper>
-                </StackPanel>
-            </dx:MeasurePixelSnapper>
-        </HierarchicalDataTemplate>
-    </dx:DXWindow.Resources>
-
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <dxlc:LayoutGroup Grid.Row="0"
+
+        <dxlc:LayoutItem Grid.Row="0"
+                         Margin="5"
+                         AddColonToLabel="True"
+                         Name="SessionSource"
+                         Label="Source"
+                         ToolTip="Select a Source">
+            <dxe:ComboBoxEdit ItemsSource="{Binding SessionsAvailable}"
+                              SelectedItem="{Binding SelectedRowSession, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              DisplayMember="Name" />
+        </dxlc:LayoutItem>
+
+        <dxlc:LayoutGroup Grid.Row="1"
                           Margin="5"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
-                          Header="Engineering Models"
+                          Header="Open Iterations"
                           Orientation="Vertical"
                           View="GroupBox">
-            <dxg:TreeListControl x:Name="iterationSelectionTreeListControl"
-                                 HorizontalAlignment="Stretch"
-                                 VerticalAlignment="Stretch"
-                                 ItemsSource="{Binding SessionsAvailable}"
-                                 SelectedItems="{Binding SelectedIterations, Mode=TwoWay}"
-                                 SelectionMode="Row">
-                <dxg:TreeListControl.Columns>
-                    <dxg:TreeListColumn FieldName="Name" HorizontalHeaderContentAlignment="Left" />
-                    <dxg:TreeListColumn FieldName="SelectedDomain"
-                                        Header="Domain Of Expertise"
-                                        HorizontalHeaderContentAlignment="Left"
-                                        AllowEditing="True" >
-                        <dxg:TreeListColumn.CellTemplate>
+            <dxg:GridControl Name="IterationGridControl"
+                             AllowLiveDataShaping="False"
+                             ItemsSource="{Binding IterationRows}"
+                             SelectionMode="Row">
+                <dxg:GridControl.View>
+                    <dxg:TableView Name="GridViewIteration"
+                                   HorizontalAlignment="Stretch"
+                                   VerticalAlignment="Stretch"
+                                   AllowColumnMoving="True"
+                                   AllowEditing="False"
+                                   AllowGrouping="True"
+                                   AutoWidth="true"
+                                   ShowFilterPanelMode="Never"
+                                   IsDetailButtonVisibleBinding="{x:Null}"
+                                   ShowGroupPanel="False"
+                                   ShowSearchPanelMode="Always">
+                        <dxg:TableView.RowStyle>
+                            <Style TargetType="{x:Type dxg:RowControl}">
+                                <Setter Property="ToolTip" Value="Select the iterations and the Domain Of Expertise to switch to" />
+                                <Setter Property="Height" Value="30" />
+                            </Style>
+                        </dxg:TableView.RowStyle>
+                    </dxg:TableView>
+                </dxg:GridControl.View>
+                <dxg:GridControl.Columns>
+                    <dxg:GridColumn FieldName="ModelName" Header="Model" SortMode="Value" SortIndex="0" />
+                    <dxg:GridColumn FieldName="Name" Header="Iteration" />
+                    <dxg:GridColumn FieldName="SelectedDomain"
+                                    Header="Domain Of Expertise"
+                                    HorizontalHeaderContentAlignment="Left"
+                                    AllowEditing="True">
+                        <dxg:GridColumn.CellTemplate>
                             <DataTemplate>
-                                <dxe:ComboBoxEdit Name="PART_Editor"
-                                                  Width="150"
-                                                  HorizontalAlignment="Left"
-                                                  DisplayMember="Name"
-                                                  IsTextEditable="False"
-                                                  ItemsSource="{Binding RowData.Row.DomainOfExpertises}"
-                                                  NullValueButtonPlacement="EditBox"
-                                                  ShowCustomItems="True"
-                                                  ShowBorder="True"/>
+                                <ComboBox IsEditable="False"
+                                          Margin="3"
+                                          Background="White"
+                                          DisplayMemberPath="Name"
+                                          SelectedValue="{Binding RowData.Row.SelectedDomain}"
+                                          ItemsSource="{Binding RowData.Row.DomainOfExpertises}" />
                             </DataTemplate>
-                        </dxg:TreeListColumn.CellTemplate>
-                    </dxg:TreeListColumn>
-                </dxg:TreeListControl.Columns>
-                <dxg:TreeListControl.View>
-                    <dxg:TreeListView x:Name="View"
-                                      AllowEditing="False"
-                                      AutoExpandAllNodes="True"
-                                      AutoWidth="True"
-                                      HorizontalScrollbarVisibility="Auto"
-                                      NavigationStyle="Cell"
-                                      ShowHorizontalLines="False"
-                                      ShowIndicator="False"
-                                      ShowNodeImages="False"
-                                      ShowVerticalLines="False"
-                                      TreeDerivationMode="HierarchicalDataTemplate"
-                                      TreeLineStyle="Solid"
-                                      VerticalScrollbarVisibility="Auto" />
-                </dxg:TreeListControl.View>
-            </dxg:TreeListControl>
+                        </dxg:GridColumn.CellTemplate>
+                    </dxg:GridColumn>
+                    <dxg:GridColumn FieldName="FrozenOnDate" Header="Frozen On" />
+                </dxg:GridControl.Columns>
+            </dxg:GridControl>
 
             <dxlc:LayoutItem>
                 <TextBox IsReadOnly="True"
@@ -133,31 +94,32 @@
                                         Mode=OneWay}"
                          Visibility="{Binding Path=HasError,
                                               UpdateSourceTrigger=PropertyChanged,
-                                              Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                              Converter={dx:BooleanToVisibilityConverter}}" />
             </dxlc:LayoutItem>
         </dxlc:LayoutGroup>
 
-        <views1:LoadingControl Grid.Row="0" Visibility="{Binding IsBusy, Converter={dx:BooleanToVisibilityConverter}}" />
+        <views1:LoadingControl Grid.Row="1" Visibility="{Binding IsBusy, Converter={dx:BooleanToVisibilityConverter}}" />
 
-        <dxlc:LayoutGroup Grid.Row="1"
+        <StackPanel Grid.Row="2" Margin="5,5,5,5" Background="Cornsilk">
+            <TextBlock TextWrapping="Wrap" Margin="5,5,5,5"
+                       Text="Choose a Domain Of Expertise for the iterations you want to change and click Switch" />
+        </StackPanel>
+
+        <dxlc:LayoutGroup Grid.Row="3"
                           Height="30"
-                          Margin="5">
-            <Button MinWidth="75"
-                    MinHeight="25"
-                    MaxWidth="75"
-                    MaxHeight="25"
+                          Margin="0,0,0,5">
+            <Button Content="Switch"
                     Margin="5"
+                    Width="75"
+                    Height="25"
                     HorizontalAlignment="Right"
-                    Command="{Binding SwitchCommand}"
-                    Content="Switch" />
-            <Button MinWidth="75"
-                    MinHeight="25"
-                    MaxWidth="75"
-                    MaxHeight="25"
+                    Command="{Binding SwitchCommand}" />
+            <Button Content="Cancel"
                     Margin="5"
+                    Width="75"
+                    Height="25"
                     HorizontalAlignment="Right"
                     Command="{Binding CancelCommand}"
-                    Content="Cancel"
                     IsDefault="True" />
         </dxlc:LayoutGroup>
     </Grid>

--- a/CDP4ShellDialogsTestFixture/ViewModels/ModelClosingDialogViewModelTestFixture.cs
+++ b/CDP4ShellDialogsTestFixture/ViewModels/ModelClosingDialogViewModelTestFixture.cs
@@ -263,6 +263,20 @@ namespace CDP4ShellDialogs.Tests
         }
 
         [Test]
+        public void VerifyThatSelectedRowSessionAndIterationRowsArePopulated()
+        {
+            this.openIterations.Add(this.iteration11, null);
+            this.openIterations.Add(this.iteration12, null);
+
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelClosingDialogViewModel(sessions);
+
+            Assert.That(viewmodel.SelectedRowSession, Is.EqualTo(viewmodel.SessionsAvailable.First()));
+            Assert.That(viewmodel.IterationRows.Count, Is.EqualTo(2));
+            Assert.That(viewmodel.IterationRows.All(r => r.ModelName == "model1"), Is.True);
+        }
+
+        [Test]
         public void VerifyThatOnlyOpenIterationsAreAvailable()
         {
             var lazyiterationSetup21 = new Lazy<Thing>(() => this.iterationSetup21);

--- a/CDP4ShellDialogsTestFixture/ViewModels/ModelIterationDomainSwitchDialogViewModelTestFixture.cs
+++ b/CDP4ShellDialogsTestFixture/ViewModels/ModelIterationDomainSwitchDialogViewModelTestFixture.cs
@@ -27,7 +27,10 @@ namespace CDP4ShellDialogs.Tests.ViewModels
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reactive.Concurrency;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Input;
 
     using CDP4Common.CommonData;
@@ -139,6 +142,64 @@ namespace CDP4ShellDialogs.Tests.ViewModels
             viewmodel.SelectedIterations.Add(new ModelSelectionIterationSetupRowViewModel(this.iterationSetup11, this.participant, this.session.Object));
             Assert.AreEqual("Switch Domain", viewmodel.DialogTitle);
             Assert.IsTrue(((ICommand)viewmodel.CancelCommand).CanExecute(null));
+        }
+
+        [Test]
+        public void VerifyThatSelectedRowSessionAndIterationRowsArePopulated()
+        {
+            var engineeringModel = new EngineeringModel(Guid.NewGuid(), this.assembler.Cache, this.uri) { EngineeringModelSetup = this.model1 };
+            var openIteration = new Iteration(Guid.NewGuid(), this.assembler.Cache, this.uri) { IterationSetup = this.iterationSetup11 };
+            engineeringModel.Iteration.Add(openIteration);
+
+            this.session.Setup(x => x.OpenIterations)
+                .Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>> { { openIteration, null } });
+
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelIterationDomainSwitchDialogViewModel(sessions);
+
+            Assert.That(viewmodel.SelectedRowSession, Is.EqualTo(viewmodel.SessionsAvailable.First()));
+            Assert.That(viewmodel.IterationRows.Count, Is.EqualTo(1));
+            Assert.That(viewmodel.IterationRows.First().ModelName, Is.EqualTo("model1"));
+        }
+
+        [Test]
+        public async Task VerifyThatMultipleDomainsCanBeSwitchedAtOnce()
+        {
+            var domain2 = new DomainOfExpertise(Guid.NewGuid(), null, this.uri) { Name = "domain2", ShortName = "domain2" };
+            this.participant.Domain.Add(domain2);
+
+            var engineeringModel1 = new EngineeringModel(Guid.NewGuid(), this.assembler.Cache, this.uri) { EngineeringModelSetup = this.model1 };
+            var openIteration1 = new Iteration(Guid.NewGuid(), this.assembler.Cache, this.uri) { IterationSetup = this.iterationSetup11 };
+            engineeringModel1.Iteration.Add(openIteration1);
+            this.iterationSetup11.IterationIid = openIteration1.Iid;
+
+            var engineeringModel2 = new EngineeringModel(Guid.NewGuid(), this.assembler.Cache, this.uri) { EngineeringModelSetup = this.model2 };
+            var openIteration2 = new Iteration(Guid.NewGuid(), this.assembler.Cache, this.uri) { IterationSetup = this.iterationSetup21 };
+            engineeringModel2.Iteration.Add(openIteration2);
+            this.iterationSetup21.IterationIid = openIteration2.Iid;
+
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domain);
+
+            this.session.Setup(x => x.OpenIterations).Returns(new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>
+            {
+                { openIteration1, null },
+                { openIteration2, null }
+            });
+
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelIterationDomainSwitchDialogViewModel(sessions);
+
+            Assert.That(viewmodel.IterationRows.Count, Is.EqualTo(2));
+
+            foreach (var row in viewmodel.IterationRows)
+            {
+                row.SelectedDomain = domain2;
+            }
+
+            await viewmodel.SwitchCommand.Execute();
+
+            this.session.Verify(x => x.SwitchDomain(this.iterationSetup11.IterationIid, domain2), Times.Once);
+            this.session.Verify(x => x.SwitchDomain(this.iterationSetup21.IterationIid, domain2), Times.Once);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #404 
Switch Domain and Close Model dialogs the same flat, searchable grid appearance as the Open Model/Iteration dialog from #342, replacing the old tree with a session combo, a sortable/searchable GridControl and a consistent styled button bar. 
It also fixes a Switch Domain interaction bug where changing multiple domain dropdowns only persisted the last one, by applying the switch to every row whose domain was changed rather than only to the selected rows.
