### PR TITLE
Feat #62 Unified the population of the ownerdropdown to everywhere only show allowed domains and default to current DoE

### DIFF
--- a/CDP4Composition.Tests/Converters/DomainOfExpertiseToFontWeightConverterTestFixture.cs
+++ b/CDP4Composition.Tests/Converters/DomainOfExpertiseToFontWeightConverterTestFixture.cs
@@ -1,0 +1,84 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertiseToFontWeightConverterTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Tests.Converters
+{
+    using System;
+    using System.Windows;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Converters;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="DomainOfExpertiseToFontWeightConverter"/>
+    /// </summary>
+    [TestFixture]
+    public class DomainOfExpertiseToFontWeightConverterTestFixture
+    {
+        private readonly Uri uri = new Uri("http://test.com");
+
+        private DomainOfExpertiseToFontWeightConverter converter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.converter = new DomainOfExpertiseToFontWeightConverter();
+        }
+
+        [Test]
+        public void VerifyThatCurrentDomainIsBold()
+        {
+            var domain = new DomainOfExpertise(Guid.NewGuid(), null, this.uri);
+
+            Assert.AreEqual(FontWeights.Bold, this.converter.Convert(new object[] { domain, domain }, null, null, null));
+        }
+
+        [Test]
+        public void VerifyThatOtherDomainIsNormal()
+        {
+            var item = new DomainOfExpertise(Guid.NewGuid(), null, this.uri);
+            var current = new DomainOfExpertise(Guid.NewGuid(), null, this.uri);
+
+            Assert.AreEqual(FontWeights.Normal, this.converter.Convert(new object[] { item, current }, null, null, null));
+        }
+
+        [Test]
+        public void VerifyThatNullCurrentDomainIsNormal()
+        {
+            var item = new DomainOfExpertise(Guid.NewGuid(), null, this.uri);
+
+            Assert.AreEqual(FontWeights.Normal, this.converter.Convert(new object[] { item, null }, null, null, null));
+        }
+
+        [Test]
+        public void VerifyThatConvertBackIsNotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => this.converter.ConvertBack(null, null, null, null));
+        }
+    }
+}

--- a/CDP4Composition/CommonView/Items/OwnerLayoutItem.xaml
+++ b/CDP4Composition/CommonView/Items/OwnerLayoutItem.xaml
@@ -6,9 +6,11 @@
              xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
              xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             xmlns:converters="clr-namespace:CDP4Composition.Converters"
              mc:Ignorable="d"
              Label="Owner: ">
     <dxlc:LayoutItem.Resources>
+        <converters:DomainOfExpertiseToFontWeightConverter x:Key="DomainOfExpertiseToFontWeightConverter" />
     </dxlc:LayoutItem.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -17,13 +19,28 @@
         </Grid.ColumnDefinitions>
         <dxe:ComboBoxEdit Name="Owner"
                         DisplayMember="Name"
+                        ApplyItemTemplateToSelectedItem="True"
                         EditValue="{Binding Path=SelectedOwner,
                                             Mode=TwoWay,
                                             UpdateSourceTrigger=PropertyChanged}"
                         IsTextEditable="False"
                         ItemsSource="{Binding Path=PossibleOwner}"
                         ShowCustomItems="False"
-                        IsReadOnly="{Binding IsReadOnly}"/>
+                        IsReadOnly="{Binding IsReadOnly}">
+            <dxe:ComboBoxEdit.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Path=Name}">
+                        <TextBlock.FontWeight>
+                            <MultiBinding Converter="{StaticResource DomainOfExpertiseToFontWeightConverter}">
+                                <Binding Path="." />
+                                <Binding Path="DataContext.CurrentDomainOfExpertise"
+                                         RelativeSource="{RelativeSource AncestorType={x:Type dxe:ComboBoxEdit}}" />
+                            </MultiBinding>
+                        </TextBlock.FontWeight>
+                    </TextBlock>
+                </DataTemplate>
+            </dxe:ComboBoxEdit.ItemTemplate>
+        </dxe:ComboBoxEdit>
         <Button Grid.Column="1"
                 Width="25"
                 Height="25"

