### PR TITLE
Feat #717 Add edit and inspect to the grapher

### DIFF
--- a/CDP4Grapher.Tests/Behaviors/GrapherOrgChartBehaviorTestFixture.cs
+++ b/CDP4Grapher.Tests/Behaviors/GrapherOrgChartBehaviorTestFixture.cs
@@ -1,10 +1,11 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GrapherOrgChartBehaviorTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -98,6 +99,8 @@ namespace CDP4Grapher.Tests.Behaviors
             this.grapherViewModel.Setup(x => x.Behavior).Returns(this.behavior);
             this.grapherViewModel.Setup(x => x.Isolate(It.IsAny<GraphElementViewModel>()));
             this.grapherViewModel.Setup(x => x.ExitIsolation());
+            this.grapherViewModel.Setup(x => x.Edit(It.IsAny<CDP4Common.CommonData.Thing>()));
+            this.grapherViewModel.Setup(x => x.Inspect(It.IsAny<CDP4Common.CommonData.Thing>()));
             this.grapherViewModel.Setup(x => x.DiagramContextMenuViewModel).Returns(this.contextMenu.Object);
             this.saveFileDialog = new Mock<IOpenSaveFileDialogService>();
             this.saveFileDialog.Setup(x => x.GetSaveFileDialog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns(string.Empty);
@@ -197,6 +200,18 @@ namespace CDP4Grapher.Tests.Behaviors
             this.grapherViewModel.Verify(x => x.Isolate(It.IsAny<GraphElementViewModel>()), Times.Once);
             this.behavior.ExitIsolation();
             this.grapherViewModel.Verify(x => x.ExitIsolation(), Times.Once);
+        }
+
+        [Test]
+        public void VerifyEditAndInspectRouteToViewModel()
+        {
+            this.behavior.Attach(new GrapherDiagramControl() { DataContext = this.grapherViewModel.Object });
+
+            this.behavior.Edit(this.ElementDefinition1);
+            this.behavior.Inspect(this.ElementUsage1);
+
+            this.grapherViewModel.Verify(x => x.Edit(this.ElementDefinition1), Times.Once);
+            this.grapherViewModel.Verify(x => x.Inspect(this.ElementUsage1), Times.Once);
         }
     }
 }

--- a/CDP4Grapher.Tests/ViewModels/DiagramControlContextMenuViewModelTestFixture.cs
+++ b/CDP4Grapher.Tests/ViewModels/DiagramControlContextMenuViewModelTestFixture.cs
@@ -1,10 +1,11 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramControlContextMenuViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -33,6 +34,7 @@ namespace CDP4Grapher.Tests.ViewModels
     using System.Threading.Tasks;
     using System.Windows.Input;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
 
@@ -79,6 +81,47 @@ namespace CDP4Grapher.Tests.ViewModels
             this.behavior.Setup(x => x.ExportGraph(It.IsAny<DiagramExportFormat>()));
             this.behavior.Setup(x => x.ApplySpecifiedLayout(It.IsAny<LayoutEnumeration>()));
             this.behavior.Setup(x => x.ApplySpecifiedLayout(It.IsAny<LayoutEnumeration>(), It.IsAny<Enum>()));
+            this.behavior.Setup(x => x.Edit(It.IsAny<Thing>()));
+            this.behavior.Setup(x => x.Inspect(It.IsAny<Thing>()));
+        }
+
+        /// <summary>
+        /// Builds a <see cref="GraphElementViewModel"/> whose represented element is an <see cref="ElementUsage"/>
+        /// </summary>
+        /// <param name="elementDefinition">The <see cref="ElementDefinition"/> referenced by the <see cref="ElementUsage"/></param>
+        /// <param name="elementUsage">The created <see cref="ElementUsage"/></param>
+        /// <returns>The <see cref="GraphElementViewModel"/></returns>
+        private GraphElementViewModel CreateUsageGraphElement(out ElementDefinition elementDefinition, out ElementUsage elementUsage)
+        {
+            elementDefinition = new ElementDefinition() { Owner = new DomainOfExpertise() };
+
+            elementUsage = new ElementUsage()
+            {
+                Container = new ElementDefinition() { Owner = new DomainOfExpertise() },
+                Owner = new DomainOfExpertise(),
+                ElementDefinition = elementDefinition
+            };
+
+            return new GraphElementViewModel(new NestedElement()
+            {
+                RootElement = new ElementDefinition() { Owner = new DomainOfExpertise() },
+                ElementUsage = { elementUsage }
+            }, this.messageBus);
+        }
+
+        /// <summary>
+        /// Builds a <see cref="GraphElementViewModel"/> whose represented element is the root <see cref="ElementDefinition"/>
+        /// </summary>
+        /// <param name="rootElement">The created root <see cref="ElementDefinition"/></param>
+        /// <returns>The <see cref="GraphElementViewModel"/></returns>
+        private GraphElementViewModel CreateRootGraphElement(out ElementDefinition rootElement)
+        {
+            rootElement = new ElementDefinition() { Owner = new DomainOfExpertise() };
+
+            return new GraphElementViewModel(new NestedElement()
+            {
+                RootElement = rootElement
+            }, this.messageBus);
         }
 
         [Test]
