### PR TITLE
Feat #1275 Made the rule Verificattion more user friendly by showing rows with violating things

### DIFF
--- a/CDP4Composition.Tests/RuleVerification/RuleVerificationServiceTestFixture.cs
+++ b/CDP4Composition.Tests/RuleVerification/RuleVerificationServiceTestFixture.cs
@@ -199,6 +199,46 @@ namespace CDP4Composition.Tests.RuleVerification
         }
 
         [Test]
+        public void VerifyThatBuiltInRuleVerificationStatusIsSetToFailedAndPersistedWhenViolationsAreFound()
+        {
+            OperationContainer writtenOperationContainer = null;
+
+            this.session.Setup(s => s.Write(It.IsAny<OperationContainer>()))
+                .Returns(Task.CompletedTask)
+                .Callback<OperationContainer>(oc => writtenOperationContainer = oc);
+
+            var service = new RuleVerificationService(this.builtInRules);
+
+            var ruleVerificationList = new RuleVerificationList(Guid.NewGuid(), this.cache, this.uri);
+            this.iteration.RuleVerificationList.Add(ruleVerificationList);
+
+            var builtInRuleVerification = new BuiltInRuleVerification(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Name = this.builtInRuleName,
+                IsActive = true
+            };
+
+            ruleVerificationList.RuleVerification.Add(builtInRuleVerification);
+
+            Assert.AreEqual(RuleVerificationStatusKind.NONE, builtInRuleVerification.Status);
+
+            service.Execute(this.session.Object, ruleVerificationList);
+
+            Assert.IsTrue(builtInRuleVerification.Violation.Any());
+            Assert.AreEqual(RuleVerificationStatusKind.FAILED, builtInRuleVerification.Status);
+
+            // the status must be part of the write transaction, otherwise the data-source round-trip resets it to its stored value
+            Assert.IsNotNull(writtenOperationContainer);
+
+            var writtenVerification = writtenOperationContainer.Operations
+                .Select(operation => operation.ModifiedThing)
+                .OfType<CDP4Common.DTO.BuiltInRuleVerification>()
+                .Single();
+
+            Assert.AreEqual(RuleVerificationStatusKind.FAILED, writtenVerification.Status);
+        }
+
+        [Test]
         public async Task VerifyThatUserRuleVerificationCanBeExecutedAndMessageBusMessagesAreReceived()
         {
             var messageReceivedCounter = 0;

--- a/CDP4Composition/Services/RuleVerification/RuleVerificationService.cs
+++ b/CDP4Composition/Services/RuleVerification/RuleVerificationService.cs
@@ -152,7 +152,7 @@ namespace CDP4Composition.Services
 
                 if (builtInRuleVerification != null && builtInRuleVerification.IsActive)
                 {
-                    await this.Execute(session, builtInRuleVerification, verificationList);
+                    await this.ExecuteAsync(session, builtInRuleVerification, verificationList);
                 }
 
                 var userRuleVerification = ruleVerification as UserRuleVerification;
@@ -176,7 +176,7 @@ namespace CDP4Composition.Services
         /// <param name="container">
         /// The container <see cref="RuleVerificationList"/> of the <paramref name="userRuleVerification"/>
         /// </param>
-        private async Task Execute(ISession session, BuiltInRuleVerification builtInRuleVerification, RuleVerificationList container)
+        private async Task ExecuteAsync(ISession session, BuiltInRuleVerification builtInRuleVerification, RuleVerificationList container)
         {
             var iteration = (Iteration)container.Container;
 
@@ -205,7 +205,7 @@ namespace CDP4Composition.Services
 
             var status = violations.Any() ? RuleVerificationStatusKind.FAILED : RuleVerificationStatusKind.PASSED;
             
-            await this.UpdateExecutedOn(session, builtInRuleVerification, status);
+            await this.UpdateExecutedOnAsync(session, builtInRuleVerification, status);
 
             builtInRuleVerification.Violation.AddRange(violations);
 
@@ -283,7 +283,7 @@ namespace CDP4Composition.Services
 
                 IDisposable subscription = null;
 
-                //Listen for changes to the verification rule that will happen after UpdateExecutedOn in order to get the updated version.
+                //Listen for changes to the verification rule that will happen after UpdateExecutedOnAsync in order to get the updated version.
                 //The violations must be added lastly as they are not persistent
                 subscription = session.CDPMessageBus.Listen<ObjectChangedEvent>(userRuleVerification)
                     .Where(objectChange => objectChange.EventKind == EventKind.Updated)
@@ -306,7 +306,7 @@ namespace CDP4Composition.Services
                         });
             }
 