--- a/CDP4Composition/Converters/DomainOfExpertiseToFontWeightConverter.cs
+++ b/CDP4Composition/Converters/DomainOfExpertiseToFontWeightConverter.cs
@@ -1,0 +1,80 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DomainOfExpertiseToFontWeightConverter.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Converters
+{
+    using System;
+    using System.Globalization;
+    using System.Windows;
+    using System.Windows.Data;
+
+    using CDP4Common.SiteDirectoryData;
+
+    /// <summary>
+    /// Converts a <see cref="DomainOfExpertise"/> item and the current session <see cref="DomainOfExpertise"/> to a
+    /// <see cref="FontWeight"/>, returning <see cref="FontWeights.Bold"/> when the item is the current domain. This is
+    /// used to visually highlight the user's current <see cref="DomainOfExpertise"/> in owner selection combo-boxes.
+    /// </summary>
+    public class DomainOfExpertiseToFontWeightConverter : IMultiValueConverter
+    {
+        /// <summary>
+        /// Converts the bound <see cref="DomainOfExpertise"/> item and the current <see cref="DomainOfExpertise"/> to a
+        /// <see cref="FontWeight"/>.
+        /// </summary>
+        /// <param name="values">
+        /// An array where the first value is the <see cref="DomainOfExpertise"/> item and the second value is the
+        /// current session <see cref="DomainOfExpertise"/>.
+        /// </param>
+        /// <param name="targetType">The parameter is not used.</param>
+        /// <param name="parameter">The parameter is not used.</param>
+        /// <param name="culture">The parameter is not used.</param>
+        /// <returns>
+        /// <see cref="FontWeights.Bold"/> when the item is the current <see cref="DomainOfExpertise"/>;
+        /// otherwise <see cref="FontWeights.Normal"/>.
+        /// </returns>
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length >= 2 && values[0] is DomainOfExpertise item && values[1] is DomainOfExpertise current && item.Iid == current.Iid)
+            {
+                return FontWeights.Bold;
+            }
+
+            return FontWeights.Normal;
+        }
+
+        /// <summary>
+        /// not supported
+        /// </summary>
+        /// <param name="value">The parameter is not used.</param>
+        /// <param name="targetTypes">The parameter is not used.</param>
+        /// <param name="parameter">The parameter is not used.</param>
+        /// <param name="culture">The parameter is not used.</param>
+        /// <returns>a <see cref="NotSupportedException"/> is thrown</returns>
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/CDP4Composition/Extensions/OwnedThingDialogExtensions.cs
+++ b/CDP4Composition/Extensions/OwnedThingDialogExtensions.cs
@@ -1,0 +1,78 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="OwnedThingDialogExtensions.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4Composition.Extensions
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+
+    /// <summary>
+    /// Extension methods that centralize how the possible owner <see cref="DomainOfExpertise"/>s of an
+    /// <see cref="IOwnedThing"/> are populated in the various owned-thing dialogs.
+    /// </summary>
+    /// <remarks>
+    /// The list of owners a user may select is restricted to the <see cref="DomainOfExpertise"/>s the active
+    /// <see cref="Participant"/> is a member of (as returned by <see cref="ISession.QueryDomainOfExpertise"/>).
+    /// This matches the <c>MODIFY_IF_OWNER</c> permission rule, which only allows a user to write an
+    /// <see cref="IOwnedThing"/> that is owned by one of their own domains. See GitHub issues #62 and #762.
+    /// </remarks>
+    public static class OwnedThingDialogExtensions
+    {
+        /// <summary>
+        /// Queries the <see cref="DomainOfExpertise"/>s that the active <see cref="Participant"/> is allowed to set as
+        /// the owner of an <see cref="IOwnedThing"/> in the provided <see cref="Iteration"/>, ordered by name.
+        /// </summary>
+        /// <param name="session">
+        /// The <see cref="ISession"/> for which the active <see cref="Participant"/>'s domains are queried.
+        /// </param>
+        /// <param name="iteration">
+        /// The <see cref="Iteration"/> the owned <see cref="Thing"/> belongs to.
+        /// </param>
+        /// <param name="currentOwner">
+        /// The current <see cref="DomainOfExpertise"/> owner of the edited <see cref="Thing"/>, if any. When set and not
+        /// already part of the allowed domains (e.g. an existing thing owned by a domain the user is not a member of),
+        /// it is kept in the list so that the value is still displayed and is not silently changed on save.
+        /// </param>
+        /// <returns>
+        /// The ordered list of allowed <see cref="DomainOfExpertise"/>s.
+        /// </returns>
+        public static IReadOnlyList<DomainOfExpertise> QueryAllowedOwners(this ISession session, Iteration iteration, DomainOfExpertise currentOwner = null)
+        {
+            var allowedOwners = (session.QueryDomainOfExpertise(iteration) ?? Enumerable.Empty<DomainOfExpertise>()).ToList();
+
+            if (currentOwner != null && allowedOwners.All(domain => domain.Iid != currentOwner.Iid))
+            {
+                allowedOwners.Add(currentOwner);
+            }
+
+            return allowedOwners.OrderBy(domain => domain.Name).ToList();
+        }
+    }
+}

