### PR TITLE
feat #1206 Show warning when item on second tab is required 

### DIFF
--- a/BasicRdl.Tests/ViewModels/Dialogs/CategoryDialogViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Dialogs/CategoryDialogViewModelTestFixture.cs
@@ -218,6 +218,16 @@ namespace BasicRdl.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatGuidanceIsShownWhenPermissibleClassListIsEmpty()
+        {
+            Assert.IsFalse(this.viewmodel.PermissibleClass.Any());
+            Assert.IsTrue(this.viewmodel.IsPermissibleClassListEmpty);
+
+            this.viewmodel.PermissibleClass.Add(ClassKind.ElementDefinition);
+            Assert.IsFalse(this.viewmodel.IsPermissibleClassListEmpty);
+        }
+
+        [Test]
         public void VerifyThatParameterlessContructorExists()
         {
             Assert.DoesNotThrow(() => new CategoryDialogViewModel());

--- a/BasicRdl.Tests/ViewModels/Dialogs/DerivedQuantityKindDialogViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Dialogs/DerivedQuantityKindDialogViewModelTestFixture.cs
@@ -167,6 +167,16 @@ namespace BasicRdl.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatGuidanceIsShownWhenQuantityKindFactorListIsEmpty()
+        {
+            Assert.IsNotEmpty(this.viewmodel.QuantityKindFactor);
+            Assert.IsFalse(this.viewmodel.IsQuantityKindFactorListEmpty);
+
+            this.viewmodel.QuantityKindFactor.Clear();
+            Assert.IsTrue(this.viewmodel.IsQuantityKindFactorListEmpty);
+        }
+
+        [Test]
         public void VerifThatUpdatingContainerPopulatesPossiblePossibleScales()
         {
             this.viewmodel.PossiblePossibleScale.Clear();

--- a/BasicRdl.Tests/ViewModels/Dialogs/EnumerationParameterTypeDialogViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Dialogs/EnumerationParameterTypeDialogViewModelTestFixture.cs
@@ -129,6 +129,16 @@ namespace BasicRdl.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatGuidanceIsShownWhenValueDefinitionListIsEmpty()
+        {
+            Assert.AreEqual(1, this.viewmodel.ValueDefinition.Count);
+            Assert.IsFalse(this.viewmodel.IsValueDefinitionListEmpty);
+
+            this.viewmodel.ValueDefinition.Clear();
+            Assert.IsTrue(this.viewmodel.IsValueDefinitionListEmpty);
+        }
+
+        [Test]
         public void VerifyDialogValidation()
         {
             Assert.AreEqual(0, this.viewmodel.ValidationErrors.Count);

--- a/BasicRdl/ViewModels/Dialogs/CategoryDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/CategoryDialogViewModel.cs
@@ -54,6 +54,11 @@ namespace BasicRdl.ViewModels
     public class CategoryDialogViewModel : CDP4CommonView.CategoryDialogViewModel, IThingDialogViewModel
     {
         /// <summary>
+        /// The backing field for <see cref="IsPermissibleClassListEmpty"/>
+        /// </summary>
+        private bool isPermissibleClassListEmpty;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CategoryDialogViewModel"/> class.
         /// </summary>
         /// <remarks>
@@ -95,6 +100,7 @@ namespace BasicRdl.ViewModels
             : base(category, transaction, session, isRoot, dialogKind, thingDialogNavigationService, container, chainOfContainers)
         {
             this.WhenAnyValue(vm => vm.PermissibleClass).Subscribe(_ => this.UpdateOkCanExecute());
+            this.PermissibleClass.CountChanged.Subscribe(_ => this.UpdateOkCanExecute());
             this.WhenAnyValue(vm => vm.Container).Subscribe(_ => this.PopulateSuperCategory());
         }
 
@@ -107,6 +113,16 @@ namespace BasicRdl.ViewModels
         /// Gets or sets the list of possible super categories
         /// </summary>
         public ReactiveList<Category> PossibleSuperCategories { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether no <see cref="ClassKind"/> has been selected as permissible class yet. When <c>true</c>
+        /// the dialog shows guidance that at least one permissible class must be selected on the "Permissible Classes" tab before saving.
+        /// </summary>
+        public bool IsPermissibleClassListEmpty
+        {
+            get => this.isPermissibleClassListEmpty;
+            private set => this.RaiseAndSetIfChanged(ref this.isPermissibleClassListEmpty, value);
+        }
 
         /// <summary>
         /// Initializes the list of this dialog
@@ -162,6 +178,7 @@ namespace BasicRdl.ViewModels
         protected override void UpdateOkCanExecute()
         {
             base.UpdateOkCanExecute();
+            this.IsPermissibleClassListEmpty = !this.PermissibleClass.Any();
             this.OkCanExecute = this.OkCanExecute && this.PermissibleClass.Any();
         }
 

--- a/BasicRdl/ViewModels/Dialogs/DerivedQuantityKindDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/DerivedQuantityKindDialogViewModel.cs
@@ -56,6 +56,11 @@ namespace BasicRdl.ViewModels
         private bool isBaseQuantityKind;
 
         /// <summary>
+        /// The backing field for <see cref="IsQuantityKindFactorListEmpty"/>
+        /// </summary>
+        private bool isQuantityKindFactorListEmpty;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DerivedQuantityKindDialogViewModel"/> class.
         /// </summary>
         /// <remarks>
@@ -118,11 +123,22 @@ namespace BasicRdl.ViewModels
         }
 
         /// <summary>
+        /// Gets a value indicating whether no <see cref="QuantityKindFactor"/> has been added yet. When <c>true</c>
+        /// the dialog shows guidance that at least one factor must be added on the "Factors" tab before saving.
+        /// </summary>
+        public bool IsQuantityKindFactorListEmpty
+        {
+            get => this.isQuantityKindFactorListEmpty;
+            private set => this.RaiseAndSetIfChanged(ref this.isQuantityKindFactorListEmpty, value);
+        }
+
+        /// <summary>
         /// Updates the <see cref="OkCanExecute"/> property using validation rules
         /// </summary>
         protected override void UpdateOkCanExecute()
         {
             base.UpdateOkCanExecute();
+            this.IsQuantityKindFactorListEmpty = !this.QuantityKindFactor.Any();
             this.OkCanExecute = this.OkCanExecute && this.QuantityKindFactor.Any() && this.SelectedDefaultScale != null;
         }
 

--- a/BasicRdl/ViewModels/Dialogs/EnumerationParameterTypeDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/EnumerationParameterTypeDialogViewModel.cs
@@ -40,6 +40,8 @@ namespace BasicRdl.ViewModels
     using CDP4Dal;
     using CDP4Dal.Operations;
 
+    using ReactiveUI;
+
     /// <summary>
     /// The purpose of the <see cref="EnumerationParameterTypeDialogViewModel"/> is to provide a dialog view model
     /// for a <see cref="EnumerationParameterType"/>
@@ -47,6 +49,11 @@ namespace BasicRdl.ViewModels
     [ThingDialogViewModelExport(ClassKind.EnumerationParameterType)]
     public class EnumerationParameterTypeDialogViewModel : CDP4CommonView.EnumerationParameterTypeDialogViewModel, IThingDialogViewModel
     {
+        /// <summary>
+        /// The backing field for <see cref="IsValueDefinitionListEmpty"/>
+        /// </summary>
+        private bool isValueDefinitionListEmpty;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EnumerationParameterTypeDialogViewModel"/> class.
         /// </summary>
@@ -94,11 +101,22 @@ namespace BasicRdl.ViewModels
         }
 
         /// <summary>
+        /// Gets a value indicating whether no <see cref="EnumerationValueDefinition"/> has been added yet. When <c>true</c>
+        /// the dialog shows guidance that at least one value must be added on the "Values" tab before saving.
+        /// </summary>
+        public bool IsValueDefinitionListEmpty
+        {
+            get => this.isValueDefinitionListEmpty;
+            private set => this.RaiseAndSetIfChanged(ref this.isValueDefinitionListEmpty, value);
+        }
+
+        /// <summary>
         /// Updates the <see cref="DialogViewModelBase{T}.OkCanExecute"/> property using validation rules
         /// </summary>
         protected override void UpdateOkCanExecute()
         {
             base.UpdateOkCanExecute();
+            this.IsValueDefinitionListEmpty = !this.ValueDefinition.Any();
             this.OkCanExecute = this.OkCanExecute && this.ValueDefinition.Any();
         }
     }

--- a/BasicRdl/Views/Dialogs/CategoryDialog.xaml
+++ b/BasicRdl/Views/Dialogs/CategoryDialog.xaml
@@ -17,6 +17,7 @@
     <dx:DXWindow.Resources>
         <ResourceDictionary>
             <converters:ReactiveClassKindToObjectListConverter x:Key="ReactiveClassKindToObjectListConverter" />
+            <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/CDP4Composition;component/CommonView/Resources/CDP4Styles.xaml" />
             </ResourceDictionary.MergedDictionaries>
@@ -74,6 +75,8 @@
             <items:HyperLinkLayoutGroup />
             <items:AdvancedLayoutGroup />
         </lc:LayoutGroup>
+        <items:WarningLayoutItem Visibility="{Binding IsPermissibleClassListEmpty, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                 WarningText="At least one Permissible Class must be selected on the 'Permissible Classes' tab before this Category can be saved." />
         <items:UserValidationButtonsLayoutGroup />
         <items:ErrorMessageLayoutGroup />
     </lc:LayoutControl>

--- a/BasicRdl/Views/Dialogs/DerivedQuantityKindDialog.xaml
+++ b/BasicRdl/Views/Dialogs/DerivedQuantityKindDialog.xaml
@@ -7,6 +7,7 @@
              xmlns:items="clr-namespace:CDP4CommonView.Items;assembly=CDP4Composition"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
+             xmlns:converters="clr-namespace:CDP4Composition.Converters;assembly=CDP4Composition"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
              xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
              xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
@@ -17,6 +18,7 @@
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </dx:DXWindow.Resources>
     <dxlc:LayoutControl Margin="5"
                         Orientation="Vertical"
@@ -120,6 +122,8 @@
             <items:HyperLinkLayoutGroup />
             <items:AdvancedLayoutGroup />
         </dxlc:LayoutGroup>
+        <items:WarningLayoutItem Visibility="{Binding IsQuantityKindFactorListEmpty, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                 WarningText="At least one Quantity Kind Factor must be added on the 'Factors' tab before this Derived Quantity Kind can be saved." />
         <items:UserValidationButtonsLayoutGroup />
         <items:ErrorMessageLayoutGroup />
     </dxlc:LayoutControl>

--- a/BasicRdl/Views/Dialogs/EnumerationParameterTypeDialog.xaml
+++ b/BasicRdl/Views/Dialogs/EnumerationParameterTypeDialog.xaml
@@ -7,6 +7,7 @@
              xmlns:items="clr-namespace:CDP4CommonView.Items;assembly=CDP4Composition"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
+             xmlns:converters="clr-namespace:CDP4Composition.Converters;assembly=CDP4Composition"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
              xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
              xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
@@ -16,6 +17,7 @@
              navigation:DialogCloser.DialogResult="{Binding DialogResult}"
              mc:Ignorable="d">
     <dx:DXWindow.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </dx:DXWindow.Resources>
     <dxlc:LayoutControl Margin="5"
                         Orientation="Vertical"
@@ -108,6 +110,8 @@
             <items:HyperLinkLayoutGroup />
             <items:AdvancedLayoutGroup />
         </dxlc:LayoutGroup>
+        <items:WarningLayoutItem Visibility="{Binding IsValueDefinitionListEmpty, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                 WarningText="At least one Value must be added on the 'Values' tab before this Enumeration Parameter Type can be saved." />
         <items:UserValidationButtonsLayoutGroup />
         <items:ErrorMessageLayoutGroup />
     </dxlc:LayoutControl>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #1206 

use warninglayoutitem on derived QK, Enumeration and category creation dialog