-            await this.UpdateExecutedOn(session, userRuleVerification, status);
+            await this.UpdateExecutedOnAsync(session, userRuleVerification, status);
         }
 
         /// <summary>
@@ -327,7 +327,7 @@ namespace CDP4Composition.Services
         /// The <paramref name="status"/> is set on the clone so that it is part of the write transaction. If it were only
         /// set on the cached instance, the data-source round-trip would echo the previously stored status and reset it.
         /// </remarks>
-        private async Task UpdateExecutedOn(ISession session, RuleVerification ruleVerification, RuleVerificationStatusKind status)
+        private async Task UpdateExecutedOnAsync(ISession session, RuleVerification ruleVerification, RuleVerificationStatusKind status)
         {
             try
             {

--- a/CDP4Composition/Services/RuleVerification/RuleVerificationService.cs
+++ b/CDP4Composition/Services/RuleVerification/RuleVerificationService.cs
@@ -28,6 +28,7 @@ namespace CDP4Composition.Services
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.Composition;
+    using System.Linq;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
 
@@ -151,7 +152,7 @@ namespace CDP4Composition.Services
 
                 if (builtInRuleVerification != null && builtInRuleVerification.IsActive)
                 {
-                    this.Execute(session, builtInRuleVerification, verificationList);
+                    await this.Execute(session, builtInRuleVerification, verificationList);
                 }
 
                 var userRuleVerification = ruleVerification as UserRuleVerification;
@@ -175,7 +176,7 @@ namespace CDP4Composition.Services
         /// <param name="container">
         /// The container <see cref="RuleVerificationList"/> of the <paramref name="userRuleVerification"/>
         /// </param>
-        private void Execute(ISession session, BuiltInRuleVerification builtInRuleVerification, RuleVerificationList container)
+        private async Task Execute(ISession session, BuiltInRuleVerification builtInRuleVerification, RuleVerificationList container)
         {
             var iteration = (Iteration)container.Container;
 
@@ -200,9 +201,11 @@ namespace CDP4Composition.Services
                 return;
             }
 
-            var violations = builtInRule.Verify(iteration);
+            var violations = builtInRule.Verify(iteration).ToList();
 
-            this.UpdateExecutedOn(session, builtInRuleVerification);
+            var status = violations.Any() ? RuleVerificationStatusKind.FAILED : RuleVerificationStatusKind.PASSED;
+            
+            await this.UpdateExecutedOn(session, builtInRuleVerification, status);
 
             builtInRuleVerification.Violation.AddRange(violations);
 
@@ -242,10 +245,10 @@ namespace CDP4Composition.Services
             }
 
             userRuleVerification.Violation.Clear();
-            userRuleVerification.Status = RuleVerificationStatusKind.PASSED;
 
             session.CDPMessageBus.SendObjectChangeEvent(userRuleVerification, EventKind.Updated);
 
+            var status = RuleVerificationStatusKind.PASSED;
             IEnumerable<RuleViolation> violations = null;
 
             switch (userRuleVerification.Rule.ClassKind)
@@ -274,12 +277,14 @@ namespace CDP4Composition.Services
 
             if (violations is not null)
             {
-                userRuleVerification.Status = RuleVerificationStatusKind.FAILED;
+                var violationList = violations.ToList();
+
+                status = violationList.Any() ? RuleVerificationStatusKind.FAILED : RuleVerificationStatusKind.PASSED;
 
                 IDisposable subscription = null;
 
                 //Listen for changes to the verification rule that will happen after UpdateExecutedOn in order to get the updated version.
-                //The violations must be added lastly as they are not persistent 
+                //The violations must be added lastly as they are not persistent
                 subscription = session.CDPMessageBus.Listen<ObjectChangedEvent>(userRuleVerification)
                     .Where(objectChange => objectChange.EventKind == EventKind.Updated)
                     .ObserveOn(RxApp.MainThreadScheduler)
@@ -290,22 +295,23 @@ namespace CDP4Composition.Services
                             subscription.Dispose();
 
                             var verification = updated.ChangedThing as UserRuleVerification;
-                            verification.Violation.AddRange(violations);
+                            verification.Violation.AddRange(violationList);
 
                             session.CDPMessageBus.SendObjectChangeEvent(verification, EventKind.Updated);
 
-                            foreach (var ruleViolation in violations)
+                            foreach (var ruleViolation in violationList)
                             {
                                 session.CDPMessageBus.SendObjectChangeEvent(ruleViolation, EventKind.Added);
                             }
                         });
             }
 