--- a/CDP4Composition/Mvvm/DialogViewModelBase.cs
+++ b/CDP4Composition/Mvvm/DialogViewModelBase.cs
@@ -39,6 +39,7 @@ namespace CDP4Composition.Mvvm
 
     using CDP4Common.CommonData;
     using CDP4Common.Exceptions;
+    using CDP4Common.SiteDirectoryData;
     using CDP4Common.Validation;
 
     using CDP4Composition.Navigation;
@@ -108,6 +109,11 @@ namespace CDP4Composition.Mvvm
         /// The kind of operation this <see cref="DialogViewModelBase{T}"/> performs
         /// </summary>
         protected ThingDialogKind dialogKind;
+
+        /// <summary>
+        /// Backing field for <see cref="CurrentDomainOfExpertise"/>
+        /// </summary>
+        private DomainOfExpertise currentDomainOfExpertise;
 
         /// <summary>
         /// Backing field for <see cref="OkCanExecute"/> property.
@@ -307,6 +313,17 @@ namespace CDP4Composition.Mvvm
         /// Gets a value indicating whether the associated view is read-only
         /// </summary>
         public virtual bool IsReadOnly => this.dialogKind == ThingDialogKind.Inspect;
+
+        /// <summary>
+        /// Gets the current <see cref="DomainOfExpertise"/> of the active session for the <see cref="CDP4Common.EngineeringModelData.Iteration"/>
+        /// the <see cref="Thing"/> belongs to, when applicable. This is used to visually highlight the user's own
+        /// <see cref="DomainOfExpertise"/> in owner-selection combo-boxes. It is <c>null</c> for dialogs that are not owner-related.
+        /// </summary>
+        public DomainOfExpertise CurrentDomainOfExpertise
+        {
+            get => this.currentDomainOfExpertise;
+            protected set => this.RaiseAndSetIfChanged(ref this.currentDomainOfExpertise, value);
+        }
 
         /// <summary>
         /// Gets a value indicating whether a non-editable field is read-only

--- a/EngineeringModel.Tests/Dialogs/ActualFiniteStateListDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/ActualFiniteStateListDialogViewModelTestFixture.cs
@@ -137,6 +137,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             this.cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.sitedir);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.possibleOwners);
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.alphaOwner);
 
             var dal = new Mock<IDal>();
             this.session.Setup(x => x.DalVersion).Returns(new Version(1, 1, 0));

--- a/EngineeringModel.Tests/Dialogs/BinaryRelationshipDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/BinaryRelationshipDialogViewModelTestFixture.cs
@@ -131,6 +131,8 @@ namespace CDP4EngineeringModel.Tests
             this.cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
 
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDir);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domain });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domain);
             var assembler = new Assembler(this.uri, this.messageBus);
             assembler.Cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
             assembler.Cache.TryAdd(new CacheKey(this.req1.Iid, this.iteration.Iid), new Lazy<Thing>(() => this.req1));

--- a/EngineeringModel.Tests/Dialogs/ElementUsageDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/ElementUsageDialogViewModelTestFixture.cs
@@ -133,6 +133,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             var transactionContext = TransactionContextResolver.ResolveContext(this.iteration);
             this.thingTransaction = new ThingTransaction(transactionContext, this.definition1Clone);
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDir);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domain1 });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domain1);
 
             var dal = new Mock<IDal>();
             this.session.Setup(x => x.DalVersion).Returns(new Version(1, 1, 0));

--- a/EngineeringModel.Tests/Dialogs/MultiRelationshipDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/MultiRelationshipDialogViewModelTestFixture.cs
@@ -134,6 +134,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
 
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDir);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domain });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domain);
             var assembler = new Assembler(this.uri, this.messageBus);
             this.session.Setup(x => x.Assembler).Returns(assembler);
 

