### PR TITLE
Fix #1371 stop autorefresh before closing the session

### DIFF
--- a/CDP4IME.Tests/ViewModels/SessionViewModelTestFixture.cs
+++ b/CDP4IME.Tests/ViewModels/SessionViewModelTestFixture.cs
@@ -38,6 +38,7 @@ namespace COMET.Tests.ViewModels
     using CDP4Common.SiteDirectoryData;
 
     using CDP4Composition.Navigation;
+    using CDP4Composition.Services;
 
     using CDP4Dal;
     using CDP4Dal.DAL;
@@ -87,6 +88,10 @@ namespace COMET.Tests.ViewModels
         public void SetUp()
         {
             RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+
+            var serviceLocator = new Mock<IServiceLocator>();
+            serviceLocator.Setup(x => x.GetInstance<IMessageBoxService>()).Returns(new Mock<IMessageBoxService>().Object);
+            ServiceLocator.SetLocatorProvider(() => serviceLocator.Object);
 
             this.messageBus = new CDPMessageBus();
             this.cache = new List<Thing>();
@@ -210,6 +215,18 @@ namespace COMET.Tests.ViewModels
 
             this.sessionViewModel.IsAutoRefreshEnabled = true;
             Assert.IsTrue(this.sessionViewModel.IsAutoRefreshEnabled);
+        }
+
+        [Test]
+        public async Task VerifyThatAutoRefreshIsStoppedWhenSessionIsClosed()
+        {
+            this.sessionViewModel.IsAutoRefreshEnabled = true;
+            Assert.IsTrue(this.sessionViewModel.IsAutoRefreshEnabled);
+
+            await this.sessionViewModel.Close.Execute();
+
+            Assert.IsTrue(this.sessionViewModel.IsClosed);
+            Assert.IsFalse(this.sessionViewModel.IsAutoRefreshEnabled);
         }
 
         [Test]

--- a/CDP4IME/ViewModels/SessionViewModel.cs
+++ b/CDP4IME/ViewModels/SessionViewModel.cs
@@ -265,6 +265,9 @@ namespace COMET.ViewModels
         /// </summary>
         private async void ExecuteClose()
         {
+            this.IsAutoRefreshEnabled = false;
+            this.timer?.Stop();
+
             await this.Session.Close();
             this.authenticationRefreshService?.Dispose();
             this.IsClosed = true;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #1371  
Set auto refresh to false before session closes and also set the timer stop to be sure 