-            await this.UpdateExecutedOn(session, userRuleVerification);
+            await this.UpdateExecutedOn(session, userRuleVerification, status);
         }
 
         /// <summary>
-        /// Updates the Executed On property of the <paramref name="ruleVerification"/> in the data-source
+        /// Updates the <see cref="RuleVerification.ExecutedOn"/> and <see cref="RuleVerification.Status"/> properties of
+        /// the <paramref name="ruleVerification"/> in the data-source.
         /// </summary>
         /// <param name="session">
         /// The <see cref="ISession"/> instance used to update the contained <see cref="RuleVerification"/> instances on the data-source.
@@ -313,8 +319,15 @@ namespace CDP4Composition.Services
         /// <param name="ruleVerification">
         /// The <see cref="RuleVerification"/> that is to be updated.
         /// </param>
+        /// <param name="status">
+        /// The <see cref="RuleVerificationStatusKind"/> that reflects the outcome of the verification and that is to be persisted.
+        /// </param>
         /// <returns>An awaitable <see cref="Task"/></returns>
-        private async Task UpdateExecutedOn(ISession session, RuleVerification ruleVerification)
+        /// <remarks>
+        /// The <paramref name="status"/> is set on the clone so that it is part of the write transaction. If it were only
+        /// set on the cached instance, the data-source round-trip would echo the previously stored status and reset it.
+        /// </remarks>
+        private async Task UpdateExecutedOn(ISession session, RuleVerification ruleVerification, RuleVerificationStatusKind status)
         {
             try
             {
@@ -323,8 +336,12 @@ namespace CDP4Composition.Services
                 var transactionContext = TransactionContextResolver.ResolveContext(ruleVerification);
                 var transaction = new ThingTransaction(transactionContext, clone);
                 clone.ExecutedOn = DateTime.UtcNow;
+                clone.Status = status;
 
                 var operationContainer = transaction.FinalizeTransaction();
+
+                ruleVerification.Status = status;
+
                 await session.Write(operationContainer);
             }
             catch (Exception ex)

--- a/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListRowViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListRowViewModelTestFixture.cs
@@ -395,5 +395,64 @@ namespace CDP4EngineeringModel.Tests.ViewModels.RuleVerificationListBrowser
             this.messageBus.SendObjectChangeEvent(userRuleVerification, EventKind.Updated);
             Assert.IsEmpty(userRow.ContainedRows);
         }