--- a/EngineeringModel.Tests/Dialogs/ParameterDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/ParameterDialogViewModelTestFixture.cs
@@ -173,6 +173,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.model.Iteration.Add(this.iteration);
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.sitedir);
             this.session.Setup(x => x.ActivePerson).Returns(testPerson);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { testDomain, anotherDomain });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(testDomain);
 
             this.cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
 

--- a/EngineeringModel.Tests/Dialogs/PossibleFiniteStateListDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/PossibleFiniteStateListDialogViewModelTestFixture.cs
@@ -120,6 +120,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             this.cache.TryAdd(new CacheKey(this.iteration.Iid, null), new Lazy<Thing>(() => this.iteration));
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.sitedir);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.possibleOwners);
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.alphaOwner);
 
             var dal = new Mock<IDal>();
             this.session.Setup(x => x.DalVersion).Returns(new Version(1, 1, 0));

--- a/EngineeringModel.Tests/Dialogs/RuleVerificationListDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/Dialogs/RuleVerificationListDialogViewModelTestFixture.cs
@@ -117,6 +117,8 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.session.Setup(x => x.DalVersion).Returns(new Version(1, 1, 0));
             this.session.Setup(x => x.Dal).Returns(dal.Object);
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.systemDomainOfExpertise, this.aocsDomainOfExpertise });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.systemDomainOfExpertise);
             dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());
         }
 

--- a/EngineeringModel.Tests/ViewModels/Dialogs/CommonFileStoreDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/CommonFileStoreDialogViewModelTestFixture.cs
@@ -135,6 +135,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.session.Setup(x => x.OpenIterations).Returns(openIterations);
             this.session.Setup(x => x.QuerySelectedDomainOfExpertise(this.iteration)).Returns(this.domainOfExpertise);
             this.session.Setup(x => x.QuerySelectedDomainOfExpertise(this.iterationClone)).Returns(this.domainOfExpertise);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domainOfExpertise });
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
 
             dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());

--- a/EngineeringModel.Tests/ViewModels/Dialogs/DomainFileStoreDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/DomainFileStoreDialogViewModelTestFixture.cs
@@ -123,6 +123,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
             this.session.Setup(x => x.OpenIterations).Returns(openIterations);
             this.session.Setup(x => x.QuerySelectedDomainOfExpertise(this.iteration)).Returns(this.domainOfExpertise);
             this.session.Setup(x => x.QuerySelectedDomainOfExpertise(this.iterationClone)).Returns(this.domainOfExpertise);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domainOfExpertise });
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
 
             dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());

--- a/EngineeringModel.Tests/ViewModels/Dialogs/FolderDialogViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/Dialogs/FolderDialogViewModelTestFixture.cs
@@ -125,6 +125,7 @@ namespace CDP4EngineeringModel.Tests.Dialogs
 
             this.session.Setup(x => x.OpenIterations).Returns(openIterations);
             this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domainOfExpertise);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domainOfExpertise });
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
 
             dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());

--- a/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ActualFiniteStateListDialogViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="ActualFiniteStateListDialogViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2022 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerenï¿½, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Thï¿½ate, Omar Elebiary
 //
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -40,6 +40,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Dal.Operations;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Mvvm.Types;
     using CDP4Composition.Navigation;
@@ -287,8 +288,13 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
             var iteration = (Iteration)this.Container;
-            var model = (EngineeringModel)iteration.Container;
-            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain.OrderBy(d => d.Name));
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/BinaryRelationshipDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/BinaryRelationshipDialogViewModel.cs
@@ -37,6 +37,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4CommonView;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -231,9 +232,14 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
 
-            var engineeringModel = (EngineeringModel)this.Container.TopContainer;
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
+            var iteration = (this.Container as Iteration) ?? this.Container.GetContainerOfType<Iteration>();
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/CommonFileStoreDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/CommonFileStoreDialogViewModel.cs
@@ -34,6 +34,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.EngineeringModelData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
 
@@ -106,12 +107,16 @@ namespace CDP4EngineeringModel.ViewModels
             base.PopulatePossibleOwner();
 
             var engineeringModel = (EngineeringModel)(this.Container ?? this.Thing.Container);
+            
+            var iteration = engineeringModel?.Iteration.FirstOrDefault();
 
