### PR TITLE
Feat #1029 and #699 Added a bulk participant creation

### DIFF
--- a/CDP4SiteDirectory.Tests/Dialogs/BulkParticipantCreationDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/BulkParticipantCreationDialogViewModelTestFixture.cs
@@ -1,0 +1,216 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="BulkParticipantCreationDialogViewModelTestFixture.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4SiteDirectory.Tests.Dialogs
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.Reactive.Concurrency;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
+    using System.Windows.Input;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Composition.Navigation;
+
+    using CDP4SiteDirectory.ViewModels;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    [TestFixture]
+    internal class BulkParticipantCreationDialogViewModelTestFixture
+    {
+        private Uri uri;
+        private ConcurrentDictionary<CacheKey, Lazy<Thing>> cache;
+        private DomainOfExpertise thermal;
+        private DomainOfExpertise systems;
+        private ParticipantRole role;
+        private Person john;
+        private Person jane;
+        private Person personWithoutDefaultDomain;
+
+        [SetUp]
+        public void Setup()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+            this.uri = new Uri("https://www.stariongroup.eu");
+            this.cache = new ConcurrentDictionary<CacheKey, Lazy<Thing>>();
+
+            this.thermal = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "Thermal" };
+            this.systems = new DomainOfExpertise(Guid.NewGuid(), this.cache, this.uri) { Name = "Systems" };
+
+            this.role = new ParticipantRole(Guid.NewGuid(), this.cache, this.uri) { Name = "Team Member" };
+
+            this.john = new Person(Guid.NewGuid(), this.cache, this.uri) { GivenName = "John", Surname = "Doe", DefaultDomain = this.thermal };
+            this.jane = new Person(Guid.NewGuid(), this.cache, this.uri) { GivenName = "Jane", Surname = "Roe", DefaultDomain = this.systems };
+            this.personWithoutDefaultDomain = new Person(Guid.NewGuid(), this.cache, this.uri) { GivenName = "No", Surname = "Domain" };
+        }
+
+        private BulkParticipantCreationDialogViewModel CreateDialogViewModel()
+        {
+            return new BulkParticipantCreationDialogViewModel(
+                new[] { this.john, this.jane, this.personWithoutDefaultDomain },
+                new[] { this.role },
+                new[] { this.thermal, this.systems });
+        }
+
+        private BulkParticipantRowViewModel RowFor(BulkParticipantCreationDialogViewModel viewModel, Person person)
+        {
+            return viewModel.Participants.Single(x => x.Person == person);
+        }
+
+        [Test]
+        public void VerifyThatArgumentNullExceptionsAreThrown()
+        {
+            Assert.Throws<ArgumentNullException>(() => new BulkParticipantCreationDialogViewModel(null, new[] { this.role }, new[] { this.thermal }));
+            Assert.Throws<ArgumentNullException>(() => new BulkParticipantCreationDialogViewModel(new[] { this.john }, null, new[] { this.thermal }));
+            Assert.Throws<ArgumentNullException>(() => new BulkParticipantCreationDialogViewModel(new[] { this.john }, new[] { this.role }, null));
+        }
+
+        [Test]
+        public void VerifyThatRowsArePopulatedWithDefaults()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            Assert.That(viewModel.Participants.Count, Is.EqualTo(3));
+            Assert.That(viewModel.Participants.All(x => x.IsSelected), Is.True);
+            Assert.That(viewModel.IsActive, Is.True);
+
+            Assert.That(this.RowFor(viewModel, this.john).SelectedDomain, Is.EqualTo(this.thermal));
+            Assert.That(this.RowFor(viewModel, this.jane).SelectedDomain, Is.EqualTo(this.systems));
+            Assert.That(this.RowFor(viewModel, this.personWithoutDefaultDomain).SelectedDomain, Is.Null);
+
+            Assert.That(this.RowFor(viewModel, this.john).PossibleDomain, Is.EquivalentTo(new[] { this.thermal, this.systems }));
+        }
+
+        [Test]
+        public void VerifyThatOkCanExecuteRequiresRoleAndDomainPerSelectedRow()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            Assert.That(viewModel.OkCanExecute, Is.False);
+
+            viewModel.SelectedRole = this.role;
+
+            // the person without a default domain has no domain selected yet
+            Assert.That(viewModel.OkCanExecute, Is.False);
+
+            this.RowFor(viewModel, this.personWithoutDefaultDomain).SelectedDomain = this.thermal;
+
+            Assert.That(viewModel.OkCanExecute, Is.True);
+
+            foreach (var row in viewModel.Participants)
+            {
+                row.IsSelected = false;
+            }
+
+            Assert.That(viewModel.OkCanExecute, Is.False);
+        }
+
+        [Test]
+        public void VerifyThatDeselectingPersonWithoutDomainAllowsOk()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            viewModel.SelectedRole = this.role;
+
+            // exclude the person without a default domain; the remaining persons resolve to their own default domain
+            this.RowFor(viewModel, this.personWithoutDefaultDomain).IsSelected = false;
+
+            Assert.That(viewModel.OkCanExecute, Is.True);
+        }
+
+        [Test]
+        public async Task VerifyThatOkResultAppliesBatchValuesToSelectedRows()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            viewModel.SelectedRole = this.role;
+            viewModel.IsActive = false;
+            this.RowFor(viewModel, this.personWithoutDefaultDomain).SelectedDomain = this.thermal;
+
+            await viewModel.OkCommand.Execute();
+
+            var result = viewModel.DialogResult as BulkParticipantCreationResult;
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Result, Is.True);
+            Assert.That(result.Participants.Count(), Is.EqualTo(3));
+            Assert.That(result.Participants.All(x => x.SelectedRole == this.role), Is.True);
+            Assert.That(result.Participants.All(x => !x.IsActive), Is.True);
+
+            Assert.That(result.Participants.Single(x => x.Person == this.john).SelectedDomain, Is.EqualTo(this.thermal));
+            Assert.That(result.Participants.Single(x => x.Person == this.jane).SelectedDomain, Is.EqualTo(this.systems));
+            Assert.That(result.Participants.Single(x => x.Person == this.personWithoutDefaultDomain).SelectedDomain, Is.EqualTo(this.thermal));
+        }
+
+        [Test]
+        public async Task VerifyThatOkResultContainsOnlySelectedParticipants()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            viewModel.SelectedRole = this.role;
+            this.RowFor(viewModel, this.personWithoutDefaultDomain).IsSelected = false;
+
+            await viewModel.OkCommand.Execute();
+
+            var result = viewModel.DialogResult as BulkParticipantCreationResult;
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.Participants.Count(), Is.EqualTo(2));
+            Assert.That(result.Participants.Any(x => x.Person == this.personWithoutDefaultDomain), Is.False);
+        }
+
+        [Test]
+        public async Task VerifyThatCancelSetsNegativeResult()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            await viewModel.CancelCommand.Execute();
+
+            Assert.That(viewModel.DialogResult, Is.Not.Null);
+            Assert.That(viewModel.DialogResult.Result, Is.False);
+        }
+
+        [Test]
+        public void VerifyThatOkCommandCanExecuteIsGatedByOkCanExecute()
+        {
+            var viewModel = this.CreateDialogViewModel();
+
+            Assert.That(((ICommand)viewModel.OkCommand).CanExecute(null), Is.False);
+
+            viewModel.SelectedRole = this.role;
+            this.RowFor(viewModel, this.personWithoutDefaultDomain).SelectedDomain = this.thermal;
+
+            Assert.That(((ICommand)viewModel.OkCommand).CanExecute(null), Is.True);
+        }
+    }
+}