+
+        [Test]
+        public void VerifyThatViolatingThingsAreResolvedToRowsWithNamesAndShortNames()
+        {
+            var elementDefinition = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Name = "Battery",
+                ShortName = "bat",
+                Owner = this.domain
+            };
+
+            this.cache.TryAdd(new CacheKey(elementDefinition.Iid, this.iteration.Iid), new Lazy<Thing>(() => elementDefinition));
+
+            var ruleVerificationList = new RuleVerificationList(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Owner = this.domain
+            };
+
+            this.iteration.RuleVerificationList.Add(ruleVerificationList);
+
+            var builtInRuleVerification = new BuiltInRuleVerification(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Name = "BuiltIn",
+                Status = RuleVerificationStatusKind.INCONCLUSIVE,
+                IsActive = true
+            };
+
+            ruleVerificationList.RuleVerification.Add(builtInRuleVerification);
+
+            var listRowViewModel = new RuleVerificationListRowViewModel(ruleVerificationList, this.session.Object, null);
+
+            var builtInRow = listRowViewModel.ContainedRows.Single(x => x.Thing == builtInRuleVerification);
+
+            var violation = new RuleViolation(Guid.NewGuid(), this.cache, this.uri)
+            {
+                Description = "The Element Definition does not contain the required parameters."
+            };
+
+            violation.ViolatingThing.Add(elementDefinition.Iid);
+
+            builtInRuleVerification.Violation.Add(violation);
+            this.revision.SetValue(builtInRuleVerification, 10);
+            this.messageBus.SendObjectChangeEvent(builtInRuleVerification, EventKind.Updated);
+
+            var violationRow = builtInRow.ContainedRows.OfType<RuleViolationRowViewModel>().Single();
+            Assert.AreEqual(violation.Description, violationRow.Tooltip);
+
+            var violatingThingRow = violationRow.ContainedRows.OfType<ViolatingThingRowViewModel>().Single();
+            Assert.AreEqual(elementDefinition, violatingThingRow.Thing);
+            Assert.AreEqual("Battery", violatingThingRow.Name);
+            Assert.AreEqual("bat", violatingThingRow.ShortName);
+            Assert.AreEqual(this.domain.ShortName, violatingThingRow.OwnerName);
+
+            // the violation row (and its resolved violating thing) is removed when the violation is cleared
+            builtInRuleVerification.Violation.Clear();
+            this.revision.SetValue(builtInRuleVerification, 20);
+            this.messageBus.SendObjectChangeEvent(builtInRuleVerification, EventKind.Updated);
+            Assert.IsEmpty(builtInRow.ContainedRows);
+        }
     }
 }

--- a/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/RuleVerificationListBrowser/RuleVerificationListViewModelTestFixture.cs
@@ -41,6 +41,7 @@ namespace CDP4EngineeringModel.Tests.ViewModels.RuleVerificationListBrowser
     using CDP4Common.Types;
 
     using CDP4Composition.DragDrop;
+    using CDP4Composition.Events;
     using CDP4Composition.Navigation;
     using CDP4Composition.Navigation.Interfaces;
     using CDP4Composition.Services;
@@ -391,6 +392,52 @@ namespace CDP4EngineeringModel.Tests.ViewModels.RuleVerificationListBrowser
             await vm.VerifyRuleVerificationList.Execute();
 
             this.ruleVerificationService.Verify(x => x.Execute(this.session.Object, ruleVerificationList));
+        }
+
+        [Test]
+        public async Task VerifyThatHighlightCommandHighlightsAllViolatingThingsBelowSelectedRow()
+        {
+            var elementDefinition1 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "Battery", ShortName = "bat", Owner = this.domain };
+            var elementDefinition2 = new ElementDefinition(Guid.NewGuid(), this.cache, this.uri) { Name = "Panel", ShortName = "pan", Owner = this.domain };
+
+            this.cache.TryAdd(new CacheKey(elementDefinition1.Iid, this.iteration.Iid), new Lazy<Thing>(() => elementDefinition1));
+            this.cache.TryAdd(new CacheKey(elementDefinition2.Iid, this.iteration.Iid), new Lazy<Thing>(() => elementDefinition2));
+
+            var ruleVerificationList = new RuleVerificationList(Guid.NewGuid(), this.cache, this.uri) { Owner = this.domain };
+            this.iteration.RuleVerificationList.Add(ruleVerificationList);
+
+            var builtInRuleVerification = new BuiltInRuleVerification(Guid.NewGuid(), this.cache, this.uri) { Name = "BuiltIn", IsActive = true };
+            ruleVerificationList.RuleVerification.Add(builtInRuleVerification);
+
+            var violation1 = new RuleViolation(Guid.NewGuid(), this.cache, this.uri) { Description = "v1" };
+            violation1.ViolatingThing.Add(elementDefinition1.Iid);
+
+            var violation2 = new RuleViolation(Guid.NewGuid(), this.cache, this.uri) { Description = "v2" };
+            violation2.ViolatingThing.Add(elementDefinition2.Iid);
+
+            var vm = new RuleVerificationListBrowserViewModel(this.iteration, this.participant, this.session.Object, null, null, null, null);
+
+            var listRow = vm.RuleVerificationListRowViewModels.Single(x => x.Thing == ruleVerificationList);
+
+            builtInRuleVerification.Violation.Add(violation1);
+            builtInRuleVerification.Violation.Add(violation2);
+            this.revision.SetValue(builtInRuleVerification, 10);
+            this.messageBus.SendObjectChangeEvent(builtInRuleVerification, EventKind.Updated);
+
+            var highlightedThings = new List<Thing>();
+            this.messageBus.Listen<HighlightEvent>().Subscribe(x => highlightedThings.Add(x.HighlightedThing));
+
+            var highlightedElementUsageDefinitions = new List<ElementDefinition>();
+            this.messageBus.Listen<ElementUsageHighlightEvent>().Subscribe(x => highlightedElementUsageDefinitions.Add(x.ElementDefinition));
+
+            // selecting the parent Rule Verification List row should highlight all violating things below it
+            vm.SelectedThing = listRow;
+            await vm.HighlightCommand.Execute();
+
+            CollectionAssert.AreEquivalent(new Thing[] { elementDefinition1, elementDefinition2 }, highlightedThings);
+
+            // ElementDefinition violating things must also raise an ElementUsageHighlightEvent so the Product Tree highlights their usages
+            CollectionAssert.AreEquivalent(new[] { elementDefinition1, elementDefinition2 }, highlightedElementUsageDefinitions);
         }
     }
 }

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleVerificationListBrowserViewModel.cs
@@ -26,6 +26,7 @@
 namespace CDP4EngineeringModel.ViewModels
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Reactive;
     using System.Reactive.Linq;
