### PR TITLE
fix #611 No longer possible to open a model with a not-active domain of expertise

### DIFF
--- a/CDP4ShellDialogs/ViewModels/ModelOpeningDialogViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelOpeningDialogViewModel.cs
@@ -2,7 +2,7 @@
 // <copyright file="ModelOpeningDialogViewModel.cs" company="Starion Group S.A.">
 //    Copyright (c) 2015-2022 Starion Group S.A.
 //
-//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary
+//    Author: Sam Gerenï¿½, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Thï¿½ate, Omar Elebiary
 //
 //    This file is part of COMET-IME Community Edition.
 //    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
@@ -31,6 +31,7 @@ namespace CDP4ShellDialogs.ViewModels
     using System.Linq;
     using System.Reactive;
     using System.Threading.Tasks;
+    using System.Windows;
     using System.Windows.Input;
 
     using CDP4Common.CommonData;
@@ -42,8 +43,11 @@ namespace CDP4ShellDialogs.ViewModels
     using CDP4Composition.Mvvm;
     using CDP4Composition.Mvvm.Types;
     using CDP4Composition.Navigation;
+    using CDP4Composition.Services;
 
     using CDP4Dal;
+
+    using CommonServiceLocator;
 
     using NLog;
 
@@ -83,6 +87,16 @@ namespace CDP4ShellDialogs.ViewModels
         /// Backing field for the <see cref="SelectedEngineeringModelSetup "/> property.
         /// </summary>
         private ModelSelectionEngineeringModelSetupRowViewModel selectedEngineeringModelSetup;
+
+        /// <summary>
+        /// The (injected) <see cref="IMessageBoxService"/> used to inform the user when no usable domain is available.
+        /// </summary>
+        private readonly IMessageBoxService messageBoxService = ServiceLocator.Current.GetInstance<IMessageBoxService>();
+
+        /// <summary>
+        /// The message shown when the user has no domain of expertise that is both assigned to them and active in the model.
+        /// </summary>
+        private const string NoActiveDomainMessage = "You have no active domain of expertise in this model. Contact a model administrator to assign an active domain.";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelOpeningDialogViewModel"/> class. 
@@ -248,6 +262,12 @@ namespace CDP4ShellDialogs.ViewModels
                     throw new NullReferenceException($"The EngineeringModelSetup that iteration {iterationSetupRow.Thing.Iid} belongs to cannot be found.");
                 }
 
