### PR TITLE
Feat #734 added the possibility to drag a subscribed parameter into the dashboard

### DIFF
--- a/CDP4Dashboard.Tests/ViewModels/DashboardBrowserViewModelTestFixture.cs
+++ b/CDP4Dashboard.Tests/ViewModels/DashboardBrowserViewModelTestFixture.cs
@@ -231,6 +231,48 @@ namespace CDP4Dashboard.Tests.ViewModels
         }
 
         [Test]
+        public void VerifyThatDragOverWorksWithParameterSubscription()
+        {
+            var vm = new DashboardBrowserViewModel(this.iteration, this.session.Object, null, null, null, null);
+
+            var parameter = this.elementDef.ContainedElement.First().ParameterOverride.First().Parameter;
+            var subscription = new ParameterSubscription(Guid.NewGuid(), this.assembler.Cache, this.uri) { Owner = this.domain };
+            parameter.ParameterSubscription.Add(subscription);
+
+            var dropinfo = new Mock<IDropInfo>();
+            dropinfo.Setup(x => x.Payload).Returns(subscription);
+
+            vm.DragOver(dropinfo.Object);
+
+            dropinfo.VerifySet(x => x.Effects = DragDropEffects.Copy);
+        }
+
+        [Test]
+        public async Task VerifyThatDropWorksWithParameterSubscription()
+        {
+            var vm = new DashboardBrowserViewModel(this.iteration, this.session.Object, null, null, this.dialogNavigationService.Object, null);
+
+            var parameter = this.elementDef.ContainedElement.First().ParameterOverride.First().Parameter;
+            var subscription = new ParameterSubscription(Guid.NewGuid(), this.assembler.Cache, this.uri) { Owner = this.domain };
+            parameter.ParameterSubscription.Add(subscription);
+
+            var dropinfo = new Mock<IDropInfo>();
+            dropinfo.Setup(x => x.Payload).Returns(subscription);
+
+            Assert.AreEqual(1, vm.Widgets.Count);
+
+            await vm.Drop(dropinfo.Object);
+
+            Assert.AreEqual(2, vm.Widgets.Count);
+
+            var widget = vm.Widgets.OfType<IterationTrackParameterView>().Single();
+            var widgetViewModel = widget.DataContext as IterationTrackParameterViewModel<Parameter, ParameterValueSet>;
+
+            Assert.IsNotNull(widgetViewModel);
+            Assert.AreEqual(parameter, widgetViewModel.IterationTrackParameter.ParameterOrOverride);
+        }
+
+        [Test]
         public void VerifyThatDummyWidgetIsAddedAutomatically()
         {
             var vm = new DashboardBrowserViewModel(this.iteration, this.session.Object, null, null, this.dialogNavigationService.Object, null);

--- a/CDP4Dashboard/ViewModels/DashboardBrowserViewModel.cs
+++ b/CDP4Dashboard/ViewModels/DashboardBrowserViewModel.cs
@@ -434,11 +434,9 @@ namespace CDP4Dashboard.ViewModels
         /// <param name="dropInfo">The <see cref="IDropInfo"/> data</param>
         public void DragOver(IDropInfo dropInfo)
         {
-            if (dropInfo.Payload is Parameter parameter && this.FindIteration(parameter.Container) == this.Thing)
-            {
-                dropInfo.Effects = DragDropEffects.Copy;
-            }
-            else if (dropInfo.Payload is ParameterOverride parameterOverride && this.FindIteration(parameterOverride.Container) == this.Thing)
+            var parameterOrOverrideBase = GetParameterOrOverrideBase(dropInfo.Payload);
+
+            if (parameterOrOverrideBase != null && this.FindIteration(parameterOrOverrideBase.Container) == this.Thing)
             {
                 dropInfo.Effects = DragDropEffects.Copy;
             }
@@ -455,25 +453,47 @@ namespace CDP4Dashboard.ViewModels
         /// <returns>A <see cref="Task"/> to be executed async</returns>
         public async Task Drop(IDropInfo dropInfo)
         {
-            if (!(dropInfo.Payload is ParameterOrOverrideBase parameterOrOverrideBase))
+            var parameterOrOverrideBase = GetParameterOrOverrideBase(dropInfo.Payload);
+
+            if (parameterOrOverrideBase == null || this.FindIteration(parameterOrOverrideBase.Container) != this.Thing)
             {
                 return;
             }
 
-            var iterartionTrackParameter = new IterationTrackParameter(parameterOrOverrideBase);
+            var iterationTrackParameter = new IterationTrackParameter(parameterOrOverrideBase);
 
-            var result = this.DialogNavigationService.NavigateModal(new IterationTrackParameterDetailViewModel(iterartionTrackParameter));
+            var result = this.DialogNavigationService.NavigateModal(new IterationTrackParameterDetailViewModel(iterationTrackParameter));
 
             if (result.Result == true)
             {
-                if (dropInfo.Payload is Parameter parameter && this.FindIteration(parameter.Container) == this.Thing)
+                if (parameterOrOverrideBase is Parameter)
                 {
-                    this.AddWidget<Parameter, ParameterValueSet>(iterartionTrackParameter);
+                    this.AddWidget<Parameter, ParameterValueSet>(iterationTrackParameter);
                 }
-                else if (dropInfo.Payload is ParameterOverride parameterOverride && this.FindIteration(parameterOverride.Container) == this.Thing)
+                else if (parameterOrOverrideBase is ParameterOverride)
                 {
-                    this.AddWidget<ParameterOverride, ParameterOverrideValueSet>(iterartionTrackParameter);
+                    this.AddWidget<ParameterOverride, ParameterOverrideValueSet>(iterationTrackParameter);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Resolves the <see cref="ParameterOrOverrideBase"/> that a drag-and-drop <paramref name="payload"/> refers to.
+        /// When a <see cref="ParameterSubscription"/> is dropped, the subscribed-to <see cref="ParameterOrOverrideBase"/>
+        /// (its container) is returned so that the parameter itself - not the subscription - is tracked on the dashboard.
+        /// </summary>
+        /// <param name="payload">The drag-and-drop payload</param>
+        /// <returns>The <see cref="ParameterOrOverrideBase"/> to track, or null when the payload is not supported</returns>
+        private static ParameterOrOverrideBase GetParameterOrOverrideBase(object payload)
+        {
+            switch (payload)
+            {
+                case ParameterOrOverrideBase parameterOrOverrideBase:
+                    return parameterOrOverrideBase;
+                case ParameterSubscription parameterSubscription:
+                    return parameterSubscription.Container as ParameterOrOverrideBase;
+                default:
+                    return null;
             }
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Feat #734 
Dragging a subscribed parameter puts a ParameterSubscription on the drag payload. The dashboard's DragOver/Drop only matched Parameter/ParameterOverride, so the drop was rejected.

- Added GetParameterOrOverrideBase returns the payload itself for a ParameterOrOverrideBase, or parameterSubscription.Container as ParameterOrOverrideBase for a ParameterSubscription.
- DragOver / Drop now resolve via that helper and branch on the resolved Parameter/ParameterOverride type. Drop also folds the iteration check into the early-return guard.