@@ -38,6 +39,7 @@ namespace CDP4EngineeringModel.ViewModels
 
     using CDP4Composition;
     using CDP4Composition.DragDrop;
+    using CDP4Composition.Events;
     using CDP4Composition.Mvvm;
     using CDP4Composition.Mvvm.Types;
     using CDP4Composition.Navigation;
@@ -201,6 +203,12 @@ namespace CDP4EngineeringModel.ViewModels
         public ReactiveCommand<Unit, Unit> VerifyRuleVerificationList { get; private set; }
 
         /// <summary>
+        /// Gets the <see cref="ReactiveCommand"/> used to highlight the selected violating <see cref="Thing"/>
+        /// in the other open browsers
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> HighlightCommand { get; private set; }
+
+        /// <summary>
         /// Gets the active <see cref="Participant"/>
         /// </summary>
         public Participant ActiveParticipant { get; private set; }
@@ -275,6 +283,8 @@ namespace CDP4EngineeringModel.ViewModels
             this.VerifyRuleVerificationList = ReactiveCommandCreator.CreateAsyncTask(
                 this.ExecuteVerifyRuleVerificationList,
                 this.WhenAnyValue(x => x.CanVerifyVerificationList));
+
+            this.HighlightCommand = ReactiveCommandCreator.Create(this.ExecuteHighlightCommand);
         }
 
         /// <summary>