+                if (iterationSetupRow.SelectedDomain == null)
+                {
+                    this.messageBoxService.Show(NoActiveDomainMessage, "No active domain of expertise", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
                 // Retrieve the Iteration from the IDal
                 var session = iterationSetupRow.Session;
 
@@ -281,9 +301,6 @@ namespace CDP4ShellDialogs.ViewModels
             var stopWatch = Stopwatch.StartNew();
             var activeIterationSetupRow = this.SelectedEngineeringModelSetup.IterationSetupRowViewModels.FirstOrDefault(x => x.Thing.FrozenOn == null);
 
-            this.IsBusy = true;
-            this.LoadingMessage = "Loading Iteration...";
-
             if (activeIterationSetupRow != null)
             {
                 if (!(activeIterationSetupRow.Thing.Container is EngineeringModelSetup modelSetup))
@@ -291,8 +308,22 @@ namespace CDP4ShellDialogs.ViewModels
                     throw new NullReferenceException($"The EngineeringModelSetup that iteration {activeIterationSetupRow.Thing.Iid} belongs to cannot be found.");
                 }
 
-                // Retrieve the Iteration from the IDal
                 var session = activeIterationSetupRow.Session;
+
+                if (!activeIterationSetupRow.DomainOfExpertises.Any())
+                {
+                    this.messageBoxService.Show(NoActiveDomainMessage, "No active domain of expertise", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return;
+                }
+
+                if (session.ActivePerson.DefaultDomain == null || !activeIterationSetupRow.DomainOfExpertises.Contains(session.ActivePerson.DefaultDomain))
+                {
+                    this.ExecuteNext();
+                    return;
+                }
+
+                this.IsBusy = true;
+                this.LoadingMessage = "Loading Iteration...";
 
                 var model = new EngineeringModel(modelSetup.EngineeringModelIid, session.Assembler.Cache, session.Credentials.Uri)
                     { EngineeringModelSetup = modelSetup };
@@ -301,18 +332,7 @@ namespace CDP4ShellDialogs.ViewModels
 
                 model.Iteration.Add(iteration);
 
-                DomainOfExpertise initialDomain;
-
-                if (session.ActivePerson.DefaultDomain != null && activeIterationSetupRow.DomainOfExpertises.Contains(session.ActivePerson.DefaultDomain))
-                {
-                    initialDomain = session.ActivePerson.DefaultDomain;
-                }
-                else
-                {
-                    initialDomain = activeIterationSetupRow.DomainOfExpertises.FirstOrDefault();
-                }
-
-                await session.Read(iteration, initialDomain);
+                await session.Read(iteration, session.ActivePerson.DefaultDomain);
             }
 
             this.IsBusy = false;

--- a/CDP4ShellDialogs/ViewModels/ModelOpeningDialogViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelOpeningDialogViewModel.cs
@@ -1,19 +1,20 @@
 // --------------------------------------------------------------------------------------------------------------------
 // <copyright file="ModelOpeningDialogViewModel.cs" company="Starion Group S.A.">
-//    Copyright (c) 2015-2022 Starion Group S.A.
+//    Copyright (c) 2015-2026 Starion Group S.A.
 //
-//    Author: Sam Geren�, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Th�ate, Omar Elebiary
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Antoine Théate, Omar Elebiary,
+//              Rowan de Voogt
 //
-//    This file is part of COMET-IME Community Edition.
-//    The COMET-IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
+//    This file is part of CDP4-COMET IME Community Edition.
+//    The CDP4-COMET IME Community Edition is the Starion Concurrent Design Desktop Application and Excel Integration
 //    compliant with ECSS-E-TM-10-25 Annex A and Annex C.
 //
-//    The COMET-IME Community Edition is free software; you can redistribute it and/or
+//    The CDP4-COMET IME Community Edition is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Affero General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or any later version.
 //
-//    The COMET-IME Community Edition is distributed in the hope that it will be useful,
+//    The CDP4-COMET IME Community Edition is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 //    GNU Affero General Public License for more details.

--- a/CDP4ShellDialogs/ViewModels/ModelSelectionIterationSetupRowViewModel.cs
+++ b/CDP4ShellDialogs/ViewModels/ModelSelectionIterationSetupRowViewModel.cs
@@ -69,9 +69,17 @@ namespace CDP4ShellDialogs.ViewModels
 
             this.DomainOfExpertises = new ReactiveList<DomainOfExpertise>();
 
-            if (participant.Domain.Count != 0)
+            var modelSetup = this.Thing.Container as EngineeringModelSetup;
+
+            var usableDomains = (modelSetup == null
+                    ? participant.Domain
+                    : participant.Domain.Where(modelSetup.ActiveDomain.Contains))
+                .OrderBy(x => x.ShortName)
+                .ToList();
+
+            if (usableDomains.Count != 0)
             {
-                this.DomainOfExpertises.AddRange(participant.Domain.OrderBy(x => x.ShortName)); 
+                this.DomainOfExpertises.AddRange(usableDomains);
 
                 this.SelectedDomain = this.DomainOfExpertises.Contains(this.ActiveParticipant.Person.DefaultDomain)
                     ? this.ActiveParticipant.Person.DefaultDomain

--- a/CDP4ShellDialogsTestFixture/ViewModels/ModelOpeningDialogViewModelTestFixture.cs
+++ b/CDP4ShellDialogsTestFixture/ViewModels/ModelOpeningDialogViewModelTestFixture.cs
@@ -31,6 +31,7 @@ namespace CDP4ShellDialogs.Tests
     using System.Reactive.Concurrency;
     using System.Reactive.Linq;
     using System.Threading.Tasks;
+    using System.Windows;
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
@@ -113,6 +114,9 @@ namespace CDP4ShellDialogs.Tests
             this.person.DefaultDomain = this.domain;
             this.model1.Participant.Add(this.participant);
             this.model2.Participant.Add(this.participant);
+
+            this.model1.ActiveDomain.Add(this.domain);
+            this.model2.ActiveDomain.Add(this.domain);
 
             this.model1.IterationSetup.Add(this.iteration11);
             this.model2.IterationSetup.Add(this.iteration21);
@@ -201,6 +205,88 @@ namespace CDP4ShellDialogs.Tests
             viewmodel.SelectedIterations.Add(new ModelSelectionEngineeringModelSetupRowViewModel(this.model1, this.session.Object));
 
             Assert.AreEqual(0, viewmodel.SelectedIterations.Count);
+        }
+
+        [Test]
+        public async Task VerifyThatSelectActiveIterationOpensModelWhenDefaultDomainIsActive()
+        {
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelOpeningDialogViewModel(sessions, null);
+
+            await viewmodel.SelectActiveIterationCommand.Execute();
+
+            var res = viewmodel.DialogResult;
+            Assert.IsNotNull(res);
+            Assert.IsTrue(res.Result.Value);
+            this.session.Verify(x => x.Read(It.IsAny<Iteration>(), this.domain, It.IsAny<bool>()), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyThatSelectActiveIterationSwitchesToIterationScreenWhenDefaultDomainIsNotActive()
+        {
+            this.person.DefaultDomain = new DomainOfExpertise(Guid.NewGuid(), null, this.uri) { Name = "nonActiveDomain" };
+
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelOpeningDialogViewModel(sessions, null);
+
+            await viewmodel.SelectActiveIterationCommand.Execute();
+
+            Assert.IsFalse(viewmodel.IsModelScreen);
+            Assert.IsTrue(viewmodel.IsIterationScreen);
+            Assert.IsFalse(viewmodel.IsBusy);
+            Assert.IsNull(viewmodel.DialogResult);
+            this.session.Verify(x => x.Read(It.IsAny<Iteration>(), It.IsAny<DomainOfExpertise>(), It.IsAny<bool>()), Times.Never);
+        }
+
+        [Test]
+        public async Task VerifyThatSelectActiveIterationSwitchesToIterationScreenWhenDefaultDomainIsNull()
+        {
+            this.person.DefaultDomain = null;
+
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelOpeningDialogViewModel(sessions, null);
+
+            await viewmodel.SelectActiveIterationCommand.Execute();
+
+            Assert.IsFalse(viewmodel.IsModelScreen);
+            Assert.IsTrue(viewmodel.IsIterationScreen);
+            Assert.IsNull(viewmodel.DialogResult);
+            this.session.Verify(x => x.Read(It.IsAny<Iteration>(), It.IsAny<DomainOfExpertise>(), It.IsAny<bool>()), Times.Never);
+        }
+
+        [Test]
+        public async Task VerifyThatSelectActiveIterationShowsMessageWhenNoActiveDomainIsAvailable()
+        {
+            // the participant's only assigned domain is no longer an active domain of the model (see issue #611)
+            this.model1.ActiveDomain.Clear();
+            this.model2.ActiveDomain.Clear();
+
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelOpeningDialogViewModel(sessions, null);
+
+            await viewmodel.SelectActiveIterationCommand.Execute();
+
+            Assert.IsTrue(viewmodel.IsModelScreen);
+            Assert.IsNull(viewmodel.DialogResult);
+            this.session.Verify(x => x.Read(It.IsAny<Iteration>(), It.IsAny<DomainOfExpertise>(), It.IsAny<bool>()), Times.Never);
+            this.messageBoxService.Verify(x => x.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>()), Times.Once);
+        }
+
+        [Test]
+        public async Task VerifyThatSelectShowsMessageWhenSelectedDomainIsNull()
+        {
+            // the participant's only assigned domain is no longer an active domain of the model, so the row has no usable domain (see issue #611)
+            this.model1.ActiveDomain.Clear();
+
+            var sessions = new List<ISession> { this.session.Object };
+            var viewmodel = new ModelOpeningDialogViewModel(sessions, null);
+            viewmodel.SelectedIterations.Add(new ModelSelectionIterationSetupRowViewModel(this.iteration11, this.participant, this.session.Object));
+
+            await viewmodel.SelectCommand.Execute();
+
+            Assert.IsNull(viewmodel.DialogResult);
+            this.session.Verify(x => x.Read(It.IsAny<Iteration>(), It.IsAny<DomainOfExpertise>(), It.IsAny<bool>()), Times.Never);
+            this.messageBoxService.Verify(x => x.Show(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MessageBoxButton>(), It.IsAny<MessageBoxImage>()), Times.Once);
         }
 
         [Test]

--- a/CDP4ShellDialogsTestFixture/ViewModels/ModelSelectionSessionTestFixture.cs
+++ b/CDP4ShellDialogsTestFixture/ViewModels/ModelSelectionSessionTestFixture.cs
@@ -79,6 +79,9 @@ namespace CDP4ShellDialogs.Tests.RowViewModels
 
             this.person.DefaultDomain = this.domain;
 
+            this.model1.ActiveDomain.Add(this.domain);
+            this.model2.ActiveDomain.Add(this.domain);
+
             this.model1.Participant.Add(new Participant(Guid.NewGuid(), null, new Uri("https://www.stariongroup.eu"))
             {
                 Person = this.person,


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/COMET-IME-Community-Edition/pulls) open
- [x] I have verified that I am following the COMET-IME [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/COMET-IME-Community-Edition/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
Fix #611 
It is no longer possible to open an engineering model under a domain of expertise that isn't valid for that model. Previously the "Open"/double-click path auto-selected a domain (the active person's default, falling back to the first assigned one) without checking it was both assigned to the participant and still active in the model, so a user whose default domain had been de-activated would open the model into an unusable state where nothing could be owned or edited. 

Now the selectable domains are restricted to participant.Domain and EngineeringModelSetup.ActiveDomain: the model opens directly only when the default domain is valid, routes to the iteration-selection screen when another usable domain exists, and is blocked with a clear message when the user has no active domain at all.