-            if (engineeringModel != null)
+            if (iteration == null)
             {
-                var domains = engineeringModel?.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-                this.PossibleOwner.AddRange(domains);
+                return;
             }
+
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/DomainFileStoreDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/DomainFileStoreDialogViewModel.cs
@@ -34,6 +34,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.EngineeringModelData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
 
@@ -105,9 +106,9 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
 
-            var engineeringModel = (EngineeringModel)this.Container.Container;
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
+            var iteration = (Iteration)this.Container;
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/ElementDefinitionDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ElementDefinitionDialogViewModel.cs
@@ -39,6 +39,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Dal.Operations;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -418,9 +419,14 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
 
-            var engineeringModel = (EngineeringModel)this.Container.Container;
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
+            var iteration = (Iteration)this.Container;
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/ElementUsageDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ElementUsageDialogViewModel.cs
@@ -38,6 +38,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Dal.Operations;
     
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -232,13 +233,19 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void PopulatePossibleOwner()
         {
             base.PopulatePossibleOwner();
-            var model = this.Thing.TopContainer as EngineeringModel;
-            if (model == null)
+            var iteration = this.Thing.GetContainerOfType<Iteration>();
+            if (iteration == null)
             {
                 throw new InvalidOperationException("The top container is not set for this usage");
             }
 
-            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name));
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/FileDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/FileDialogViewModel.cs
@@ -36,6 +36,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
 
@@ -218,9 +219,14 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void PopulatePossibleOwner()
         {
             base.PopulatePossibleOwner();
-            var engineeringModel = this.Container.GetContainerOfType<EngineeringModel>();
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
+            var iteration = this.Container.GetContainerOfType<Iteration>();
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/FolderDialogViewModel.cs
@@ -34,6 +34,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.EngineeringModelData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
 
@@ -105,12 +106,19 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
 
-            var engineeringModel = this.Container.GetContainerOfType<EngineeringModel>();
-            var domains = engineeringModel?.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
+            var iteration = this.Container.GetContainerOfType<Iteration>();
 
-            if (domains != null)
+            if (iteration == null)
             {
-                this.PossibleOwner.AddRange(domains);
+                return;
+            }
+
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
             }
         }
 

--- a/EngineeringModel/ViewModels/Dialogs/MultiRelationshipDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/MultiRelationshipDialogViewModel.cs
@@ -37,6 +37,7 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -239,9 +240,14 @@ namespace CDP4EngineeringModel.ViewModels.Dialogs
         {
             base.PopulatePossibleOwner();
 
-            var engineeringModel = (EngineeringModel)this.Container.TopContainer;
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
+            var iteration = (this.Container as Iteration) ?? this.Container.GetContainerOfType<Iteration>();
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
     }
 }

--- a/EngineeringModel/ViewModels/Dialogs/ParameterDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ParameterDialogViewModel.cs
@@ -38,6 +38,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4CommonView;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Mvvm.Types;
     using CDP4Composition.Navigation;
@@ -499,20 +500,19 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void PopulatePossibleOwner()
         {
             base.PopulatePossibleOwner();
-            var model = this.Thing.TopContainer as EngineeringModel;
+            var iteration = this.Thing.GetContainerOfType<Iteration>();
 
-            if (model == null)
+            if (iteration == null)
             {
                 return;
             }
 
-            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name));
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
 
-            if (this.SelectedOwner == null)
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
             {
-                Tuple<DomainOfExpertise, Participant> tuple;
-                this.Session.OpenIterations.TryGetValue(this.Thing.GetContainerOfType<Iteration>(), out tuple);
-                this.SelectedOwner = tuple.Item1;
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
             }
         }
 

--- a/EngineeringModel/ViewModels/Dialogs/ParameterOverrideDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/ParameterOverrideDialogViewModel.cs
@@ -35,6 +35,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Mvvm.Types;
     using CDP4Composition.Navigation;