@@ -313,6 +323,68 @@ namespace CDP4EngineeringModel.ViewModels
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Create a BuiltIn Rule Verification", "", this.CreateBuiltInRuleVerification, MenuItemKind.Create, ClassKind.BuiltInRuleVerification));
 
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Execute the Rule Verification List", "", this.VerifyRuleVerificationList, MenuItemKind.None, ClassKind.NotThing));
+            }
+
+            if (this.SelectedThing != null && this.QueryViolatingThings(this.SelectedThing).Any())
+            {
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Highlight the violating Things in the open Browsers", "", this.HighlightCommand, MenuItemKind.Highlight, ClassKind.NotThing));
+            }
+        }
+
+        /// <summary>
+        /// Executes the <see cref="HighlightCommand"/> by sending a <see cref="HighlightEvent"/> for each violating
+        /// <see cref="Thing"/> that is contained by the selected row, so that they are all highlighted in the other
+        /// open browsers. This works for a single violating <see cref="Thing"/> row as well as for a parent
+        /// <see cref="RuleViolation"/>, <see cref="RuleVerification"/> or <see cref="RuleVerificationList"/> row.
+        /// </summary>
+        private void ExecuteHighlightCommand()
+        {
+            this.CDPMessageBus.SendMessage(new CancelHighlightEvent());
+
+            if (this.SelectedThing == null)
+            {
+                return;
+            }
+
+            var violatingThings = this.QueryViolatingThings(this.SelectedThing).Distinct().ToList();
+
+            foreach (var violatingThing in violatingThings)
+            {
+                this.CDPMessageBus.SendMessage(new HighlightEvent(violatingThing), violatingThing);
+                this.CDPMessageBus.SendMessage(new HighlightEvent(violatingThing), null);
+                
+                if (violatingThing is ElementDefinition elementDefinition)
+                {
+                    this.CDPMessageBus.SendMessage(new ElementUsageHighlightEvent(elementDefinition), elementDefinition);
+                    this.CDPMessageBus.SendMessage(new ElementUsageHighlightEvent(elementDefinition), null);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Recursively queries the violating <see cref="Thing"/>s that are represented by the
+        /// <see cref="ViolatingThingRowViewModel"/>s contained by (or equal to) the provided row.
+        /// </summary>
+        /// <param name="row">The row to query.</param>
+        /// <returns>The violating <see cref="Thing"/>s found below the provided row.</returns>
+        private IEnumerable<Thing> QueryViolatingThings(IRowViewModelBase<Thing> row)
+        {
+            if (row is ViolatingThingRowViewModel violatingThingRow)
+            {
+                if (violatingThingRow.Thing != null)
+                {
+                    yield return violatingThingRow.Thing;
+                }
+
+                yield break;
+            }
+
+            foreach (var containedRow in row.ContainedRows)
+            {
+                foreach (var violatingThing in this.QueryViolatingThings(containedRow))
+                {
+                    yield return violatingThing;
+                }
             }
         }
 

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleViolationRowViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/RuleViolationRowViewModel.cs
@@ -1,0 +1,136 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RuleViolationRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.ViewModels
+{
+    using System.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Composition.Mvvm;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+
+    /// <summary>
+    /// A row representing a <see cref="RuleViolation"/>.
+    /// </summary>
+    /// <remarks>
+    /// In addition to the textual <see cref="RuleViolation.Description"/>, this row resolves the
+    /// <see cref="RuleViolation.ViolatingThing"/> identifiers to the actual <see cref="Thing"/>s and exposes
+    /// them as child rows. This presents the offending model items with their name, short name, owner and type
+    /// in dedicated columns, rather than only as identifiers embedded in a single sentence.
+    /// </remarks>
+    public class RuleViolationRowViewModel : CDP4CommonView.RuleViolationRowViewModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RuleViolationRowViewModel"/> class.
+        /// </summary>
+        /// <param name="ruleViolation">
+        /// The <see cref="RuleViolation"/> that is represented by the current row-view-model.
+        /// </param>
+        /// <param name="session">
+        /// The current active <see cref="ISession"/>
+        /// </param>
+        /// <param name="containerViewModel">
+        /// The view-model that is the container of the current row-view-model.
+        /// </param>
+        public RuleViolationRowViewModel(RuleViolation ruleViolation, ISession session, IViewModelBase<Thing> containerViewModel)
+            : base(ruleViolation, session, containerViewModel)
+        {
+            this.UpdateProperties();
+        }
+
+        /// <summary>
+        /// The <see cref="ObjectChangedEvent"/> handler
+        /// </summary>
+        /// <param name="objectChange">The <see cref="ObjectChangedEvent"/></param>
+        protected override void ObjectChangeEventHandler(ObjectChangedEvent objectChange)
+        {
+            base.ObjectChangeEventHandler(objectChange);
+            this.UpdateProperties();
+        }
+
+        /// <summary>
+        /// Updates the properties of this row on the update of the current <see cref="Thing"/>
+        /// </summary>
+        private void UpdateProperties()
+        {
+            this.Tooltip = this.Thing.Description;
+            this.PopulateViolatingThings();
+        }
+
+        /// <summary>
+        /// Populates the child rows that represent the <see cref="Thing"/>s referenced by
+        /// <see cref="RuleViolation.ViolatingThing"/>.
+        /// </summary>
+        private void PopulateViolatingThings()
+        {
+            var resolvedThings = this.Thing.ViolatingThing
+                .Select(this.ResolveViolatingThing)
+                .Where(thing => thing != null)
+                .ToList();
+
+            var currentThings = this.ContainedRows.Select(x => x.Thing).ToList();
+
+            var newThings = resolvedThings.Except(currentThings).ToList();
+            var oldThings = currentThings.Except(resolvedThings).ToList();
+
+            foreach (var violatingThing in newThings)
+            {
+                var row = new ViolatingThingRowViewModel(violatingThing, this.Session, this);
+                this.ContainedRows.Add(row);
+            }
+
+            foreach (var violatingThing in oldThings)
+            {
+                var row = this.ContainedRows.SingleOrDefault(x => x.Thing == violatingThing);
+
+                if (row != null)
+                {
+                    this.ContainedRows.RemoveAndDispose(row);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolves a violating <see cref="Thing"/> identifier to the cached <see cref="Thing"/>.
+        /// </summary>
+        /// <param name="iid">The <see cref="System.Guid"/> identifier of the violating <see cref="Thing"/>.</param>
+        /// <returns>The resolved <see cref="Thing"/>, or null when it cannot be found in the cache.</returns>
+        private Thing ResolveViolatingThing(System.Guid iid)
+        {
+            if (this.Thing.Cache == null)
+            {
+                return null;
+            }
+
+            return this.Thing.Cache.Values
+                .Select(lazy => lazy.Value)
+                .FirstOrDefault(thing => thing.Iid == iid);
+        }
+    }
+}

--- a/EngineeringModel/ViewModels/RuleVerificationListBrowser/ViolatingThingRowViewModel.cs
+++ b/EngineeringModel/ViewModels/RuleVerificationListBrowser/ViolatingThingRowViewModel.cs
@@ -1,0 +1,130 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ViolatingThingRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4EngineeringModel.ViewModels
+{
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Composition.Mvvm;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// A row that represents a <see cref="Thing"/> that violates a <see cref="CDP4Common.EngineeringModelData.Rule"/>.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="RuleViolation"/> only carries the <see cref="System.Guid"/> identifiers of the violating
+    /// <see cref="Thing"/>s. This row resolves each identifier to the actual <see cref="Thing"/> so that its
+    /// human friendly name, short name, owner and type can be presented in dedicated, sortable columns instead
+    /// of only an identifier buried in a sentence.
+    /// </remarks>
+    public class ViolatingThingRowViewModel : RowViewModelBase<Thing>
+    {
+        /// <summary>
+        /// Backing field for <see cref="Name"/>
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// Backing field for <see cref="ShortName"/>
+        /// </summary>
+        private string shortName;
+
+        /// <summary>
+        /// Backing field for <see cref="OwnerName"/>
+        /// </summary>
+        private string ownerName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViolatingThingRowViewModel"/> class.
+        /// </summary>
+        /// <param name="violatingThing">
+        /// The <see cref="Thing"/> that violates a rule and that is represented by the current row-view-model.
+        /// </param>
+        /// <param name="session">
+        /// The current active <see cref="ISession"/>
+        /// </param>
+        /// <param name="containerViewModel">
+        /// The view-model that is the container of the current row-view-model.
+        /// </param>
+        public ViolatingThingRowViewModel(Thing violatingThing, ISession session, IViewModelBase<Thing> containerViewModel)
+            : base(violatingThing, session, containerViewModel)
+        {
+            this.UpdateProperties();
+        }
+
+        /// <summary>
+        /// Gets the human friendly name of the violating <see cref="Thing"/>
+        /// </summary>
+        public string Name
+        {
+            get => this.name;
+            private set => this.RaiseAndSetIfChanged(ref this.name, value);
+        }
+
+        /// <summary>
+        /// Gets the short name of the violating <see cref="Thing"/>
+        /// </summary>
+        public string ShortName
+        {
+            get => this.shortName;
+            private set => this.RaiseAndSetIfChanged(ref this.shortName, value);
+        }
+
+        /// <summary>
+        /// Gets the short name of the owning domain of expertise of the violating <see cref="Thing"/>, if any
+        /// </summary>
+        public string OwnerName
+        {
+            get => this.ownerName;
+            private set => this.RaiseAndSetIfChanged(ref this.ownerName, value);
+        }
+
+        /// <summary>
+        /// The <see cref="ObjectChangedEvent"/> handler
+        /// </summary>
+        /// <param name="objectChange">The <see cref="ObjectChangedEvent"/></param>
+        protected override void ObjectChangeEventHandler(ObjectChangedEvent objectChange)
+        {
+            base.ObjectChangeEventHandler(objectChange);
+            this.UpdateProperties();
+        }
+
+        /// <summary>
+        /// Updates the properties of this row from the violating <see cref="Thing"/>
+        /// </summary>
+        private void UpdateProperties()
+        {
+            this.Name = this.Thing is INamedThing namedThing ? namedThing.Name : this.Thing.UserFriendlyName;
+            this.ShortName = this.Thing is IShortNamedThing shortNamedThing ? shortNamedThing.ShortName : this.Thing.UserFriendlyShortName;
+            this.OwnerName = this.Thing is IOwnedThing ownedThing && ownedThing.Owner != null ? ownedThing.Owner.ShortName : string.Empty;
+            this.Tooltip = $"{this.RowType}: {this.Name} [{this.ShortName}]";
+        }
+    }
+}

--- a/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
+++ b/EngineeringModel/Views/RuleVerificationListBrowser/RuleVerificationListBrowser.xaml
@@ -67,7 +67,27 @@
             </dx:MeasurePixelSnapper>
         </HierarchicalDataTemplate>
 
-        <HierarchicalDataTemplate DataType="{x:Type cdp4CommonView:RuleViolationRowViewModel}">
+        <HierarchicalDataTemplate DataType="{x:Type viewModels:RuleViolationRowViewModel}"
+                                  ItemsSource="{Binding ContainedRows}">
+            <dx:MeasurePixelSnapper>
+                <StackPanel Orientation="Horizontal">
+                    <dx:PixelSnapper>
+                        <Image Style="{StaticResource ThingIcon}">
+                            <Image.Source>
+                                <MultiBinding Converter="{StaticResource ThingToIconUriConverter}" Mode="OneWay">
+                                    <Binding Path="DataContext.Row.Thing" RelativeSource="{RelativeSource AncestorType={x:Type dxg:RowControl}}" />
+                                </MultiBinding>
+                            </Image.Source>
+                        </Image>
+                    </dx:PixelSnapper>
+                    <ContentPresenter x:Name="defaultRowPresenter"
+                                      Content="{Binding}"
+                                      ContentTemplate="{Binding View.DefaultDataRowTemplate}" />
+                </StackPanel>
+            </dx:MeasurePixelSnapper>
+        </HierarchicalDataTemplate>
+
+        <HierarchicalDataTemplate DataType="{x:Type viewModels:ViolatingThingRowViewModel}">
             <dx:MeasurePixelSnapper>
                 <StackPanel Orientation="Horizontal">
                     <dx:PixelSnapper>
@@ -153,6 +173,8 @@
                     <dxg:TreeListColumn FieldName="Name" Header="Name" />
                     <dxg:TreeListColumn FieldName="ShortName" Header="Short Name" />
                     <dxg:TreeListColumn FieldName="OwnerName" Header="Owner" />
+                    <dxg:TreeListColumn FieldName="RowType" Header="Type" />
+                    <dxg:TreeListColumn FieldName="Status" Header="Status" />
                 </dxg:TreeListControl.Columns>
                 <dxg:TreeListControl.InputBindings>
                     <KeyBinding Gesture="CTRL+I" Command="{Binding Path=InspectCommand}"></KeyBinding>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #1275 
Rule violations now expand to show the violating model items, with a context-menu "Highlight" that flags them in both the Element Definition browser and the Product Tree.

The Status column now reflects the actual outcome: fixed RuleVerificationService so BuiltIn (and User) verifications persist PASSED/FAILED instead of always NONE via the write transaction instead of in-memory.

Also fixed non-persistent RuleViolations being wiped, so BuiltIn violations are finally shown

<img width="1297" height="429" alt="image" src="https://github.com/user-attachments/assets/83f9d4c4-02c8-4f60-b7a8-7f52b4314dc3" />