--- a/CDP4SiteDirectory.Tests/Dialogs/ParticipantDialogViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/Dialogs/ParticipantDialogViewModelTestFixture.cs
@@ -145,6 +145,29 @@ namespace CDP4SiteDirectory.Tests.Dialogs
         }
 
         [Test]
+        public void VerifyThatIsActiveIsTrueByDefaultOnCreate()
+        {
+            var participant = new Participant(Guid.NewGuid(), this.cache, this.uri);
+
+            var dialog = new ParticipantDialogViewModel(participant, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, this.clone);
+
+            Assert.IsTrue(dialog.IsActive);
+        }
+
+        [Test]
+        public void VerifyThatIsActiveIsNotForcedOnInspectOrUpdate()
+        {
+            var participant = new Participant(Guid.NewGuid(), this.cache, this.uri) { Person = this.person, IsActive = false };
+            this.clone.Participant.Add(participant);
+
+            var dialog = new ParticipantDialogViewModel(participant, this.thingTransaction, this.session.Object,
+                true, ThingDialogKind.Update, this.thingDialogNavigationService.Object, this.clone);
+
+            Assert.IsFalse(dialog.IsActive);
+        }
+
+        [Test]
         public void VerifyPossiblePerson()
         {
             var participant = new Participant(Guid.NewGuid(), this.cache, this.uri) { Person = this.person };

--- a/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
+++ b/CDP4SiteDirectory.Tests/ModelBrowser/ModelBrowserViewModelTestFixture.cs
@@ -349,7 +349,7 @@ namespace CDP4SiteDirectory.Tests
             Assert.IsTrue(viewmodel.CanCreateIterationSetup);
             Assert.IsTrue(viewmodel.CanCreateEngineeringModelSetup);
             viewmodel.PopulateContextMenu();
-            Assert.AreEqual(7, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(8, viewmodel.ContextMenu.Count);
 
             var participantFolderRow =
                 modelRow.ContainedRows.OfType<FolderRowViewModel>().Single(x => x.Name == "Participants");
@@ -360,7 +360,7 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(2, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(3, viewmodel.ContextMenu.Count);
 
             viewmodel.SelectedThing = iterationFolderRow;
             viewmodel.ComputePermission();
@@ -373,7 +373,7 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(4, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(5, viewmodel.ContextMenu.Count);
 
             var iterationRow = iterationFolderRow.ContainedRows.Single();
             viewmodel.SelectedThing = iterationRow;
@@ -418,7 +418,7 @@ namespace CDP4SiteDirectory.Tests
             Assert.IsTrue(viewmodel.CanCreateIterationSetup);
             Assert.IsTrue(viewmodel.CanCreateEngineeringModelSetup);
             viewmodel.PopulateContextMenu();
-            Assert.AreEqual(7, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(8, viewmodel.ContextMenu.Count);
 
             var participantFolderRow =
                 modelRow.ContainedRows.OfType<FolderRowViewModel>().Single(x => x.Name == "Participants");
@@ -429,7 +429,7 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(2, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(3, viewmodel.ContextMenu.Count);
 
             viewmodel.SelectedThing = iterationFolderRow;
             viewmodel.ComputePermission();
@@ -442,7 +442,7 @@ namespace CDP4SiteDirectory.Tests
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
 
-            Assert.AreEqual(3, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(4, viewmodel.ContextMenu.Count);
 
             foreach (var conMenu in viewmodel.ContextMenu)
             {
@@ -488,7 +488,7 @@ namespace CDP4SiteDirectory.Tests
             Assert.IsTrue(viewmodel.CanCreateIterationSetup);
             Assert.IsTrue(viewmodel.CanCreateEngineeringModelSetup);
             viewmodel.PopulateContextMenu();
-            Assert.AreEqual(7, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(8, viewmodel.ContextMenu.Count);
 
             await viewmodel.CreateParticipantCommand.Execute();
             this.thingDialogNavigationService.Verify(x => x.Navigate(It.IsAny<Participant>(), It.IsAny<IThingTransaction>(), this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, It.IsAny<EngineeringModelSetup>(), null));
@@ -564,7 +564,7 @@ namespace CDP4SiteDirectory.Tests
 
             viewmodel.ComputePermission();
             viewmodel.PopulateContextMenu();
-            Assert.AreEqual(7, viewmodel.ContextMenu.Count);
+            Assert.AreEqual(8, viewmodel.ContextMenu.Count);
 
             await viewmodel.CreateCommand.Execute();
             this.thingDialogNavigationService.Verify(x => x.Navigate(It.IsAny<EngineeringModelSetup>(), It.IsAny<IThingTransaction>(), this.session.Object, true, ThingDialogKind.Create, this.thingDialogNavigationService.Object, It.IsAny<SiteDirectory>(), null));
@@ -589,6 +589,136 @@ namespace CDP4SiteDirectory.Tests
             viewmodel = new ModelBrowserViewModel(this.session.Object, this.session.Object.RetrieveSiteDirectory(), this.thingDialogNavigationService.Object, this.navigationService.Object, null, null);
 
             Assert.IsFalse(((ICommand)viewmodel.CreateCommand).CanExecute(null));
+        }
+
+        [Test]
+        public async Task VerifyThatCreateMultipleParticipantsCommandWritesParticipants()
+        {
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(Task.CompletedTask);
+
+            var dialogNavigationService = new Mock<IDialogNavigationService>();
+
+            var viewmodel = new ModelBrowserViewModel(this.session.Object, this.siteDirectory, this.thingDialogNavigationService.Object, this.navigationService.Object, dialogNavigationService.Object, null);
+
+            var role = new ParticipantRole(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Model Admin" };
+            this.siteDirectory.ParticipantRole.Add(role);
+
+            var domain = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Thermal" };
+            this.siteDirectory.Domain.Add(domain);
+
+            var newPerson = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "Jane", Surname = "Roe", DefaultDomain = domain };
+            this.siteDirectory.Person.Add(newPerson);
+
+            var model = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            model.ActiveDomain.Add(domain);
+            this.siteDirectory.Model.Add(model);
+
+            this.revPropertyInfo.SetValue(this.siteDirectory, 50);
+            this.messageBus.SendObjectChangeEvent(this.siteDirectory, EventKind.Updated);
+
+            var modelRow = viewmodel.ModelSetup.Single();
+            viewmodel.SelectedThing = modelRow;
+            viewmodel.ComputePermission();
+
+            Assert.IsTrue(viewmodel.CanCreateParticipant);
+
+            var row = new BulkParticipantRowViewModel(newPerson, new[] { domain })
+            {
+                SelectedRole = role,
+                SelectedDomain = domain,
+                IsActive = true
+            };
+
+            dialogNavigationService
+                .Setup(x => x.NavigateModal(It.IsAny<IDialogViewModel>()))
+                .Returns(new BulkParticipantCreationResult(true, new[] { row }));
+
+            await viewmodel.CreateMultipleParticipantsCommand.Execute();
+
+            dialogNavigationService.Verify(x => x.NavigateModal(It.IsAny<IDialogViewModel>()), Times.Once);
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyThatCreateMultipleParticipantsExcludesDeprecatedPersons()
+        {
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+
+            var dialogNavigationService = new Mock<IDialogNavigationService>();
+
+            var viewmodel = new ModelBrowserViewModel(this.session.Object, this.siteDirectory, this.thingDialogNavigationService.Object, this.navigationService.Object, dialogNavigationService.Object, null);
+
+            var domain = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Thermal" };
+            this.siteDirectory.Domain.Add(domain);
+
+            var activePerson = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "Jane", Surname = "Roe", DefaultDomain = domain };
+            var deprecatedPerson = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "Old", Surname = "User", DefaultDomain = domain, IsDeprecated = true };
+            this.siteDirectory.Person.Add(activePerson);
+            this.siteDirectory.Person.Add(deprecatedPerson);
+
+            var model = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            model.ActiveDomain.Add(domain);
+            this.siteDirectory.Model.Add(model);
+
+            this.revPropertyInfo.SetValue(this.siteDirectory, 50);
+            this.messageBus.SendObjectChangeEvent(this.siteDirectory, EventKind.Updated);
+
+            var modelRow = viewmodel.ModelSetup.Single();
+            viewmodel.SelectedThing = modelRow;
+            viewmodel.ComputePermission();
+
+            BulkParticipantCreationDialogViewModel capturedDialog = null;
+
+            dialogNavigationService
+                .Setup(x => x.NavigateModal(It.IsAny<IDialogViewModel>()))
+                .Callback<IDialogViewModel>(vm => capturedDialog = vm as BulkParticipantCreationDialogViewModel)
+                .Returns(new BaseDialogResult(false));
+
+            await viewmodel.CreateMultipleParticipantsCommand.Execute();
+
+            Assert.That(capturedDialog, Is.Not.Null);
+            Assert.That(capturedDialog.Participants.Any(x => x.Person == activePerson), Is.True);
+            Assert.That(capturedDialog.Participants.Any(x => x.Person == deprecatedPerson), Is.False);
+        }
+
+        [Test]
+        public async Task VerifyThatCreateMultipleParticipantsCommandDoesNotWriteWhenCancelled()
+        {
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(), It.IsAny<Thing>())).Returns(true);
+            this.session.Setup(x => x.Write(It.IsAny<OperationContainer>())).Returns(Task.CompletedTask);
+
+            var dialogNavigationService = new Mock<IDialogNavigationService>();
+
+            var viewmodel = new ModelBrowserViewModel(this.session.Object, this.siteDirectory, this.thingDialogNavigationService.Object, this.navigationService.Object, dialogNavigationService.Object, null);
+
+            var role = new ParticipantRole(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Model Admin" };
+            this.siteDirectory.ParticipantRole.Add(role);
+
+            var domain = new DomainOfExpertise(Guid.NewGuid(), this.assembler.Cache, this.uri) { Name = "Thermal" };
+            this.siteDirectory.Domain.Add(domain);
+
+            var newPerson = new Person(Guid.NewGuid(), this.assembler.Cache, this.uri) { GivenName = "Jane", Surname = "Roe", DefaultDomain = domain };
+            this.siteDirectory.Person.Add(newPerson);
+
+            var model = new EngineeringModelSetup(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            model.ActiveDomain.Add(domain);
+            this.siteDirectory.Model.Add(model);
+
+            this.revPropertyInfo.SetValue(this.siteDirectory, 50);
+            this.messageBus.SendObjectChangeEvent(this.siteDirectory, EventKind.Updated);
+
+            var modelRow = viewmodel.ModelSetup.Single();
+            viewmodel.SelectedThing = modelRow;
+            viewmodel.ComputePermission();
+
+            dialogNavigationService
+                .Setup(x => x.NavigateModal(It.IsAny<IDialogViewModel>()))
+                .Returns(new BaseDialogResult(false));
+
+            await viewmodel.CreateMultipleParticipantsCommand.Execute();
+
+            this.session.Verify(x => x.Write(It.IsAny<OperationContainer>()), Times.Never);
         }
     }
 }

--- a/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantCreationDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantCreationDialogViewModel.cs
@@ -1,0 +1,206 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="BulkParticipantCreationDialogViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4SiteDirectory.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Mvvm;
+    using CDP4Composition.Navigation;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// The dialog-view-model that allows the user to create multiple <see cref="Participant"/>s at once for a single
+    /// <see cref="EngineeringModelSetup"/>. The selected <see cref="Person"/>s all receive the same
+    /// <see cref="ParticipantRole"/> and active state, while the <see cref="DomainOfExpertise"/> of each
+    /// <see cref="Participant"/> is chosen per <see cref="Person"/> (defaulting to the <see cref="Person"/>'s own
+    /// default domain).
+    /// </summary>
+    public class BulkParticipantCreationDialogViewModel : DialogViewModelBase
+    {
+        /// <summary>
+        /// Backing field for <see cref="SelectedRole"/>
+        /// </summary>
+        private ParticipantRole selectedRole;
+
+        /// <summary>
+        /// Backing field for <see cref="IsActive"/>
+        /// </summary>
+        private bool isActive;
+
+        /// <summary>
+        /// Backing field for <see cref="OkCanExecute"/>
+        /// </summary>
+        private bool okCanExecute;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BulkParticipantCreationDialogViewModel"/> class.
+        /// </summary>
+        /// <param name="persons">
+        /// The <see cref="Person"/>s for which a <see cref="Participant"/> may be created.
+        /// </param>
+        /// <param name="participantRoles">
+        /// The possible <see cref="ParticipantRole"/>s that may be assigned.
+        /// </param>
+        /// <param name="domainsOfExpertise">
+        /// The possible <see cref="DomainOfExpertise"/>s (the active domains of the model) that may be assigned.
+        /// </param>
+        public BulkParticipantCreationDialogViewModel(IEnumerable<Person> persons, IEnumerable<ParticipantRole> participantRoles, IEnumerable<DomainOfExpertise> domainsOfExpertise)
+        {
+            if (persons == null)
+            {
+                throw new ArgumentNullException(nameof(persons), $"The {nameof(persons)} may not be null");
+            }
+
+            if (participantRoles == null)
+            {
+                throw new ArgumentNullException(nameof(participantRoles), $"The {nameof(participantRoles)} may not be null");
+            }
+
+            if (domainsOfExpertise == null)
+            {
+                throw new ArgumentNullException(nameof(domainsOfExpertise), $"The {nameof(domainsOfExpertise)} may not be null");
+            }
+
+            this.PossibleRole = participantRoles.OrderBy(x => x.Name).ToList();
+            this.PossibleDomain = domainsOfExpertise.OrderBy(x => x.Name).ToList();
+            this.Participants = new ReactiveList<BulkParticipantRowViewModel>();
+            this.IsActive = true;
+
+            foreach (var person in persons.OrderBy(x => x.Name))
+            {
+                var row = new BulkParticipantRowViewModel(person, this.PossibleDomain);
+                this.Subscriptions.Add(row.WhenAnyValue(x => x.IsSelected, x => x.SelectedDomain).Subscribe(_ => this.UpdateOkCanExecute()));
+                this.Participants.Add(row);
+            }
+
+            this.Subscriptions.Add(this.WhenAnyValue(x => x.SelectedRole).Subscribe(_ => this.UpdateOkCanExecute()));
+
+            this.InitializeReactiveCommands();
+            this.UpdateOkCanExecute();
+        }
+
+        /// <summary>
+        /// Gets the rows representing the <see cref="Participant"/>s that may be created.
+        /// </summary>
+        public ReactiveList<BulkParticipantRowViewModel> Participants { get; private set; }
+
+        /// <summary>
+        /// Gets the possible <see cref="ParticipantRole"/>s that may be assigned.
+        /// </summary>
+        public IReadOnlyList<ParticipantRole> PossibleRole { get; private set; }
+
+        /// <summary>
+        /// Gets the possible <see cref="DomainOfExpertise"/>s that may be assigned.
+        /// </summary>
+        public IReadOnlyList<DomainOfExpertise> PossibleDomain { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ParticipantRole"/> that every created <see cref="Participant"/> shall receive.
+        /// </summary>
+        public ParticipantRole SelectedRole
+        {
+            get => this.selectedRole;
+            set => this.RaiseAndSetIfChanged(ref this.selectedRole, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether every created <see cref="Participant"/> shall be active.
+        /// </summary>
+        public bool IsActive
+        {
+            get => this.isActive;
+            set => this.RaiseAndSetIfChanged(ref this.isActive, value);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="OkCommand"/> can be executed.
+        /// </summary>
+        public bool OkCanExecute
+        {
+            get => this.okCanExecute;
+            private set => this.RaiseAndSetIfChanged(ref this.okCanExecute, value);
+        }
+
+        /// <summary>
+        /// Gets the Ok command.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> OkCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the Cancel command.
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> CancelCommand { get; private set; }
+
+        /// <summary>
+        /// Initialize the <see cref="ReactiveCommand"/>s.
+        /// </summary>
+        private void InitializeReactiveCommands()
+        {
+            this.OkCommand = ReactiveCommandCreator.Create(this.ExecuteOk, this.WhenAnyValue(x => x.OkCanExecute));
+            this.CancelCommand = ReactiveCommandCreator.Create(this.ExecuteCancel);
+        }
+
+        /// <summary>
+        /// Updates the <see cref="OkCanExecute"/> property.
+        /// </summary>
+        private void UpdateOkCanExecute()
+        {
+            var selectedRows = this.Participants.Where(x => x.IsSelected).ToList();
+
+            this.OkCanExecute = selectedRows.Any() && this.SelectedRole != null && selectedRows.All(x => x.SelectedDomain != null);
+        }
+
+        /// <summary>
+        /// Executes the <see cref="OkCommand"/>.
+        /// </summary>
+        private void ExecuteOk()
+        {
+            var selectedRows = this.Participants.Where(x => x.IsSelected).ToList();
+
+            foreach (var row in selectedRows)
+            {
+                row.SelectedRole = this.SelectedRole;
+                row.IsActive = this.IsActive;
+            }
+
+            this.DialogResult = new BulkParticipantCreationResult(true, selectedRows);
+        }
+
+        /// <summary>
+        /// Executes the <see cref="CancelCommand"/>.
+        /// </summary>
+        private void ExecuteCancel()
+        {
+            this.DialogResult = new BaseDialogResult(false);
+        }
+    }
+}

--- a/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantCreationResult.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantCreationResult.cs
@@ -1,0 +1,60 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="BulkParticipantCreationResult.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4SiteDirectory.ViewModels
+{
+    using System.Collections.Generic;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Composition.Navigation;
+
+    /// <summary>
+    /// The result of the <see cref="BulkParticipantCreationDialogViewModel"/>, carrying the set of
+    /// <see cref="BulkParticipantRowViewModel"/>s for which a <see cref="Participant"/> shall be created.
+    /// </summary>
+    public class BulkParticipantCreationResult : BaseDialogResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BulkParticipantCreationResult"/> class.
+        /// </summary>
+        /// <param name="result">
+        /// A value indicating whether the result is positive or negative.
+        /// </param>
+        /// <param name="participants">
+        /// The selected <see cref="BulkParticipantRowViewModel"/>s for which a <see cref="Participant"/> shall be created.
+        /// </param>
+        public BulkParticipantCreationResult(bool? result, IEnumerable<BulkParticipantRowViewModel> participants)
+            : base(result)
+        {
+            this.Participants = participants;
+        }
+
+        /// <summary>
+        /// Gets the selected <see cref="BulkParticipantRowViewModel"/>s for which a <see cref="Participant"/> shall be created.
+        /// </summary>
+        public IEnumerable<BulkParticipantRowViewModel> Participants { get; private set; }
+    }
+}

--- a/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantRowViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/BulkParticipantRowViewModel.cs
@@ -1,0 +1,118 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="BulkParticipantRowViewModel.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4SiteDirectory.ViewModels
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.SiteDirectoryData;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Represents a single candidate <see cref="Participant"/> to be created in the
+    /// <see cref="BulkParticipantCreationDialogViewModel"/>. Each row maps one <see cref="Person"/> to the
+    /// <see cref="DomainOfExpertise"/> the created <see cref="Participant"/> shall receive. The
+    /// <see cref="ParticipantRole"/> and active state are applied for the whole batch by the owning
+    /// <see cref="BulkParticipantCreationDialogViewModel"/>.
+    /// </summary>
+    public class BulkParticipantRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="IsSelected"/>
+        /// </summary>
+        private bool isSelected;
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedDomain"/>
+        /// </summary>
+        private DomainOfExpertise selectedDomain;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BulkParticipantRowViewModel"/> class.
+        /// </summary>
+        /// <param name="person">
+        /// The <see cref="Person"/> for which a <see cref="Participant"/> may be created.
+        /// </param>
+        /// <param name="possibleDomains">
+        /// The possible <see cref="DomainOfExpertise"/>s (the active domains of the model) that may be assigned.
+        /// </param>
+        public BulkParticipantRowViewModel(Person person, IEnumerable<DomainOfExpertise> possibleDomains)
+        {
+            this.Person = person;
+            this.PossibleDomain = possibleDomains.ToList();
+            this.IsSelected = true;
+
+            if (person.DefaultDomain != null && this.PossibleDomain.Contains(person.DefaultDomain))
+            {
+                this.SelectedDomain = person.DefaultDomain;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Person"/> represented by this row.
+        /// </summary>
+        public Person Person { get; }
+
+        /// <summary>
+        /// Gets the name of the <see cref="Person"/> represented by this row.
+        /// </summary>
+        public string PersonName => this.Person.Name;
+
+        /// <summary>
+        /// Gets the possible <see cref="DomainOfExpertise"/>s that may be assigned to this <see cref="Person"/>.
+        /// </summary>
+        public IReadOnlyList<DomainOfExpertise> PossibleDomain { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a <see cref="Participant"/> shall be created for this <see cref="Person"/>.
+        /// </summary>
+        public bool IsSelected
+        {
+            get => this.isSelected;
+            set => this.RaiseAndSetIfChanged(ref this.isSelected, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="DomainOfExpertise"/> that the created <see cref="Participant"/> shall receive.
+        /// </summary>
+        public DomainOfExpertise SelectedDomain
+        {
+            get => this.selectedDomain;
+            set => this.RaiseAndSetIfChanged(ref this.selectedDomain, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ParticipantRole"/> that the created <see cref="Participant"/> shall receive.
+        /// </summary>
+        public ParticipantRole SelectedRole { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the created <see cref="Participant"/> shall be active.
+        /// </summary>
+        public bool IsActive { get; set; }
+    }
+}

--- a/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/Dialogs/ParticipantDialogViewModel.cs
@@ -109,6 +109,11 @@ namespace CDP4SiteDirectory.ViewModels
             this.isSelectedRoleDeprecated =
                 this.WhenAny(x => x.SelectedRole, selectedRole => selectedRole.Value?.IsDeprecated == true)
                     .ToProperty(this, x => x.IsSelectedRoleDeprecated, out this.isSelectedRoleDeprecated, scheduler: RxApp.MainThreadScheduler);
+
+            if (this.dialogKind == ThingDialogKind.Create)
+            {
+                this.IsActive = true;
+            }
         }
 
         /// <summary>

--- a/CDP4SiteDirectory/ViewModels/ModelBrowser/ModelBrowserViewModel.cs
+++ b/CDP4SiteDirectory/ViewModels/ModelBrowser/ModelBrowserViewModel.cs
@@ -25,10 +25,12 @@
 
 namespace CDP4SiteDirectory.ViewModels
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel.Composition;
     using System.Linq;
     using System.Reactive;
+    using System.Threading.Tasks;
 
     using CDP4Common.CommonData;
     using CDP4Common.SiteDirectoryData;
@@ -45,6 +47,7 @@ namespace CDP4SiteDirectory.ViewModels
 
     using CDP4Dal;
     using CDP4Dal.Events;
+    using CDP4Dal.Operations;
 
     using ReactiveUI;
 
@@ -110,6 +113,11 @@ namespace CDP4SiteDirectory.ViewModels
         /// Gets the <see cref="ICommand" /> to create a new <see cref="Participant" />
         /// </summary>
         public ReactiveCommand<Unit, Unit> CreateParticipantCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the <see cref="ICommand" /> to create multiple <see cref="Participant" />s at once
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> CreateMultipleParticipantsCommand { get; private set; }
 
         /// <summary>
         /// Gets the <see cref="ICommand" /> to create a new <see cref="IterationSetup" />
@@ -178,7 +186,11 @@ namespace CDP4SiteDirectory.ViewModels
                     }
 
                     this.ExecuteCreateCommand<Participant>(container);
-                }, 
+                },
+                this.WhenAnyValue(x => x.CanCreateParticipant));
+
+            this.CreateMultipleParticipantsCommand = ReactiveCommandCreator.CreateAsyncTask(
+                this.ExecuteCreateMultipleParticipantsCommand,
                 this.WhenAnyValue(x => x.CanCreateParticipant));
 
             this.CreateIterationSetupCommand = ReactiveCommandCreator.Create(() =>
@@ -191,8 +203,68 @@ namespace CDP4SiteDirectory.ViewModels
                     }
 
                     this.ExecuteCreateCommand<IterationSetup>(container);
-                }, 
+                },
                 this.WhenAnyValue(x => x.CanCreateIterationSetup));
+        }
+
+        /// <summary>
+        /// Executes the <see cref="CreateMultipleParticipantsCommand" /> by presenting the bulk participant creation
+        /// dialog and persisting the selected <see cref="Participant" />s in a single transaction.
+        /// </summary>
+        /// <returns>
+        /// an awaitable <see cref="Task" />
+        /// </returns>
+        private async Task ExecuteCreateMultipleParticipantsCommand()
+        {
+            var modelSetup = this.GetSelectedModelSetupContainer();
+
+            if (modelSetup == null)
+            {
+                return;
+            }
+
+            var siteDirectory = this.Session.RetrieveSiteDirectory();
+
+            var eligiblePersons = siteDirectory.Person
+                .Where(person => !person.IsDeprecated)
+                .Except(modelSetup.Participant.Select(p => p.Person))
+                .ToList();
+
+            if (!eligiblePersons.Any())
+            {
+                return;
+            }
+
+            var dialogViewModel = new BulkParticipantCreationDialogViewModel(eligiblePersons, siteDirectory.ParticipantRole, modelSetup.ActiveDomain);
+
+            var result = this.DialogNavigationService.NavigateModal(dialogViewModel) as BulkParticipantCreationResult;
+
+            if (result?.Result != true || result.Participants == null || !result.Participants.Any())
+            {
+                return;
+            }
+
+            var context = TransactionContextResolver.ResolveContext(modelSetup);
+            var modelSetupClone = modelSetup.Clone(false);
+            var transaction = new ThingTransaction(context, modelSetupClone);
+
+            foreach (var row in result.Participants)
+            {
+                var participant = new Participant(Guid.NewGuid(), null, null)
+                {
+                    Person = row.Person,
+                    Role = row.SelectedRole,
+                    SelectedDomain = row.SelectedDomain,
+                    IsActive = row.IsActive
+                };
+
+                participant.Domain.Add(row.SelectedDomain);
+
+                modelSetupClone.Participant.Add(participant);
+                transaction.Create(participant, modelSetupClone);
+            }
+
+            await this.Session.Write(transaction.FinalizeTransaction());
         }
 
         /// <summary>
@@ -223,6 +295,7 @@ namespace CDP4SiteDirectory.ViewModels
             {
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Create an Engineering Model Setup", "", this.CreateCommand, MenuItemKind.Create, ClassKind.EngineeringModelSetup));
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Participant", "", this.CreateParticipantCommand, MenuItemKind.Create, ClassKind.Participant));
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Create Multiple Participants", "", this.CreateMultipleParticipantsCommand, MenuItemKind.Create, ClassKind.Participant));
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Create an Iteration Setup", "", this.CreateIterationSetupCommand, MenuItemKind.Create, ClassKind.IterationSetup));
             }
             else if (this.SelectedThing is ModelParticipantRowViewModel participantRowViewModel)
@@ -240,6 +313,7 @@ namespace CDP4SiteDirectory.ViewModels
                 }
 
                 this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Participant", "", this.CreateParticipantCommand, MenuItemKind.Create, ClassKind.Participant));
+                this.ContextMenu.Add(new ContextMenuItemViewModel("Create Multiple Participants", "", this.CreateMultipleParticipantsCommand, MenuItemKind.Create, ClassKind.Participant));
             }
             else if (this.SelectedThing is IterationSetupRowViewModel)
             {
@@ -256,6 +330,7 @@ namespace CDP4SiteDirectory.ViewModels
                     else if (folderRowViewModel.ShortName == "Participants")
                     {
                         this.ContextMenu.Add(new ContextMenuItemViewModel("Create a Participant", "", this.CreateParticipantCommand, MenuItemKind.Create, ClassKind.Participant));
+                        this.ContextMenu.Add(new ContextMenuItemViewModel("Create Multiple Participants", "", this.CreateMultipleParticipantsCommand, MenuItemKind.Create, ClassKind.Participant));
                     }
                 }
             }

--- a/CDP4SiteDirectory/Views/Dialogs/BulkParticipantCreationDialog.xaml
+++ b/CDP4SiteDirectory/Views/Dialogs/BulkParticipantCreationDialog.xaml
@@ -1,0 +1,120 @@
+﻿<dx:DXWindow x:Class="CDP4SiteDirectory.Views.BulkParticipantCreationDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
+             xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dxg="http://schemas.devexpress.com/winfx/2008/xaml/grid"
+             xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:navigation="clr-namespace:CDP4Composition.Navigation;assembly=CDP4Composition"
+             Title="Create Multiple Participants"
+             Width="550"
+             Height="500"
+             navigation:ExtendedDialogResultCloser.DialogResult="{Binding DialogResult}"
+             mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" Margin="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,10,5" VerticalAlignment="Center" Text="Participant Role:" />
+            <dxe:ComboBoxEdit Grid.Row="0" Grid.Column="1"
+                              Margin="0,0,0,5"
+                              Name="Role"
+                              DisplayMember="Name"
+                              IsTextEditable="False"
+                              EditValue="{Binding SelectedRole, UpdateSourceTrigger=PropertyChanged}"
+                              ItemsSource="{Binding PossibleRole}" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,0" VerticalAlignment="Center" Text="Is Active:" />
+            <dxe:CheckEdit Grid.Row="1" Grid.Column="1"
+                           Name="IsActiveCheckEdit"
+                           HorizontalAlignment="Left"
+                           IsChecked="{Binding IsActive, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        </Grid>
+
+        <TextBlock Grid.Row="1" Margin="5,0,5,2" Text="Persons:" />
+
+        <dxg:GridControl Grid.Row="2"
+                         Margin="5"
+                         Name="PersonsGridControl"
+                         AllowLiveDataShaping="False"
+                         ItemsSource="{Binding Participants}"
+                         SelectionMode="Row">
+            <dxg:GridControl.View>
+                <dxg:TableView Name="PersonsGridView"
+                               HorizontalAlignment="Stretch"
+                               VerticalAlignment="Stretch"
+                               AllowColumnMoving="False"
+                               AllowEditing="False"
+                               AllowGrouping="False"
+                               AutoWidth="True"
+                               ShowFilterPanelMode="Never"
+                               ShowGroupPanel="False"
+                               ShowSearchPanelMode="Always" />
+            </dxg:GridControl.View>
+            <dxg:GridControl.Columns>
+                <dxg:GridColumn FieldName="IsSelected"
+                                Header="Add"
+                                Width="45"
+                                AllowEditing="True"
+                                HorizontalHeaderContentAlignment="Center">
+                    <dxg:GridColumn.CellTemplate>
+                        <DataTemplate>
+                            <dxe:CheckEdit HorizontalAlignment="Center"
+                                           VerticalAlignment="Center"
+                                           IsChecked="{Binding RowData.Row.IsSelected, UpdateSourceTrigger=PropertyChanged}" />
+                        </DataTemplate>
+                    </dxg:GridColumn.CellTemplate>
+                </dxg:GridColumn>
+                <dxg:GridColumn FieldName="PersonName" Header="Person" SortMode="Value" SortIndex="0" />
+                <dxg:GridColumn FieldName="SelectedDomain"
+                                Header="Domain of Expertise"
+                                HorizontalHeaderContentAlignment="Left"
+                                AllowEditing="True">
+                    <dxg:GridColumn.CellTemplate>
+                        <DataTemplate>
+                            <ComboBox Margin="3"
+                                      Background="White"
+                                      IsEditable="False"
+                                      DisplayMemberPath="Name"
+                                      SelectedItem="{Binding RowData.Row.SelectedDomain, UpdateSourceTrigger=PropertyChanged}"
+                                      ItemsSource="{Binding RowData.Row.PossibleDomain}" />
+                        </DataTemplate>
+                    </dxg:GridColumn.CellTemplate>
+                </dxg:GridColumn>
+            </dxg:GridControl.Columns>
+        </dxg:GridControl>
+
+        <dxlc:LayoutGroup Grid.Row="3" Height="35" Margin="0,0,5,5">
+            <Button Content="OK"
+                    Margin="5"
+                    Width="75"
+                    Height="25"
+                    IsDefault="True"
+                    HorizontalAlignment="Right"
+                    Command="{Binding OkCommand}" />
+            <Button Content="Cancel"
+                    Margin="5"
+                    Width="75"
+                    Height="25"
+                    IsCancel="True"
+                    HorizontalAlignment="Right"
+                    Command="{Binding CancelCommand}" />
+        </dxlc:LayoutGroup>
+    </Grid>
+</dx:DXWindow>

--- a/CDP4SiteDirectory/Views/Dialogs/BulkParticipantCreationDialog.xaml.cs
+++ b/CDP4SiteDirectory/Views/Dialogs/BulkParticipantCreationDialog.xaml.cs
@@ -1,0 +1,63 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="BulkParticipantCreationDialog.xaml.cs" company="Starion Group S.A.">
+//    Copyright (c) 2015-2026 Starion Group S.A.
+//
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Rowan de Voogt
+//
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
+//
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Affero General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or any later version.
+//
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program. If not, see http://www.gnu.org/licenses/.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace CDP4SiteDirectory.Views
+{
+    using CDP4Composition.Attributes;
+    using CDP4Composition.Navigation.Interfaces;
+
+    using DevExpress.Xpf.Core;
+
+    /// <summary>
+    /// Interaction logic for BulkParticipantCreationDialog.xaml
+    /// </summary>
+    [DialogViewExport("BulkParticipantCreationDialog", "Create Multiple Participants")]
+    public partial class BulkParticipantCreationDialog : DXWindow, IDialogView
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BulkParticipantCreationDialog"/> class.
+        /// </summary>
+        public BulkParticipantCreationDialog()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BulkParticipantCreationDialog"/> class.
+        /// </summary>
+        /// <param name="initializeComponent">
+        /// a value indicating whether the contained Components shall be loaded
+        /// </param>
+        /// <remarks>
+        /// This constructor is called by the navigation service
+        /// </remarks>
+        public BulkParticipantCreationDialog(bool initializeComponent)
+        {
+            if (initializeComponent)
+            {
+                this.InitializeComponent();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #1029 and #699 
Created a BulkParticipantCreationDialog which works per one role, so you select the role all the participants will get. 
Below is the isActive checkbox which is checked by default. Now, also in the normal create participant dialog.
Below there is a grid with Persons:
It shows all not yet added not deprecated persons, with their name and a single domain of expertise selection (default domain selected as default) and an OK

Not implemented: 
Teams as that would require a model change and sdk changes and not sure what the additional benefit would be maybe we could make it. 
Only one domain selection such that i could reuse the format used for domain of expertise selection and keep it quick and easy.

<img width="547" height="501" alt="image" src="https://github.com/user-attachments/assets/0edff219-d9b0-4b5b-be78-f9ad03540efc" />