@@ -319,12 +320,14 @@ namespace CDP4EngineeringModel.ViewModels
         protected override void PopulatePossibleOwner()
         {
             base.PopulatePossibleOwner();
-            var model = this.Container.Container.Container.Container as EngineeringModel;
+            var iteration = this.Thing.GetContainerOfType<Iteration>();
 
-            if (model == null)
+            if (iteration == null)
             {
                 return;
             }
+
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
 
             if (this.SelectedOwner == null)
             {
@@ -333,7 +336,7 @@ namespace CDP4EngineeringModel.ViewModels
 
             if (this.Thing.Parameter.AllowDifferentOwnerOfOverride)
             {
-                this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name));
+                this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
             }
             else
             {

--- a/EngineeringModel/ViewModels/Dialogs/PossibleFiniteStateListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/PossibleFiniteStateListDialogViewModel.cs
@@ -40,6 +40,7 @@ namespace CDP4EngineeringModel.ViewModels
     using CDP4Dal.Operations;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -153,8 +154,13 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
             var iteration = (Iteration)this.Container;
-            var model = (EngineeringModel)iteration.Container;
-            this.PossibleOwner.AddRange(model.EngineeringModelSetup.ActiveDomain.OrderBy(d => d.Name));
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/EngineeringModel/ViewModels/Dialogs/RuleVerificationListDialogViewModel.cs
+++ b/EngineeringModel/ViewModels/Dialogs/RuleVerificationListDialogViewModel.cs
@@ -8,11 +8,14 @@ namespace CDP4EngineeringModel.ViewModels
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Dal.Operations;
     using CDP4Common.SiteDirectoryData;
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -75,9 +78,14 @@ namespace CDP4EngineeringModel.ViewModels
         {
             base.PopulatePossibleOwner();
 
-            var engineeringModel = (EngineeringModel)this.Container.Container;
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain;
-            this.PossibleOwner.AddRange(domains);
+            var iteration = (Iteration)this.Container;
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementDialogViewModelTestFixture.cs
@@ -151,6 +151,8 @@ namespace CDP4Requirements.Tests.Dialogs
             person.DefaultDomain = this.domainOfExpertise;
 
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDir);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domain, this.domainOfExpertise });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domain);
             this.session.Setup(x => x.ActivePerson).Returns(person);
             this.siteDir.Domain.Add(this.domainOfExpertise);
 

--- a/Requirements.Tests/Dialogs/RequirementsGroupDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementsGroupDialogViewModelTestFixture.cs
@@ -114,6 +114,8 @@ namespace CDP4Requirements.Tests.Dialogs
             this.engineeringModelSetup.IterationSetup.Add(this.iterationSetup);
 
             this.session.Setup(x => x.RetrieveSiteDirectory()).Returns(this.siteDir);
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domainOfExpertise });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domainOfExpertise);
             this.session.Setup(x => x.ActivePerson).Returns(person);
             this.siteDir.Domain.Add(this.domainOfExpertise);
 

--- a/Requirements.Tests/Dialogs/RequirementsSpecificationDialogViewModelTestFixture.cs
+++ b/Requirements.Tests/Dialogs/RequirementsSpecificationDialogViewModelTestFixture.cs
@@ -138,6 +138,10 @@ namespace CDP4Requirements.Tests
             this.session.Setup(x => x.CDPMessageBus).Returns(this.messageBus);
             dal.Setup(x => x.MetaDataProvider).Returns(new MetaDataProvider());
             this.modelSetup.ActiveDomain.Add(this.domain);
+
+            this.session.Setup(x => x.QueryDomainOfExpertise(It.IsAny<Iteration>())).Returns(new[] { this.domain });
+            this.session.Setup(x => x.QuerySelectedDomainOfExpertise(It.IsAny<Iteration>())).Returns(this.domain);
+
             this.viewmodel = new RequirementsSpecificationDialogViewModel(this.resSpec, this.transaction, this.session.Object, true, ThingDialogKind.Create, null, clone);
         }
 
@@ -183,6 +187,38 @@ namespace CDP4Requirements.Tests
 
             Assert.IsNotNull(this.viewmodel.WriteException);
             Assert.AreEqual("test", this.viewmodel.WriteException.Message);
