### PR TITLE
Feat #561 Made textbox of the label and added a gridsplitter to the grapher

### DIFF
--- a/CDP4Composition/Views/ElementParameterRowControl.xaml
+++ b/CDP4Composition/Views/ElementParameterRowControl.xaml
@@ -24,15 +24,26 @@
     <Grid Background="AliceBlue" >
         <Grid.RowDefinitions>
             <RowDefinition Height="3*"></RowDefinition>
+            <RowDefinition Height="5"></RowDefinition>
             <RowDefinition Height="7*"></RowDefinition>
         </Grid.RowDefinitions>
-        <ScrollViewer VerticalScrollBarVisibility="Auto" Margin="10,30,10,10" Grid.Row="0">
-            <Label Content="{Binding ElementTooltipInfo}"></Label>
-        </ScrollViewer>
+        <TextBox Grid.Row="0"
+                 Margin="5,10,10,10"
+                 Padding="0"
+                 Background="Transparent"
+                 BorderThickness="0"
+                 IsReadOnly="True"
+                 TextWrapping="Wrap"
+                 VerticalScrollBarVisibility="Auto"
+                 HorizontalScrollBarVisibility="Auto"
+                 Text="{Binding ElementTooltipInfo, Mode=OneWay}" />
 
+        <GridSplitter Grid.Row="1"
+                      Height="5"
+                      HorizontalAlignment="Stretch" />
 
         <dxg:TreeListControl x:Name="TreeList"
-                             Grid.Row="1"
+                             Grid.Row="2"
                              ItemsSource="{Binding Parameters}"
                              SelectedItem="{Binding SelectedThing}"
                              CurrentItem="{Binding FocusedRow, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #561 
Improve right panel layout of grapher. 
A read-only TextBox so users can select and copy the values instead of a non-selectable Label. 
A GridSplitter was added between the data block and the parameter list, letting users resize the two sections to their preference. 