@@ -86,7 +129,7 @@ namespace CDP4Grapher.Tests.ViewModels
         {
             var vm = new DiagramControlContextMenuViewModel { Behavior = this.behavior.Object };
             Assert.IsNotEmpty(vm.ContextMenu);
-            Assert.AreEqual(5, vm.ContextMenu.Count);
+            Assert.AreEqual(9, vm.ContextMenu.Count);
             Assert.AreEqual(6, vm.ContextMenu.OfType<BarSubItem>().SelectMany(x => x.Items).Count());
             Assert.AreEqual(12, vm.ContextMenu.OfType<BarSubItem>().SelectMany(x => x.Items.OfType<BarSubItem>().SelectMany(s => s.Items)).Count());
             Assert.IsNotNull(vm.Behavior);
@@ -112,7 +155,60 @@ namespace CDP4Grapher.Tests.ViewModels
             Assert.IsNotNull(vm.ApplyCircularLayout);
             Assert.IsNotNull(vm.ApplyOrganisationalChartLayout);
 
+            Assert.IsNotNull(vm.EditElementDefinitionCommand);
+            Assert.IsNotNull(vm.InspectElementDefinitionCommand);
+            Assert.IsNotNull(vm.EditElementUsageCommand);
+            Assert.IsNotNull(vm.InspectElementUsageCommand);
+
             Assert.IsNull(vm.HoveredElement);
+        }
+
+        [Test]
+        public async Task VerifyEditAndInspectElementUsageNode()
+        {
+            var vm = new DiagramControlContextMenuViewModel { Behavior = this.behavior.Object };
+            var graphElement = this.CreateUsageGraphElement(out var elementDefinition, out var elementUsage);
+
+            Assert.IsFalse(((ICommand)vm.EditElementDefinitionCommand).CanExecute(null));
+            Assert.IsFalse(((ICommand)vm.EditElementUsageCommand).CanExecute(null));
+
+            vm.HoveredElement = graphElement;
+
+            Assert.IsTrue(((ICommand)vm.EditElementDefinitionCommand).CanExecute(null));
+            Assert.IsTrue(((ICommand)vm.InspectElementDefinitionCommand).CanExecute(null));
+            Assert.IsTrue(((ICommand)vm.EditElementUsageCommand).CanExecute(null));
+            Assert.IsTrue(((ICommand)vm.InspectElementUsageCommand).CanExecute(null));
+
+            await vm.EditElementDefinitionCommand.Execute();
+            await vm.InspectElementDefinitionCommand.Execute();
+            await vm.EditElementUsageCommand.Execute();
+            await vm.InspectElementUsageCommand.Execute();
+
+            this.behavior.Verify(x => x.Edit(elementDefinition), Times.Once);
+            this.behavior.Verify(x => x.Inspect(elementDefinition), Times.Once);
+            this.behavior.Verify(x => x.Edit(elementUsage), Times.Once);
+            this.behavior.Verify(x => x.Inspect(elementUsage), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyEditAndInspectRootNode()
+        {
+            var vm = new DiagramControlContextMenuViewModel { Behavior = this.behavior.Object };
+            var graphElement = this.CreateRootGraphElement(out var rootElement);
+
+            vm.HoveredElement = graphElement;
+
+            Assert.IsTrue(((ICommand)vm.EditElementDefinitionCommand).CanExecute(null));
+            Assert.IsTrue(((ICommand)vm.InspectElementDefinitionCommand).CanExecute(null));
+            Assert.IsFalse(((ICommand)vm.EditElementUsageCommand).CanExecute(null));
+            Assert.IsFalse(((ICommand)vm.InspectElementUsageCommand).CanExecute(null));
+
+            await vm.EditElementDefinitionCommand.Execute();
+            await vm.InspectElementDefinitionCommand.Execute();
+
+            this.behavior.Verify(x => x.Edit(rootElement), Times.Once);
+            this.behavior.Verify(x => x.Inspect(rootElement), Times.Once);
+            this.behavior.Verify(x => x.Edit(It.IsAny<ElementUsage>()), Times.Never);
         }
 
         [Test]

--- a/CDP4Grapher.Tests/ViewModels/GrapherViewModelTestFixture.cs
+++ b/CDP4Grapher.Tests/ViewModels/GrapherViewModelTestFixture.cs
@@ -1,10 +1,11 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GrapherViewModelTestFixture.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -31,6 +32,7 @@ namespace CDP4Grapher.Tests.ViewModels
     using System.Threading;
     using System.Windows;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
 
     using CDP4Composition.Navigation;
@@ -38,6 +40,7 @@ namespace CDP4Grapher.Tests.ViewModels
     using CDP4Composition.PluginSettingService;
 
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
 
     using CDP4Grapher.Tests.Data;
     using CDP4Grapher.ViewModels;
@@ -152,6 +155,43 @@ namespace CDP4Grapher.Tests.ViewModels
             vm.SetsSelectedElementAndSelectedElementPath(vm.GraphElements.FirstOrDefault());
             Assert.IsNotNull(vm.SelectedElementModelCode);
             Assert.IsNotNull(vm.SelectedElement);
+        }
+
+        [Test]
+        public void VerifyEditOpensUpdateDialog()
+        {
+            var vm = new GrapherViewModel(this.Option, this.Session.Object, this.thingNavigationService.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, this.pluginSettingService.Object);
+
+            vm.Edit(this.ElementUsage1);
+
+            this.thingNavigationService.Verify(
+                x => x.Navigate(It.Is<Thing>(t => t.Iid == this.ElementUsage1.Iid), It.IsAny<IThingTransaction>(), this.Session.Object, true, ThingDialogKind.Update, this.thingNavigationService.Object, It.IsAny<Thing>(), It.IsAny<System.Collections.Generic.IEnumerable<Thing>>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void VerifyInspectOpensInspectDialog()
+        {
+            var vm = new GrapherViewModel(this.Option, this.Session.Object, this.thingNavigationService.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, this.pluginSettingService.Object);
+
+            vm.Inspect(this.TopElement);
+
+            this.thingNavigationService.Verify(
+                x => x.Navigate(this.TopElement, It.IsAny<IThingTransaction>(), this.Session.Object, true, ThingDialogKind.Inspect, this.thingNavigationService.Object, It.IsAny<Thing>(), It.IsAny<System.Collections.Generic.IEnumerable<Thing>>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void VerifyEditOrInspectWithNullThingDoesNothing()
+        {
+            var vm = new GrapherViewModel(this.Option, this.Session.Object, this.thingNavigationService.Object, this.panelNavigationService.Object, this.dialogNavigationService.Object, this.pluginSettingService.Object);
+
+            vm.Edit(null);
+            vm.Inspect(null);
+
+            this.thingNavigationService.Verify(
+                x => x.Navigate(It.IsAny<Thing>(), It.IsAny<IThingTransaction>(), It.IsAny<CDP4Dal.ISession>(), It.IsAny<bool>(), It.IsAny<ThingDialogKind>(), It.IsAny<IThingDialogNavigationService>(), It.IsAny<Thing>(), It.IsAny<System.Collections.Generic.IEnumerable<Thing>>()),
+                Times.Never);
         }
 
         [Test]

--- a/CDP4Grapher/Behaviors/GrapherOrgChartBehavior.cs
+++ b/CDP4Grapher/Behaviors/GrapherOrgChartBehavior.cs
@@ -1,20 +1,20 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GrapherOrgChartBehavior.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2020 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft,
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Rowan de Voogt
 
 //
-//    This file is part of CDP4-IME Community Edition. 
-//    The CDP4-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    This file is part of CDP4-COMET IME Community Edition. 
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
-//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or any later version.
 //
-//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //    GNU Affero General Public License for more details.
@@ -30,6 +30,7 @@ namespace CDP4Grapher.Behaviors
     using System.Linq;
     using System.Windows;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
 
     using CDP4Composition.Navigation;
@@ -382,6 +383,24 @@ namespace CDP4Grapher.Behaviors
         public void ExitIsolation()
         {
             (this.AssociatedObject.DataContext as IGrapherViewModel)?.ExitIsolation();
+        }
+
+        /// <summary>
+        /// Opens the edit dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to edit</param>
+        public void Edit(Thing thing)
+        {
+            (this.AssociatedObject.DataContext as IGrapherViewModel)?.Edit(thing);
+        }
+
+        /// <summary>
+        /// Opens the inspect dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to inspect</param>
+        public void Inspect(Thing thing)
+        {
+            (this.AssociatedObject.DataContext as IGrapherViewModel)?.Inspect(thing);
         }
     }
 }

--- a/CDP4Grapher/Behaviors/IGrapherOrgChartBehavior.cs
+++ b/CDP4Grapher/Behaviors/IGrapherOrgChartBehavior.cs
@@ -1,20 +1,19 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IGrapherOrgChartBehavior.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2020 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski
-
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski, Rowan de Voogt
 //
-//    This file is part of CDP4-IME Community Edition. 
-//    The CDP4-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    This file is part of CDP4-COMET IME Community Edition. 
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
-//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or any later version.
 //
-//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //    GNU Affero General Public License for more details.
@@ -27,6 +26,8 @@
 namespace CDP4Grapher.Behaviors
 {
     using System;
+
+    using CDP4Common.CommonData;
 
     using CDP4Grapher.Utilities;
 
@@ -72,5 +73,17 @@ namespace CDP4Grapher.Behaviors
         /// Exits the isolation
         /// </summary>
         void ExitIsolation();
+
+        /// <summary>
+        /// Opens the edit dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to edit</param>
+        void Edit(Thing thing);
+
+        /// <summary>
+        /// Opens the inspect dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to inspect</param>
+        void Inspect(Thing thing);
     }
 }

--- a/CDP4Grapher/ViewModels/DiagramControlContextMenuViewModel.cs
+++ b/CDP4Grapher/ViewModels/DiagramControlContextMenuViewModel.cs
@@ -1,19 +1,19 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="DiagramControlContextMenuViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2020 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski, Rowan de Voogt
 //
-//    This file is part of CDP4-IME Community Edition. 
-//    The CDP4-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    This file is part of CDP4-COMET IME Community Edition. 
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
-//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or any later version.
 //
-//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //    GNU Affero General Public License for more details.
@@ -30,6 +30,8 @@ namespace CDP4Grapher.ViewModels
     using System.Reactive;
     using System.Reactive.Linq;
     using System.Windows.Input;
+
+    using CDP4Common.EngineeringModelData;
 
     using CDP4Composition.Mvvm;
 
@@ -79,6 +81,21 @@ namespace CDP4Grapher.ViewModels
         public IGrapherOrgChartBehavior Behavior { get; set; }
 
         /// <summary>
+        /// Gets the <see cref="ElementDefinition"/> represented by the <see cref="HoveredElement"/>, if any.
+        /// For a usage node this is the referenced <see cref="ElementDefinition"/>, for the root node the node itself.
+        /// </summary>
+        private ElementDefinition HoveredElementDefinition =>
+            this.HoveredElement?.NestedElementElement is ElementUsage elementUsage
+                ? elementUsage.ElementDefinition
+                : this.HoveredElement?.NestedElementElement as ElementDefinition;
+
+        /// <summary>
+        /// Gets the <see cref="ElementUsage"/> represented by the <see cref="HoveredElement"/>, if any.
+        /// The root node of the tree is not an <see cref="ElementUsage"/> and therefore returns null.
+        /// </summary>
+        private ElementUsage HoveredElementUsage => this.HoveredElement?.NestedElementElement as ElementUsage;
+
+        /// <summary>
         /// Holds the <see cref="BarButtonItem"/> and <see cref="BarSubItem"/> representing an overridable diagram Context Menu
         /// </summary>
         public List<IBarManagerControllerAction> ContextMenu { get; set; } = new List<IBarManagerControllerAction>();
@@ -110,6 +127,26 @@ namespace CDP4Grapher.ViewModels
         /// Gets the <see cref="ReactiveCommand"/> to exit isolation
         /// </summary>
         public ReactiveCommand<Unit, Unit> ExitIsolationCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> to edit the <see cref="ElementDefinition"/> of the <see cref="HoveredElement"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> EditElementDefinitionCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> to inspect the <see cref="ElementDefinition"/> of the <see cref="HoveredElement"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> InspectElementDefinitionCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> to edit the <see cref="ElementUsage"/> of the <see cref="HoveredElement"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> EditElementUsageCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> to inspect the <see cref="ElementUsage"/> of the <see cref="HoveredElement"/>
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> InspectElementUsageCommand { get; private set; }
         
         /// <summary>
         /// Gets the <see cref="ReactiveCommand"/> to export the generated diagram as png
@@ -213,6 +250,22 @@ namespace CDP4Grapher.ViewModels
                 this.WhenAnyValue(x => x.CanExitIsolation)
                     .ObserveOn(RxApp.MainThreadScheduler));
 
+            this.EditElementDefinitionCommand = ReactiveCommandCreator.Create(this.ExecuteEditElementDefinition,
+                this.WhenAnyValue(x => x.HoveredElement)
+                    .Select(x => x?.NestedElementElement != null).ObserveOn(RxApp.MainThreadScheduler));
+
+            this.InspectElementDefinitionCommand = ReactiveCommandCreator.Create(this.ExecuteInspectElementDefinition,
+                this.WhenAnyValue(x => x.HoveredElement)
+                    .Select(x => x?.NestedElementElement != null).ObserveOn(RxApp.MainThreadScheduler));
+
+            this.EditElementUsageCommand = ReactiveCommandCreator.Create(this.ExecuteEditElementUsage,
+                this.WhenAnyValue(x => x.HoveredElement)
+                    .Select(x => x?.NestedElementElement is ElementUsage).ObserveOn(RxApp.MainThreadScheduler));
+
+            this.InspectElementUsageCommand = ReactiveCommandCreator.Create(this.ExecuteInspectElementUsage,
+                this.WhenAnyValue(x => x.HoveredElement)
+                    .Select(x => x?.NestedElementElement is ElementUsage).ObserveOn(RxApp.MainThreadScheduler));
+
             this.ExportGraphAsJpg = ReactiveCommandCreator.Create(this.ExecuteExportGraphAsPng, this.WhenAnyValue(x => x.CanExportDiagram).ObserveOn(RxApp.MainThreadScheduler));
             
             this.ExportGraphAsPdf = ReactiveCommandCreator.Create(this.ExecuteExportGraphAsPdf, this.WhenAnyValue(x => x.CanExportDiagram).ObserveOn(RxApp.MainThreadScheduler));
@@ -251,6 +304,10 @@ namespace CDP4Grapher.ViewModels
         /// </summary>
         private void CreateContextMenu()
         {
+            this.ContextMenu.Add(this.GenerateContextMenuItem<BarButtonItem>("Edit Element Definition", this.EditElementDefinitionCommand, "XAF/Action_Inline_Edit.svg"));
+            this.ContextMenu.Add(this.GenerateContextMenuItem<BarButtonItem>("Inspect Element Definition", this.InspectElementDefinitionCommand, "Find/Find.svg"));
+            this.ContextMenu.Add(this.GenerateContextMenuItem<BarButtonItem>("Edit Element Usage", this.EditElementUsageCommand, "XAF/Action_Inline_Edit.svg"));
+            this.ContextMenu.Add(this.GenerateContextMenuItem<BarButtonItem>("Inspect Element Usage", this.InspectElementUsageCommand, "Find/Find.svg"));
             this.ContextMenu.Add(this.GenerateContextMenuItem<BarButtonItem>("Isolate", this.IsolateCommand, "Snap/SeparatorListNone.svg"));
             this.ContextMenu.Add(this.GenerateContextMenuItem<BarButtonItem>("Exit Isolation", this.ExitIsolationCommand, "Icon Builder/Actions_RemoveCircled.svg"));
             this.ContextMenu.Add(this.GenerateContextMenuItem<BarButtonItem>("Export Graph as JPG", this.ExportGraphAsJpg, "XAF/Action_Export_ToImage.svg"));
@@ -327,6 +384,38 @@ namespace CDP4Grapher.ViewModels
             this.CanExportDiagram = false;
             this.Behavior.ExportGraph(DiagramExportFormat.JPEG);
             this.CanExportDiagram = true;
+        }
+
+        /// <summary>
+        /// Executes the <see cref="EditElementDefinitionCommand"/>
+        /// </summary>
+        private void ExecuteEditElementDefinition()
+        {
+            this.Behavior.Edit(this.HoveredElementDefinition);
+        }
+
+        /// <summary>
+        /// Executes the <see cref="InspectElementDefinitionCommand"/>
+        /// </summary>
+        private void ExecuteInspectElementDefinition()
+        {
+            this.Behavior.Inspect(this.HoveredElementDefinition);
+        }
+
+        /// <summary>
+        /// Executes the <see cref="EditElementUsageCommand"/>
+        /// </summary>
+        private void ExecuteEditElementUsage()
+        {
+            this.Behavior.Edit(this.HoveredElementUsage);
+        }
+
+        /// <summary>
+        /// Executes the <see cref="InspectElementUsageCommand"/>
+        /// </summary>
+        private void ExecuteInspectElementUsage()
+        {
+            this.Behavior.Inspect(this.HoveredElementUsage);
         }
 
         /// <summary>

--- a/CDP4Grapher/ViewModels/GrapherViewModel.cs
+++ b/CDP4Grapher/ViewModels/GrapherViewModel.cs
@@ -1,10 +1,11 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="GrapherViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2024 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
+//    This file is part of CDP4-COMET IME Community Edition.
 //    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
@@ -30,6 +31,7 @@ namespace CDP4Grapher.ViewModels
     using System.Reactive.Linq;
     using System.Windows;
 
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.Helpers;
     using CDP4Common.SiteDirectoryData;
@@ -352,6 +354,34 @@ namespace CDP4Grapher.ViewModels
         {
             this.SelectedElement = new ElementParameterRowControlViewModel(element.NestedElementElement, this.option);
             this.SelectedElementModelCode = element.ModelCode;
+        }
+
+        /// <summary>
+        /// Opens the edit dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to edit</param>
+        public void Edit(Thing thing)
+        {
+            if (thing == null)
+            {
+                return;
+            }
+
+            this.ExecuteUpdateCommand(thing);
+        }
+
+        /// <summary>
+        /// Opens the inspect dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to inspect</param>
+        public void Inspect(Thing thing)
+        {
+            if (thing == null)
+            {
+                return;
+            }
+
+            this.ExecuteInspectCommand(thing);
         }
     }
 }

--- a/CDP4Grapher/ViewModels/IGrapherViewModel.cs
+++ b/CDP4Grapher/ViewModels/IGrapherViewModel.cs
@@ -1,19 +1,19 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="IGrapherViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2020 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Kamil Wojnowski, Rowan de Voogt
 //
-//    This file is part of CDP4-IME Community Edition. 
-//    The CDP4-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    This file is part of CDP4-COMET IME Community Edition. 
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
-//    The CDP4-IME Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or any later version.
 //
-//    The CDP4-IME Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //    GNU Affero General Public License for more details.
@@ -25,6 +25,8 @@
 
 namespace CDP4Grapher.ViewModels
 {
+    using CDP4Common.CommonData;
+
     using CDP4Composition.Mvvm;
     using CDP4Composition.ViewModels;
 
@@ -73,5 +75,17 @@ namespace CDP4Grapher.ViewModels
         /// </summary>
         /// <param name="element">The selected element</param>
         void SetsSelectedElementAndSelectedElementPath(GraphElementViewModel element);
+
+        /// <summary>
+        /// Opens the edit dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to edit</param>
+        void Edit(Thing thing);
+
+        /// <summary>
+        /// Opens the inspect dialog for the provided <see cref="Thing"/>
+        /// </summary>
+        /// <param name="thing">The <see cref="Thing"/> to inspect</param>
+        void Inspect(Thing thing);
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #717 and #560 as it is the same as inspect : 
Adds Edit/Inspect Element Definition and Edit/Inspect Element Usage entries to the grapher's right-click context menu, opening the standard Thing dialogs via the existing IThingDialogNavigationService (Element Usage entries are disabled on the root node).
Wired through the established context-menu → GrapherOrgChartBehavior → GrapherViewModel path, reusing BrowserViewModelBase's rather than a new message-bus event.



