### PR TITLE
Fix issue 843 which was already fixed but added a feature to expand and collapse all rows in the element definition browser

### DIFF
--- a/CDP4Composition/Mvvm/BrowserViewModelBase.cs
+++ b/CDP4Composition/Mvvm/BrowserViewModelBase.cs
@@ -407,6 +407,16 @@ namespace CDP4Composition.Mvvm
         public ReactiveCommand<Unit, Unit> CollpaseRowsCommand { get; private set; }
 
         /// <summary>
+        /// Gets the Expand All Rows Command that expands every root row of the browser and its descendants
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> ExpandAllRowsCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the Collapse All Rows Command that collapses every root row of the browser and its descendants
+        /// </summary>
+        public ReactiveCommand<Unit, Unit> CollapseAllRowsCommand { get; private set; }
+
+        /// <summary>
         /// Gets the Context Menu for this browser
         /// </summary>
         public ReactiveList<ContextMenuItemViewModel> ContextMenu { get; private set; }
@@ -847,6 +857,13 @@ namespace CDP4Composition.Mvvm
         }
 
         /// <summary>
+        /// Gets the top-level rows of this browser, used by the <see cref="ExpandAllRowsCommand"/> and
+        /// <see cref="CollapseAllRowsCommand"/>. Returns an empty collection by default; browsers that present
+        /// a tree should override this to return their root <see cref="IRowViewModelBase{T}"/>s.
+        /// </summary>
+        protected virtual IEnumerable<IRowViewModelBase<Thing>> RootRowViewModels => Enumerable.Empty<IRowViewModelBase<Thing>>();
+
+        /// <summary>
         /// Executes the expand rows logic
         /// </summary>
         private void ExecuteExpandRows()
@@ -869,6 +886,28 @@ namespace CDP4Composition.Mvvm
             if (rowViewModelBase != null)
             {
                 rowViewModelBase.CollapseAllRows();
+            }
+        }
+
+        /// <summary>
+        /// Executes the expand all rows logic, expanding every root row of the browser and its descendants
+        /// </summary>
+        private void ExecuteExpandAllRows()
+        {
+            foreach (var row in this.RootRowViewModels)
+            {
+                row.ExpandAllRows();
+            }
+        }
+
+        /// <summary>
+        /// Executes the collapse all rows logic, collapsing every root row of the browser and its descendants
+        /// </summary>
+        private void ExecuteCollapseAllRows()
+        {
+            foreach (var row in this.RootRowViewModels)
+            {
+                row.CollapseAllRows();
             }
         }
 
@@ -900,6 +939,8 @@ namespace CDP4Composition.Mvvm
             this.ChangeFocusCommand = ReactiveCommandCreator.Create(this.ExecuteChangeFocusCommand);
             this.ExpandRowsCommand = ReactiveCommandCreator.Create(this.ExecuteExpandRows);
             this.CollpaseRowsCommand = ReactiveCommandCreator.Create(this.ExecuteCollapseRows);
+            this.ExpandAllRowsCommand = ReactiveCommandCreator.Create(this.ExecuteExpandAllRows);
+            this.CollapseAllRowsCommand = ReactiveCommandCreator.Create(this.ExecuteCollapseAllRows);
 
             var iteration = this.Thing as Iteration ?? this.Thing.GetContainerOfType<Iteration>();
 
@@ -972,6 +1013,23 @@ namespace CDP4Composition.Mvvm
                     this.ContextMenu.Add(new ContextMenuItemViewModel("Expand Rows", "", this.ExpandRowsCommand, MenuItemKind.None, ClassKind.NotThing));
                 }
             }
+
+            this.AddExpandCollapseAllContextMenuItems();
+        }
+
+        /// <summary>
+        /// Adds the "Expand All Rows" and "Collapse All Rows" <see cref="ContextMenuItemViewModel"/>s to the
+        /// <see cref="ContextMenu"/> when this browser exposes root rows (see <see cref="RootRowViewModels"/>).
+        /// </summary>
+        protected void AddExpandCollapseAllContextMenuItems()
+        {
+            if (!this.RootRowViewModels.Any())
+            {
+                return;
+            }
+
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Expand All Rows", "", this.ExpandAllRowsCommand, MenuItemKind.None, ClassKind.NotThing));
+            this.ContextMenu.Add(new ContextMenuItemViewModel("Collapse All Rows", "", this.CollapseAllRowsCommand, MenuItemKind.None, ClassKind.NotThing));
         }
 
         /// <summary>

--- a/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
+++ b/EngineeringModel.Tests/ViewModels/ElementDefinitionsBrowser/ElementDefinitionBrowserViewModelTestFixture.cs
@@ -653,29 +653,73 @@ namespace CDP4EngineeringModel.Tests
 
             vm.SelectedThing = defRow;
             vm.PopulateContextMenu();
