### PR TITLE
Fix #1199 Show error ball with x for parametertype in the component table for arrays and changed the default shortname 

### DIFF
--- a/BasicRdl.Tests/ViewModels/Dialogs/ArrayParameterTypeDialogViewModelTestFixture.cs
+++ b/BasicRdl.Tests/ViewModels/Dialogs/ArrayParameterTypeDialogViewModelTestFixture.cs
@@ -156,6 +156,38 @@ namespace BasicRdl.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatNewComponentHasValidDefaultShortName()
+        {
+            var transactionContext = TransactionContextResolver.ResolveContext(this.siteDir);
+            var transaction = new ThingTransaction(transactionContext);
+            var viewmodel = new ArrayParameterTypeDialogViewModel(this.arrayPt, transaction, this.session.Object, true, ThingDialogKind.Create, null);
+
+            var component = (ParameterTypeComponentRowViewModel)viewmodel.Component.Single();
+
+            Assert.AreEqual("{1;1;1}", component.Coordinates);
+            Assert.AreEqual("C1_1_1", component.ShortName);
+
+            // a default short name must not raise a short-name validation error
+            Assert.IsEmpty(component["ShortName"]);
+        }
+
+        [Test]
+        public void VerifyThatMissingParameterTypeIsReportedAsError()
+        {
+            var transactionContext = TransactionContextResolver.ResolveContext(this.siteDir);
+            var transaction = new ThingTransaction(transactionContext);
+            var viewmodel = new ArrayParameterTypeDialogViewModel(this.arrayPt, transaction, this.session.Object, true, ThingDialogKind.Create, null);
+
+            var component = (ParameterTypeComponentRowViewModel)viewmodel.Component.Single();
+
+            Assert.IsNull(component.ParameterType);
+            Assert.IsNotEmpty(component["ParameterType"]);
+
+            component.ParameterType = this.qt;
+            Assert.IsEmpty(component["ParameterType"]);
+        }
+
+        [Test]
         public void VerifyThatParameterlessContructorExists()
         {
             Assert.DoesNotThrow(() => new ArrayParameterTypeDialogViewModel());

--- a/BasicRdl/ViewModels/Dialogs/ArrayParameterTypeDialogViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/ArrayParameterTypeDialogViewModel.cs
@@ -241,7 +241,7 @@ namespace BasicRdl.ViewModels
                     // create new ParameterTypeComponent
                     var component = new ParameterTypeComponent();
                     row = new ParameterTypeComponentRowViewModel(component, this.Session, this);
-                    row.ShortName = coordinates;
+                    row.ShortName = ComputeComponentShortName(coordinates);
                 }
 
                 row.Coordinates = coordinates;
@@ -294,6 +294,19 @@ namespace BasicRdl.ViewModels
             }
 
             return "{" + string.Join(";", indexList.Select(x => x.ToString(CultureInfo.InvariantCulture))) + "}";
+        }
+
+        /// <summary>
+        /// Compute a valid default <see cref="ParameterTypeComponent.ShortName"/> from a component's coordinates
+        /// </summary>
+        /// <param name="coordinates">The coordinates of the component, e.g. <c>{1;1;1}</c></param>
+        /// <returns>
+        /// A short name that complies with the short-name validation rules (starts with a letter, only contains
+        /// alphanumeric characters or underscores), e.g. <c>C1_1_1</c>
+        /// </returns>
+        private static string ComputeComponentShortName(string coordinates)
+        {
+            return "C" + coordinates.Trim('{', '}').Replace(";", "_");
         }
 
         /// <summary>

--- a/BasicRdl/ViewModels/Dialogs/Rows/ParameterTypeComponentRowViewModel.cs
+++ b/BasicRdl/ViewModels/Dialogs/Rows/ParameterTypeComponentRowViewModel.cs
@@ -178,12 +178,20 @@ namespace BasicRdl.ViewModels
         {
             get
             {
+                var shortNameError = this.ValidationService.ValidateObjectProperty("ShortName", this);
+                var parameterTypeError = this.ParameterType == null ? "The ParameterType must be selected." : null;
+                
+                this.ErrorMsg = shortNameError ?? parameterTypeError;
+                ((CompoundParameterTypeDialogViewModel)this.ContainerViewModel).UpdateOkCanExecuteStatus();
+
                 if (columnName == "ShortName")
                 {
-                    var validationResult = this.ValidationService.ValidateObjectProperty(columnName, this);
-                    this.ErrorMsg = validationResult;
-                    ((CompoundParameterTypeDialogViewModel)this.ContainerViewModel).UpdateOkCanExecuteStatus();
-                    return validationResult != null ? validationResult : string.Empty;
+                    return shortNameError ?? string.Empty;
+                }
+
+                if (columnName == "ParameterType")
+                {
+                    return parameterTypeError ?? string.Empty;
                 }
 
                 return string.Empty;


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #1199 
Show Red X for ParameterType when creating an array parameter type
Changed default shortname from {1;1;1} to a valid C1_1_1