+        }
+
+        [Test]
+        public void VerifyThatPossibleOwnerIsRestrictedToParticipantAllowedDomainsAndDefaultsToCurrent()
+        {
+            var otherDomain = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "other" };
+            this.modelSetup.ActiveDomain.Add(otherDomain);
+
+            var newSpec = new RequirementsSpecification(Guid.NewGuid(), this.cache, this.uri);
+            var newClone = this.iteration.Clone(false);
+            var newTransaction = new ThingTransaction(TransactionContextResolver.ResolveContext(this.iteration), newClone);
+
+            var vm = new RequirementsSpecificationDialogViewModel(newSpec, newTransaction, this.session.Object, true, ThingDialogKind.Create, null, newClone);
+
+            Assert.That(vm.PossibleOwner, Does.Contain(this.domain));
+            Assert.That(vm.PossibleOwner, Does.Not.Contain(otherDomain));
+            Assert.That(vm.SelectedOwner, Is.EqualTo(this.domain));
+        }
+
+        [Test]
+        public void VerifyThatExistingOwnerIsKeptWhenNotAmongAllowedDomains()
+        {
+            var foreignDomain = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "foreign" };
+            this.resSpec.Owner = foreignDomain;
+
+            var editClone = this.iteration.Clone(false);
+            var editTransaction = new ThingTransaction(TransactionContextResolver.ResolveContext(this.iteration), editClone);
+
+            var vm = new RequirementsSpecificationDialogViewModel(this.resSpec, editTransaction, this.session.Object, true, ThingDialogKind.Update, null, editClone);
+
+            Assert.That(vm.PossibleOwner, Does.Contain(foreignDomain));
+            Assert.That(vm.SelectedOwner, Is.EqualTo(foreignDomain));
         }
 
         [Test]

--- a/Requirements/ViewModels/Dialogs/RequirementDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementDialogViewModel.cs
@@ -34,6 +34,7 @@ namespace CDP4Requirements.ViewModels
     using CDP4Dal.Operations;
     
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -339,11 +340,15 @@ namespace CDP4Requirements.ViewModels
         protected override void PopulatePossibleOwner()
         {
             base.PopulatePossibleOwner();
-            
-            var engineeringModel = (EngineeringModel)this.Container.TopContainer;
 
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
+            var iteration = this.Container.GetContainerOfType<Iteration>();
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
 
         /// <summary>

--- a/Requirements/ViewModels/Dialogs/RequirementsGroupDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementsGroupDialogViewModel.cs
@@ -34,6 +34,7 @@ namespace CDP4Requirements.ViewModels
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -137,10 +138,14 @@ namespace CDP4Requirements.ViewModels
         protected override void PopulatePossibleOwner()
         {
             base.PopulatePossibleOwner();
-            var engineeringModel = (EngineeringModel)this.Container.TopContainer;
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
-            this.SelectedOwner = this.PossibleOwner.FirstOrDefault(x => this.Session.ActivePerson?.DefaultDomain != null && x.Iid == this.Session.ActivePerson.DefaultDomain.Iid) ?? this.PossibleOwner.First();
+            var iteration = this.Container.GetContainerOfType<Iteration>();
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
     }
 }

--- a/Requirements/ViewModels/Dialogs/RequirementsSpecificationDialogViewModel.cs
+++ b/Requirements/ViewModels/Dialogs/RequirementsSpecificationDialogViewModel.cs
@@ -33,6 +33,7 @@ namespace CDP4Requirements.ViewModels
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Attributes;
+    using CDP4Composition.Extensions;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
@@ -145,10 +146,14 @@ namespace CDP4Requirements.ViewModels
         {
             base.PopulatePossibleOwner();
 
-            var engineeringModel = (EngineeringModel)this.Container.Container;
-            var domains = engineeringModel.EngineeringModelSetup.ActiveDomain.OrderBy(x => x.Name);
-            this.PossibleOwner.AddRange(domains);
-            this.SelectedOwner = this.PossibleOwner.FirstOrDefault(x => this.Session.ActivePerson?.DefaultDomain != null && x.Iid == this.Session.ActivePerson.DefaultDomain.Iid) ?? this.PossibleOwner.First();
+            var iteration = (Iteration)this.Container;
+            this.PossibleOwner.AddRange(this.Session.QueryAllowedOwners(iteration, this.Thing.Owner));
+            this.CurrentDomainOfExpertise = this.Session.QuerySelectedDomainOfExpertise(iteration);
+
+            if (this.SelectedOwner == null && this.dialogKind == ThingDialogKind.Create)
+            {
+                this.SelectedOwner = this.CurrentDomainOfExpertise ?? this.PossibleOwner.FirstOrDefault();
+            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #62 and #762 
Unified the population of the ownerdropdown to everywhere only show allowed domains and default to current DoE which is also bold

Left the browser filter dropdown the same as you are allowed to see Things of other domains so you might also want to filter on them