-            Assert.AreEqual(15, vm.ContextMenu.Count);
+            Assert.AreEqual(17, vm.ContextMenu.Count);
             vm.SelectedThing = defRow.ContainedRows[0];
             vm.PopulateContextMenu();
-            Assert.AreEqual(10, vm.ContextMenu.Count);
+            Assert.AreEqual(12, vm.ContextMenu.Count);
 
             vm.SelectedThing = defRow.ContainedRows[1];
             vm.PopulateContextMenu();
-            Assert.AreEqual(9, vm.ContextMenu.Count);
+            Assert.AreEqual(11, vm.ContextMenu.Count);
 
             var usageRow = defRow.ContainedRows[2];
             var usage2Row = defRow.ContainedRows[3];
 
             vm.SelectedThing = usageRow;
             vm.PopulateContextMenu();
-            Assert.AreEqual(6, vm.ContextMenu.Count);
+            Assert.AreEqual(8, vm.ContextMenu.Count);
 
             vm.SelectedThing = usageRow.ContainedRows.Single();
             vm.PopulateContextMenu();
-            Assert.AreEqual(10, vm.ContextMenu.Count);
+            Assert.AreEqual(12, vm.ContextMenu.Count);
 
             vm.SelectedThing = usage2Row.ContainedRows.Single();
             vm.PopulateContextMenu();
-            Assert.AreEqual(8, vm.ContextMenu.Count);
+            Assert.AreEqual(10, vm.ContextMenu.Count);
+
+            vm.Dispose();
+        }
+
+        [Test]
+        public async Task VerifyThatExpandAllAndCollapseAllRowsCommandsWork()
+        {
+            var parameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri)
+            {
+                ParameterType = this.pt
+            };
+
+            var def2 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri);
+            var usage = new ElementUsage(Guid.NewGuid(), this.assembler.Cache, this.uri)
+            {
+                ElementDefinition = def2
+            };
+
+            this.elementDef.Parameter.Add(parameter);
+            this.elementDef.ContainedElement.Add(usage);
+
+            this.iteration.Element.Add(this.elementDef);
+            this.iteration.Element.Add(def2);
+
+            var vm = new ElementDefinitionsBrowserViewModel(this.iteration, this.session.Object, null, null, null, null, null, null);
+            await this.DelayedCheck(() => vm.SingleRunBackgroundWorker == null);
+
+            var defRow = vm.ElementDefinitionRowViewModels.Single(x => x.Thing == this.elementDef);
+
+            await vm.ExpandAllRowsCommand.Execute();
+
+            Assert.IsTrue(vm.ElementDefinitionRowViewModels.All(x => x.IsExpanded));
+            Assert.IsTrue(defRow.ContainedRows.All(x => x.IsExpanded));
+
+            await vm.CollapseAllRowsCommand.Execute();
+
+            Assert.IsTrue(vm.ElementDefinitionRowViewModels.All(x => !x.IsExpanded));
+            Assert.IsTrue(defRow.ContainedRows.All(x => !x.IsExpanded));
+
+            vm.SelectedThing = defRow;
+            vm.PopulateContextMenu();
+
+            Assert.IsTrue(vm.ContextMenu.Any(x => x.Header == "Expand All Rows"));
+            Assert.IsTrue(vm.ContextMenu.Any(x => x.Header == "Collapse All Rows"));
 
             vm.Dispose();
         }

--- a/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
+++ b/EngineeringModel/ViewModels/ElementDefinitionBrowser/ElementDefinitionsBrowserViewModel.cs
@@ -379,6 +379,11 @@ namespace CDP4EngineeringModel.ViewModels
         public DisposableReactiveList<IRowViewModelBase<Thing>> ElementDefinitionRowViewModels { get; private set; }
 
         /// <summary>
+        /// Gets the top-level rows of this browser, used by the Expand All / Collapse All commands
+        /// </summary>
+        protected override IEnumerable<IRowViewModelBase<Thing>> RootRowViewModels => this.ElementDefinitionRowViewModels;
+
+        /// <summary>
         /// Gets or sets the dock layout group target name to attach this panel to on opening
         /// </summary>
         public string TargetName { get; set; } = LayoutGroupNames.DocumentContainer;
@@ -757,6 +762,8 @@ namespace CDP4EngineeringModel.ViewModels
                 {
                     this.ContextMenu.Add(this.SelectedThing.IsExpanded ? new ContextMenuItemViewModel("Collapse Rows", "", this.CollpaseRowsCommand, MenuItemKind.None, ClassKind.NotThing) : new ContextMenuItemViewModel("Expand Rows", "", this.ExpandRowsCommand, MenuItemKind.None, ClassKind.NotThing));
                 }
+
+                this.AddExpandCollapseAllContextMenuItems();
 
                 if (this.SelectedThing is IHaveModelCode)
                 {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #843
Extensively tested and looked back and the issue was actually already solved
While I was busy with this I added a button to the context menu of the element definition browser to expand and collapse all rows, as sometimes i wanted to have this option myself.
